### PR TITLE
Remove the unneeded `node_modules/.bin/` path in npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "webpack-merge": "^4.2.2"
   },
   "scripts": {
-    "dev": "node_modules/.bin/webpack-dev-server --mode development",
-    "watch": "node_modules/.bin/webpack --progress --mode development --watch",
-    "build": "node_modules/.bin/webpack -p --progress --mode production"
+    "dev": "webpack-dev-server --mode development",
+    "watch": "webpack --progress --mode development --watch",
+    "build": "webpack -p --progress --mode production"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
npm will put that directory explicitly on the PATH, and so there is no point in having these here.