### PR TITLE
Use the JRE variant of the openjdk image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-slim
+FROM openjdk:11-jre-slim
 
 WORKDIR /app
 COPY docker /


### PR DESCRIPTION
There is no reason really to use a full JDK image for running akhq, and switching to the JRE variant saves ~150MiB.

---
FWIW: 7114c33 changed from a JRE image to a JDK image, but it isn't obvious why -- and the image built using the JRE image seems to work just fine.