### PR TITLE
Redirect to /login/unauthorized on authorization errors

### DIFF
--- a/src/main/java/org/akhq/controllers/ErrorController.java
+++ b/src/main/java/org/akhq/controllers/ErrorController.java
@@ -49,7 +49,7 @@ public class ErrorController extends AbstractController {
             .body(error);
     }
 
-    @Error(global = true)
+    @Error(status = HttpStatus.INTERNAL_SERVER_ERROR, global = true)
     public HttpResponse<?> error(HttpRequest<?> request, Throwable e) {
         log.error(e.getMessage(), e);
 


### PR DESCRIPTION
This fixes #268, which basically was caused by the error controller "eating" the authorization error, so that the actual session configuration for how to redirect for authorization errors didn't get used anymore.

The proposed fix limits the error controller to only show the internal error page for actual internal errors -- but my micronaut knowledge isn't good enough to know whether this is the correct way. 