### PR TITLE
Use temporary redirects for / -> /{cluster}/topic

### DIFF
--- a/src/main/java/org/akhq/controllers/RedirectController.java
+++ b/src/main/java/org/akhq/controllers/RedirectController.java
@@ -30,7 +30,7 @@ public class RedirectController extends AbstractController {
 
     @Get("${akhq.server.base-path:}")
     public HttpResponse<?> home() throws URISyntaxException {
-        return HttpResponse.redirect(this.uri("/" + kafkaModule.getClustersList().get(0) + "/topic"));
+        return this.slash();
     }
 
     @Get("${akhq.server.base-path:}/{cluster:(?!login)[^/]+}")

--- a/src/main/java/org/akhq/controllers/RedirectController.java
+++ b/src/main/java/org/akhq/controllers/RedirectController.java
@@ -25,7 +25,7 @@ public class RedirectController extends AbstractController {
 
     @Get
     public HttpResponse<?> slash() throws URISyntaxException {
-        return HttpResponse.redirect(this.uri("/" + kafkaModule.getClustersList().get(0) + "/topic"));
+        return HttpResponse.temporaryRedirect(this.uri("/" + kafkaModule.getClustersList().get(0) + "/topic"));
     }
 
     @Get("${akhq.server.base-path:}")


### PR DESCRIPTION
The configuration name for the cluster can change easily, so we need a temporary redirect to prevent the browser from caching the redirection in its own cache, and then always going to the wrong place.