### PR TITLE
Do not send the 'node' directory to docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .git
-node_modules
+node/
+node_modules/
 .gradle
 .idea
 build/


### PR DESCRIPTION
This directory contains the NodeJS runtime for Gradle _when building the frontend assets_, but it isn't
needed when packaging the docker image.

---
This should have no impact at all on the runtime, but speed up builds a bit.