### PR TITLE
Change functionality of getPlugin to not get all plugins and try vali…

### DIFF
--- a/src/main/java/org/akhq/repositories/ConnectRepository.java
+++ b/src/main/java/org/akhq/repositories/ConnectRepository.java
@@ -9,7 +9,7 @@ import io.micronaut.retry.annotation.Retryable;
 import org.akhq.models.ConnectDefinition;
 import org.akhq.models.ConnectPlugin;
 import org.akhq.modules.KafkaModule;
-import org.sourcelab.kafka.connect.apiclient.request.dto.ConnectorDefinition;
+import org.sourcelab.kafka.connect.apiclient.request.dto.ConnectorPlugin;
 import org.sourcelab.kafka.connect.apiclient.request.dto.ConnectorPluginConfigDefinition;
 import org.sourcelab.kafka.connect.apiclient.request.dto.NewConnectorDefinition;
 import org.sourcelab.kafka.connect.apiclient.rest.exceptions.ConcurrentConfigModificationException;
@@ -30,63 +30,56 @@ public class ConnectRepository extends AbstractRepository {
     @Retryable(includes = ConcurrentConfigModificationException.class, delay = "3s", attempts = "5")
     public ConnectDefinition getDefinition(String clusterId, String connectId, String name) {
         return new ConnectDefinition(
-            this.kafkaModule
-                .getConnectRestClient(clusterId)
-                .get(connectId)
-                .getConnector(name),
-            this.kafkaModule
-                .getConnectRestClient(clusterId)
-                .get(connectId)
-                .getConnectorStatus(name)
+                this.kafkaModule
+                        .getConnectRestClient(clusterId)
+                        .get(connectId)
+                        .getConnector(name),
+                this.kafkaModule
+                        .getConnectRestClient(clusterId)
+                        .get(connectId)
+                        .getConnectorStatus(name)
         );
     }
 
     @Retryable(includes = ConcurrentConfigModificationException.class, delay = "3s", attempts = "5")
     public List<ConnectDefinition> getDefinitions(String clusterId, String connectId) {
         return this.kafkaModule
-            .getConnectRestClient(clusterId)
-            .get(connectId)
-            .getConnectors()
-            .stream()
-            .map(s -> getDefinition(clusterId, connectId, s))
-            .collect(Collectors.toList());
+                .getConnectRestClient(clusterId)
+                .get(connectId)
+                .getConnectors()
+                .stream()
+                .map(s -> getDefinition(clusterId, connectId, s))
+                .collect(Collectors.toList());
     }
 
 
     public Optional<ConnectPlugin> getPlugin(String clusterId, String connectId, String className) {
-        return this.getPlugins(clusterId, connectId)
-            .stream()
-            .filter(connectPlugin -> connectPlugin.getShortClassName().equals(className))
-            .findFirst();
+        return this.kafkaModule
+                .getConnectRestClient(clusterId)
+                .get(connectId)
+                .getConnectorPlugins()
+                .stream()
+                .filter(connectPlugin -> getShortClassName(connectPlugin.getClassName()).equals(className))
+                .map(s -> mapToConnectPlugin(s, clusterId, connectId))
+                .findFirst();
     }
 
     public List<ConnectPlugin> getPlugins(String clusterId, String connectId) {
         return this.kafkaModule
-            .getConnectRestClient(clusterId)
-            .get(connectId)
-            .getConnectorPlugins()
-            .stream()
-            .map(s -> new ConnectPlugin(
-                s,this.kafkaModule
                 .getConnectRestClient(clusterId)
                 .get(connectId)
-                .validateConnectorPluginConfig(new ConnectorPluginConfigDefinition(
-                    Iterables.getLast(Arrays.asList(s.getClassName().split("/"))),
-                    ImmutableMap.of(
-                        "connector.class", s.getClassName(),
-                        "topics", "getPlugins"
-                    )
-                )))
-            )
-            .collect(Collectors.toList());
+                .getConnectorPlugins()
+                .stream()
+                .map(s -> mapToConnectPlugin(s, clusterId, connectId))
+                .collect(Collectors.toList());
     }
 
     public ConnectDefinition create(String clusterId, String connectId, String name, Map<String, String> configs) {
         try {
             this.kafkaModule
-                .getConnectRestClient(clusterId)
-                .get(connectId)
-                .addConnector(new NewConnectorDefinition(name, configs));
+                    .getConnectRestClient(clusterId)
+                    .get(connectId)
+                    .addConnector(new NewConnectorDefinition(name, configs));
         } catch (InvalidRequestException e) {
             throw new IllegalArgumentException(e);
         }
@@ -97,9 +90,9 @@ public class ConnectRepository extends AbstractRepository {
     public ConnectDefinition update(String clusterId, String connectId, String name, Map<String, String> configs) {
         try {
             this.kafkaModule
-                .getConnectRestClient(clusterId)
-                .get(connectId)
-                .updateConnectorConfig(name, configs);
+                    .getConnectRestClient(clusterId)
+                    .get(connectId)
+                    .updateConnectorConfig(name, configs);
         } catch (InvalidRequestException e) {
             throw new IllegalArgumentException(e);
         }
@@ -110,9 +103,9 @@ public class ConnectRepository extends AbstractRepository {
     public boolean delete(String clusterId, String connectId, String name) {
         try {
             return this.kafkaModule
-                .getConnectRestClient(clusterId)
-                .get(connectId)
-                .deleteConnector(name);
+                    .getConnectRestClient(clusterId)
+                    .get(connectId)
+                    .deleteConnector(name);
         } catch (InvalidRequestException e) {
             throw new IllegalArgumentException(e);
         }
@@ -121,9 +114,9 @@ public class ConnectRepository extends AbstractRepository {
     public boolean pause(String clusterId, String connectId, String name) {
         try {
             return this.kafkaModule
-                .getConnectRestClient(clusterId)
-                .get(connectId)
-                .pauseConnector(name);
+                    .getConnectRestClient(clusterId)
+                    .get(connectId)
+                    .pauseConnector(name);
         } catch (InvalidRequestException e) {
             throw new IllegalArgumentException(e);
         }
@@ -132,9 +125,9 @@ public class ConnectRepository extends AbstractRepository {
     public boolean resume(String clusterId, String connectId, String name) {
         try {
             return this.kafkaModule
-                .getConnectRestClient(clusterId)
-                .get(connectId)
-                .resumeConnector(name);
+                    .getConnectRestClient(clusterId)
+                    .get(connectId)
+                    .resumeConnector(name);
         } catch (InvalidRequestException e) {
             throw new IllegalArgumentException(e);
         }
@@ -143,9 +136,9 @@ public class ConnectRepository extends AbstractRepository {
     public boolean restart(String clusterId, String connectId, String name) {
         try {
             return this.kafkaModule
-                .getConnectRestClient(clusterId)
-                .get(connectId)
-                .restartConnector(name);
+                    .getConnectRestClient(clusterId)
+                    .get(connectId)
+                    .restartConnector(name);
         } catch (InvalidRequestException e) {
             throw new IllegalArgumentException(e);
         }
@@ -154,9 +147,9 @@ public class ConnectRepository extends AbstractRepository {
     public boolean restartTask(String clusterId, String connectId, String name, int task) {
         try {
             return this.kafkaModule
-                .getConnectRestClient(clusterId)
-                .get(connectId)
-                .restartConnectorTask(name, task);
+                    .getConnectRestClient(clusterId)
+                    .get(connectId)
+                    .restartConnectorTask(name, task);
         } catch (InvalidRequestException e) {
             throw new IllegalArgumentException(e);
         }
@@ -164,26 +157,47 @@ public class ConnectRepository extends AbstractRepository {
 
     public static Map<String, String> validConfigs(Map<String, String> configs, String transformsValue) {
         Map<String, String> list = configs
-            .entrySet()
-            .stream()
-            .filter(config -> !config.getKey().equals("transforms-value"))
-            .filter(config -> !config.getValue().isEmpty())
-            .filter(config -> config.getKey().startsWith("configs["))
-            .map(entry -> new AbstractMap.SimpleEntry<>(
-                    entry.getKey().substring("configs[".length(), entry.getKey().length() - 1),
-                    entry.getValue()
+                .entrySet()
+                .stream()
+                .filter(config -> !config.getKey().equals("transforms-value"))
+                .filter(config -> !config.getValue().isEmpty())
+                .filter(config -> config.getKey().startsWith("configs["))
+                .map(entry -> new AbstractMap.SimpleEntry<>(
+                                entry.getKey().substring("configs[".length(), entry.getKey().length() - 1),
+                                entry.getValue()
+                        )
                 )
-            )
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         if (!transformsValue.trim().isEmpty()) {
             list.putAll(gson.fromJson(
-                transformsValue,
-                new TypeToken<HashMap<String, String>>() {
-                }.getType()
+                    transformsValue,
+                    new TypeToken<HashMap<String, String>>() {
+                    }.getType()
             ));
         }
 
         return list;
+    }
+
+    private ConnectPlugin mapToConnectPlugin(ConnectorPlugin plugin, String clusterId, String connectId) {
+        return new ConnectPlugin(
+                plugin,
+                this.kafkaModule
+                        .getConnectRestClient(clusterId)
+                        .get(connectId)
+                        .validateConnectorPluginConfig(new ConnectorPluginConfigDefinition(
+                                Iterables.getLast(Arrays.asList(plugin.getClassName().split("/"))),
+                                ImmutableMap.of(
+                                        "connector.class", plugin.getClassName(),
+                                        "topics", "getPlugins"
+                                )
+                        )));
+    }
+
+    private String getShortClassName(String className) {
+        String[] split = className.split("\\.");
+
+        return split[split.length - 1];
     }
 }


### PR DESCRIPTION
…dating them.  This causes a NPE for connectors that aren't in use and deployed as connectors.  This will also improve performance as it will no longer validate all connector plugins, but only the one necessary.