### PR TITLE
Fixed issue where keystore was not being set properly for Kafka Connect

### DIFF
--- a/src/main/java/org/akhq/modules/KafkaModule.java
+++ b/src/main/java/org/akhq/modules/KafkaModule.java
@@ -213,7 +213,7 @@ public class KafkaModule {
                     }
 
                     if (connect.getSslKeyStore() != null) {
-                        configuration.useTrustStore(
+                        configuration.useKeyStore(
                                 new File(connect.getSslKeyStore()),
                                 connect.getSslKeyStorePassword()
                         );


### PR DESCRIPTION
Fixed issue where keystore for Kafka Connect was being set to the truststore.