### PR TITLE
add requirements on using helm repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ helm repo add akhq https://akhq.io/
 helm install --name akhq akhq/akhq
 ```
 
+#### Requirements
+
+* Chart version >=0.1.1 requires Kubernetes version >=1.14
+* Chart version 0.1.0 works on previous Kubernetes versions
+```sh
+helm install --name akhq akhq/akhq --version 0.1.0
+```
+
 ### Using git
 * Clone the repository:
 ```sh


### PR DESCRIPTION
Since the change made in commit [313d1e40](https://github.com/tchiotludo/akhq/commit/313d1e4057ff49950eecee0884862787426ecdb9) the AKHQ Helm Chart isn't compatible with Kubernetes versions prior 1.14. It took me a while to find out why the chart cannot be installed on our cluster 1.13. Therefore I think that a hint in the README would be useful.