### PR TITLE
add initcontainers value to the helm chart

### DIFF
--- a/helm/akhq/templates/deployment.yaml
+++ b/helm/akhq/templates/deployment.yaml
@@ -36,7 +36,14 @@ spec:
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{ toYaml .Values.imagePullSecrets | indent 8 }}
-      {{- end }}       
+      {{- end }}  
+      {{- if .Values.initContainers }}
+      initContainers:
+        {{- range $key, $value := .Values.initContainers }}
+        - name: {{ $key }}
+{{ toYaml $value | indent 10 }}
+        {{- end }}
+      {{- end }}     
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -25,7 +25,6 @@ configuration: |
       access-log: 
         enabled: false 
         name: org.akhq.log.access
-
 ##... and secret for connection information
 secrets: |
   akhq:
@@ -42,11 +41,18 @@ secrets: |
             url: "http://connect:8083"
             basic-auth-username: basic-auth-user
             basic-auth-password: basic-auth-pass
-
 # Any extra volumes to define for the pod (like keystore/truststore)
 extraVolumes: []
 # Any extra volume mounts to define for the akhq container
 extraVolumeMounts: []
+# Add your own init container or uncomment and modify the example.
+initContainers: 
+  create-keystore: 
+    image: "openjdk:11-slim"
+    command: ['sh', '-c', 'keytool']
+    volumeMounts:
+      - mountPath: /tmp
+        name: certs
 
 service:
   enabled: true

--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -46,13 +46,13 @@ extraVolumes: []
 # Any extra volume mounts to define for the akhq container
 extraVolumeMounts: []
 # Add your own init container or uncomment and modify the example.
-initContainers: 
-  create-keystore: 
-    image: "openjdk:11-slim"
-    command: ['sh', '-c', 'keytool']
-    volumeMounts:
-      - mountPath: /tmp
-        name: certs
+initContainers: {}
+#   create-keystore: 
+#     image: "openjdk:11-slim"
+#     command: ['sh', '-c', 'keytool']
+#     volumeMounts:
+#      - mountPath: /tmp
+#        name: certs
 
 service:
   enabled: true


### PR DESCRIPTION
Add value to attach an initcontainer to the akhq deployment. I need this to generate the keystore.