### PR TITLE
Add topic configuration button in topic list screen

### DIFF
--- a/src/main/resources/views/topicList.ftl
+++ b/src/main/resources/views/topicList.ftl
@@ -25,7 +25,7 @@
                 <#if skipConsumerGroups == false>
                     <th>Consumers Groups</th>
                 </#if>
-                <th colspan="2" class="khq-row-action"></th>
+                <th colspan="3" class="khq-row-action"></th>
             </tr>
         </thead>
         <thead class="thead-dark">
@@ -43,6 +43,7 @@
                 <#if skipConsumerGroups == false>
                     <th class="text-nowrap">Consumer Groups</th>
                 </#if>
+                <th class="khq-row-action"></th>
                 <th class="khq-row-action"></th>
                 <#if canDelete == true>
                     <th class="khq-row-action"></th>
@@ -92,6 +93,9 @@
                         </#if>
                         <td class="khq-row-action khq-row-action-main">
                             <a href="${basePath}/${clusterId}/topic/${topic.getName()}${roles?seq_contains("topic/data/read")?then("", "/partitions")}" ><i class="fa fa-search"></i></a>
+                        </td>
+                        <td class="khq-row-action">
+                            <a href="${basePath}/${clusterId}/topic/${topic.getName()}/configs" ><i class="fa fa-gear"></i></a>
                         </td>
                         <#if canDelete == true>
                             <td class="khq-row-action">


### PR DESCRIPTION
**Problem:**
Needed configure button/action to go to the topic's configuration. 
This is very much useful when we want to view or modify topic's configuration. Without this feature, we have to wait for the topic to read data(default action) before we can go to the config tab.

**Action**
Add topic's configuration button in topic list ui.
