### PR TITLE
Display consumer groups ordered by group id

### DIFF
--- a/src/main/java/org/akhq/repositories/ConsumerGroupRepository.java
+++ b/src/main/java/org/akhq/repositories/ConsumerGroupRepository.java
@@ -82,6 +82,7 @@ public class ConsumerGroupRepository extends AbstractRepository {
                     .distinct()
                     .collect(Collectors.toMap(Function.identity(), topicTopicsOffsets::get))
             ))
+            .sorted(Comparator.comparing(ConsumerGroup::getId))
             .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
**Problem:**
Consumer Groups page displays consumers in random order. 
When this list grows it is much helpful to navigate if these consumer groups are sorted by Id.

**Action**
Return consumer group list after sorting it by consumer group id from ConsumerGroupRepository
