### PR TITLE
Sort topic records by timestamp across all partitions

### DIFF
--- a/src/main/java/org/akhq/repositories/RecordRepository.java
+++ b/src/main/java/org/akhq/repositories/RecordRepository.java
@@ -89,6 +89,8 @@ public class RecordRepository extends AbstractRepository {
 
         consumer.close();
 
+        list.sort(Comparator.comparing(Record::getTimestamp));
+
         return list;
     }
 
@@ -227,6 +229,7 @@ public class RecordRepository extends AbstractRepository {
                 return Stream.of(list);
             })
             .flatMap(List::stream)
+            .sorted(Comparator.comparing(Record::getTimestamp).reversed())
             .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
**Problem**
While sorting topic records by "**Newest**" or "**Oldest**". Records are getting sorted by timestamp only withing individual partitions. 

- Sorted by "Newest" 
![image](https://user-images.githubusercontent.com/28188759/87880379-e3e4d880-ca0e-11ea-9ec3-68e0a70ca427.png)

- Sorted by "Oldest"
![image](https://user-images.githubusercontent.com/28188759/87880392-f8c16c00-ca0e-11ea-9a26-5fbc85544a38.png)

- When the number of partitions is more. The user feels a few records are not visible or missed by akhq. 
- The user spends more time to find the desired records and increases his analysis time

**Actions**
Records to be sorted by record timestamp across all partitions.

- Sorted by "Newest" After implementation
![image](https://user-images.githubusercontent.com/28188759/87880462-784f3b00-ca0f-11ea-8f4b-6f34cb848a08.png)


- Sorted by "Oldest" After implementation
![image](https://user-images.githubusercontent.com/28188759/87880471-8604c080-ca0f-11ea-906d-d0a7df272781.png)
