### PR TITLE
Disable defaults validation during Avro schema parsing

### DIFF
--- a/src/main/java/org/akhq/models/Schema.java
+++ b/src/main/java/org/akhq/models/Schema.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 public class Schema {
     @JsonIgnore
-    private final Parser parser = new Parser();
+    private final Parser parser = new Parser().setValidateDefaults(false);
 
     private Integer id;
     private String subject;


### PR DESCRIPTION
**Problem**

AKHQ is returning errors when it tries to parse schemas which are accepted by Confluent Schema Registry:

```
Invalid avro schema with error : org.apache.avro.AvroTypeException: Invalid default for field [...]
```

This behavior is due to a change in Avro Unions management between version [1.7.6](https://avro.apache.org/docs/1.7.6/spec.html#Unions) and [1.7.7](https://avro.apache.org/docs/1.7.77/spec.html#Unions), in particular to the introduction of an additional constraint for the order of default values for union types:

> Note that when a default value is specified for a record field whose type is a union, the type of the default value must match the first element of the union. Thus, for unions containing "null", the "null" is usually listed first, since the default value of such unions is typically null

For this reason, older producers may publish to Confluent Schema Registry Avro schemas which are not responding to this requirement. The Schema Registry will accept them accordingly to [implementation](https://github.com/confluentinc/schema-registry/blob/master/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java#L106).

This PR might be related to #89 and it might be an answer to [this comment](https://github.com/tchiotludo/akhq/issues/89#issuecomment-510613941).

**Solution**

Disabling the validation of defaults during parsing, the proposed solution just aligns the behavior of Avro Schema parsing in AKHQ to the [one adopted by Confluent Schema Registry](https://github.com/confluentinc/schema-registry/blob/master/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java#L106).
