### PR TITLE
Improve compatibility with TIBCO schema repository (#354)

### DIFF
--- a/src/main/java/org/akhq/modules/KafkaModule.java
+++ b/src/main/java/org/akhq/modules/KafkaModule.java
@@ -1,5 +1,6 @@
 package org.akhq.modules;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
@@ -7,6 +8,7 @@ import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import io.confluent.kafka.schemaregistry.client.security.basicauth.BasicAuthCredentialProvider;
 import io.confluent.kafka.schemaregistry.client.security.basicauth.BasicAuthCredentialProviderFactory;
 import io.confluent.kafka.schemaregistry.client.security.basicauth.UserInfoCredentialProvider;
+import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -25,6 +27,7 @@ import org.sourcelab.kafka.connect.apiclient.KafkaConnectClient;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.File;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -144,6 +147,8 @@ public class KafkaModule {
             RestService restService = new RestService(
                 connection.getSchemaRegistry().getUrl().toString()
             );
+
+            restService.setHttpHeaders(Collections.singletonMap("Accept", "application/json"));
 
             if (connection.getSchemaRegistry().getBasicAuthUsername() != null) {
                 BasicAuthCredentialProvider basicAuthCredentialProvider = BasicAuthCredentialProviderFactory

--- a/src/main/java/org/akhq/repositories/SchemaRegistryRepository.java
+++ b/src/main/java/org/akhq/repositories/SchemaRegistryRepository.java
@@ -1,8 +1,10 @@
 package org.akhq.repositories;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.ConfigUpdateRequest;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import org.akhq.models.Schema;
 import org.akhq.modules.AvroSerializer;
@@ -216,5 +218,9 @@ public class SchemaRegistryRepository extends AbstractRepository {
             this.avroSerializer = new AvroSerializer(this.kafkaModule.getRegistryClient(clusterId));
         }
         return this.avroSerializer;
+    }
+
+    static {
+        JacksonMapper.INSTANCE.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 }


### PR DESCRIPTION
A couple small changes that allow basic browsing of Avro schemas stored in the TIBCO schema repository.  Shouldn't interfere with any existing schema registry compatibility (Schema unit tests still pass OK).

The two issues this fixes are:

- The TIBCO schema repo is a little more strict in what it allows for the "Accept" header on requests, so this sets the Accept header appropriately.
- The TIBCO schema repo in some cases returns _more_ fields in its responses than other schema repositories do; this change ignores those additional fields (they're not needed for AKHQ use).