### PR TITLE
Allow security configuration without basic auth

### DIFF
--- a/src/main/java/org/akhq/configs/SecurityProperties.java
+++ b/src/main/java/org/akhq/configs/SecurityProperties.java
@@ -3,12 +3,13 @@ package org.akhq.configs;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import lombok.Data;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @ConfigurationProperties("akhq.security")
 @Data
 public class SecurityProperties {
-    private List<BasicAuth> basicAuth;
+    private List<BasicAuth> basicAuth = new ArrayList<>();
     private List<Group> groups;
     private String defaultGroup;
 }


### PR DESCRIPTION
Currently, we need to specify basic auth section in `akhq.security` even if we don't use it.

If not NullPointerException is thrown in https://github.com/tchiotludo/akhq/blob/cbcaf627216a1c3650323e0611a9f95013c25779/src/main/java/org/akhq/controllers/AkhqController.java#L69