### PR TITLE
Support BCrypt password encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,9 @@ Define groups with specific roles for your users
 ##### Basic Auth
 * `akhq.security.basic-auth`: List user & password with affected roles 
   * `- username: actual-username`: Login of the current user as a yaml key (may be anything email, login, ...)
-    * `password`: Password in sha256, can be converted with command `echo -n "password" | sha256sum`
+    * `password`: Password in sha256 or bcrypt. The password can be converted 
+      * For sha256, with command `echo -n "password" | sha256sum` or Ansible filter `{{ 'password' | hash('sha256') }}`
+      * For BCrypt, with Ansible filter `{{ 'password' | password_hash('blowfish') }}`
     * `groups`: Groups for current user
 
 > Take care that basic auth will use session store in server **memory**. If your instance is behind a reverse proxy or a

--- a/README.md
+++ b/README.md
@@ -348,16 +348,28 @@ Define groups with specific roles for your users
 ##### Basic Auth
 * `akhq.security.basic-auth`: List user & password with affected roles 
   * `- username: actual-username`: Login of the current user as a yaml key (may be anything email, login, ...)
-    * `password`: Password in sha256 or bcrypt. The password can be converted 
-      * For sha256, with command `echo -n "password" | sha256sum` or Ansible filter `{{ 'password' | hash('sha256') }}`
+    * `password`: Password in sha256 (default) or bcrypt. The password can be converted 
+      * For default SHA256, with command `echo -n "password" | sha256sum` or Ansible filter `{{ 'password' | hash('sha256') }}`
       * For BCrypt, with Ansible filter `{{ 'password' | password_hash('blowfish') }}`
+    * `passwordHash`: Password hashing algorithm, either `SHA256` or `BCRYPT`
     * `groups`: Groups for current user
 
 > Take care that basic auth will use session store in server **memory**. If your instance is behind a reverse proxy or a
 > loadbalancer, you will need to forward the session cookie named `SESSION` and / or use
 > [sesssion stickiness](https://en.wikipedia.org/wiki/Load_balancing_(computing)#Persistence)
 
-
+Configure basic-auth connection in AKHQ
+```yaml
+akhq.security:
+  basic-auth:
+    admin:
+      password: "$2a$<hashed password>"
+      passwordHash: BCRYPT
+      groups: admin
+    reader:
+      password: "<SHA-256 hashed password>"
+      groups: reader
+```
 
 ##### LDAP
 Configure how the ldap groups will be matched in AKHQ groups 

--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,9 @@ dependencies {
     // utils
     implementation group: 'org.codehaus.httpcache4j.uribuilder', name: 'uribuilder', version: '2.0.0'
 
+    // Password hashing
+    implementation group: "org.mindrot", name: "jbcrypt", version: "0.4"
+
     // api
 
     // client

--- a/src/main/java/org/akhq/configs/BasicAuth.java
+++ b/src/main/java/org/akhq/configs/BasicAuth.java
@@ -1,6 +1,5 @@
 package org.akhq.configs;
 
-import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import lombok.Data;
 import org.mindrot.jbcrypt.BCrypt;
@@ -8,8 +7,6 @@ import org.mindrot.jbcrypt.BCrypt;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Data
 public class BasicAuth {
@@ -17,45 +14,20 @@ public class BasicAuth {
     String password;
     List<String> groups = new ArrayList<>();
 
-    /**
-     * Crypt format
-     * $<id>[$<param>=<value>(,<param>=<value>)*][$<salt>[$<hash>]]
-     * https://en.wikipedia.org/wiki/Crypt_(C)
-     */
-    private static final Pattern CRYPT_FORMAT = Pattern.compile("^\\$([a-z0-9]+)\\$(.+)");
-
     @SuppressWarnings("UnstableApiUsage")
     public boolean isValidPassword(String password) {
-        Matcher cryptMatcher = CRYPT_FORMAT.matcher(this.password);
-        if (cryptMatcher.matches()) {
-            // Crypt format
-            String id = cryptMatcher.group(1);
-            String hashPassword = cryptMatcher.group(2);
-            if (id.startsWith("1")) {
-                return checkPassword(password, Hashing.md5(), hashPassword);
-            } else if (id.startsWith("2")) {
-                // See http://www.mindrot.org/projects/jBCrypt/
-                return BCrypt.checkpw(password, this.password);
-            } else if (id.equals("5")) {
-                return checkPassword(password, Hashing.sha256(), hashPassword);
-            } else if (id.equals("6")) {
-                return checkPassword(password, Hashing.sha512(), hashPassword);
-            } else {
-                throw new IllegalStateException("Unsupported crypt algorithm " + id);
-            }
-
+        if (this.password.startsWith("$2")) {
+            // See http://www.mindrot.org/projects/jBCrypt/
+            return BCrypt.checkpw(password, this.password);
         } else {
             // Default Sha256 format
-            return checkPassword(password, Hashing.sha256(), this.password);
+            return this.password.equals(
+                    Hashing.sha256()
+                            .hashString(password, StandardCharsets.UTF_8)
+                            .toString()
+            );
         }
     }
 
-    private static boolean checkPassword(String plainPassword, HashFunction hashFunction, String hashedPassword) {
-        return hashedPassword.equals(
-                hashFunction
-                        .hashString(plainPassword, StandardCharsets.UTF_8)
-                        .toString()
-        );
-    }
 }
 

--- a/src/main/java/org/akhq/configs/BasicAuth.java
+++ b/src/main/java/org/akhq/configs/BasicAuth.java
@@ -12,22 +12,36 @@ import java.util.List;
 public class BasicAuth {
     String username;
     String password;
+    PasswordHash passwordHash = PasswordHash.SHA256;
     List<String> groups = new ArrayList<>();
 
     @SuppressWarnings("UnstableApiUsage")
     public boolean isValidPassword(String password) {
-        if (this.password.startsWith("$2")) {
-            // See http://www.mindrot.org/projects/jBCrypt/
-            return BCrypt.checkpw(password, this.password);
-        } else {
-            // Default Sha256 format
-            return this.password.equals(
-                    Hashing.sha256()
-                            .hashString(password, StandardCharsets.UTF_8)
-                            .toString()
-            );
-        }
+        return passwordHash.checkPassword(password, this.password);
     }
 
+    /**
+     * Password hashing algorithm
+     */
+    public enum PasswordHash {
+        SHA256 {
+            @Override
+            public boolean checkPassword(String plainPassword, String hashedPassword) {
+                return hashedPassword.equals(
+                        Hashing.sha256()
+                                .hashString(plainPassword, StandardCharsets.UTF_8)
+                                .toString());
+            }
+        },
+        BCRYPT {
+            @Override
+            public boolean checkPassword(String plainPassword, String hashedPassword) {
+                // See http://www.mindrot.org/projects/jBCrypt/
+                return BCrypt.checkpw(plainPassword, hashedPassword);
+            }
+        };
+
+        public abstract boolean checkPassword(String plainPassword, String hashedPassword);
+    }
 }
 

--- a/src/main/java/org/akhq/configs/BasicAuth.java
+++ b/src/main/java/org/akhq/configs/BasicAuth.java
@@ -1,11 +1,15 @@
 package org.akhq.configs;
 
+import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import lombok.Data;
+import org.mindrot.jbcrypt.BCrypt;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Data
 public class BasicAuth {
@@ -13,11 +17,43 @@ public class BasicAuth {
     String password;
     List<String> groups = new ArrayList<>();
 
+    /**
+     * Crypt format
+     * $<id>[$<param>=<value>(,<param>=<value>)*][$<salt>[$<hash>]]
+     * https://en.wikipedia.org/wiki/Crypt_(C)
+     */
+    private static final Pattern CRYPT_FORMAT = Pattern.compile("^\\$([a-z0-9]+)\\$(.+)");
+
     @SuppressWarnings("UnstableApiUsage")
     public boolean isValidPassword(String password) {
-        return this.password.equals(
-                Hashing.sha256()
-                        .hashString(password, StandardCharsets.UTF_8)
+        Matcher cryptMatcher = CRYPT_FORMAT.matcher(this.password);
+        if (cryptMatcher.matches()) {
+            // Crypt format
+            String id = cryptMatcher.group(1);
+            String hashPassword = cryptMatcher.group(2);
+            if (id.startsWith("1")) {
+                return checkPassword(password, Hashing.md5(), hashPassword);
+            } else if (id.startsWith("2")) {
+                // See http://www.mindrot.org/projects/jBCrypt/
+                return BCrypt.checkpw(password, this.password);
+            } else if (id.equals("5")) {
+                return checkPassword(password, Hashing.sha256(), hashPassword);
+            } else if (id.equals("6")) {
+                return checkPassword(password, Hashing.sha512(), hashPassword);
+            } else {
+                throw new IllegalStateException("Unsupported crypt algorithm " + id);
+            }
+
+        } else {
+            // Default Sha256 format
+            return checkPassword(password, Hashing.sha256(), this.password);
+        }
+    }
+
+    private static boolean checkPassword(String plainPassword, HashFunction hashFunction, String hashedPassword) {
+        return hashedPassword.equals(
+                hashFunction
+                        .hashString(plainPassword, StandardCharsets.UTF_8)
                         .toString()
         );
     }

--- a/src/test/java/org/akhq/configs/BasicAuthTest.java
+++ b/src/test/java/org/akhq/configs/BasicAuthTest.java
@@ -1,0 +1,66 @@
+package org.akhq.configs;
+
+import org.junit.jupiter.api.Test;
+import org.mindrot.jbcrypt.BCrypt;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BasicAuthTest {
+
+    @Test
+    void isValidPasswordSha256Invalid() {
+        BasicAuth basicAuth = new BasicAuth();
+        basicAuth.password = "xx";
+        assertFalse(basicAuth.isValidPassword("Passw0rd"));
+    }
+
+    @Test
+    void isValidPasswordSha256Valid() {
+        BasicAuth basicAuth = new BasicAuth();
+        basicAuth.password = "ec04b8cb3cb42d6e28f4472c33efe93e41b138637e5223d7d758c5bceff11df8";
+        assertTrue(basicAuth.isValidPassword("TestAKHQ"));
+    }
+
+    @Test
+    void isValidPasswordCryptSha256Valid() {
+        BasicAuth basicAuth = new BasicAuth();
+        basicAuth.password = "$5$ec04b8cb3cb42d6e28f4472c33efe93e41b138637e5223d7d758c5bceff11df8";
+        assertFalse(basicAuth.isValidPassword("Bad"));
+    }
+
+    @Test
+    void isValidPasswordCryptSha256Invalid() {
+        BasicAuth basicAuth = new BasicAuth();
+        basicAuth.password = "$5$ec04b8cb3cb42d6e28f4472c33efe93e41b138637e5223d7d758c5bceff11df8";
+        assertTrue(basicAuth.isValidPassword("TestAKHQ"));
+    }
+
+    @Test
+    void isValidPasswordCryptSha512Invalid() {
+        BasicAuth basicAuth = new BasicAuth();
+        basicAuth.password = "$6$211e747869b31084a70813d9e1dd8436bbde805db1429a5d322c4a6b1ab0bf304ea66fbb9e5457191f8568db035258845cd5f1b6b7c5439d21d888475fbe1f9c";
+        assertFalse(basicAuth.isValidPassword("Bad"));
+    }
+
+    @Test
+    void isValidPasswordCryptSha512Valid() {
+        BasicAuth basicAuth = new BasicAuth();
+        basicAuth.password = "$6$211e747869b31084a70813d9e1dd8436bbde805db1429a5d322c4a6b1ab0bf304ea66fbb9e5457191f8568db035258845cd5f1b6b7c5439d21d888475fbe1f9c";
+        assertTrue(basicAuth.isValidPassword("TestAKHQ"));
+    }
+
+    @Test
+    void isValidPasswordBCryptInvalid() {
+        BasicAuth basicAuth = new BasicAuth();
+        basicAuth.password = "$2a$10$AtmQQDDSWnqsskzRxX1vGO0k6txZcJv.XlWRWA13.QOPq1wGB0DjS";
+        assertFalse(basicAuth.isValidPassword("Bad"));
+    }
+
+    @Test
+    void isValidPasswordBCryptValid() {
+        BasicAuth basicAuth = new BasicAuth();
+        basicAuth.password = "$2a$10$AtmQQDDSWnqsskzRxX1vGO0k6txZcJv.XlWRWA13.QOPq1wGB0DjS";
+        assertTrue(basicAuth.isValidPassword("TestAKHQ"));
+    }
+
+}

--- a/src/test/java/org/akhq/configs/BasicAuthTest.java
+++ b/src/test/java/org/akhq/configs/BasicAuthTest.java
@@ -1,51 +1,24 @@
 package org.akhq.configs;
 
 import org.junit.jupiter.api.Test;
-import org.mindrot.jbcrypt.BCrypt;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class BasicAuthTest {
 
     @Test
     void isValidPasswordSha256Invalid() {
         BasicAuth basicAuth = new BasicAuth();
-        basicAuth.password = "xx";
-        assertFalse(basicAuth.isValidPassword("Passw0rd"));
+        basicAuth.password = "ec04b8cb3cb42d6e28f4472c33efe93e41b138637e5223d7d758c5bceff11df8";
+        assertFalse(basicAuth.isValidPassword("Bad"));
     }
+
 
     @Test
     void isValidPasswordSha256Valid() {
         BasicAuth basicAuth = new BasicAuth();
         basicAuth.password = "ec04b8cb3cb42d6e28f4472c33efe93e41b138637e5223d7d758c5bceff11df8";
-        assertTrue(basicAuth.isValidPassword("TestAKHQ"));
-    }
-
-    @Test
-    void isValidPasswordCryptSha256Valid() {
-        BasicAuth basicAuth = new BasicAuth();
-        basicAuth.password = "$5$ec04b8cb3cb42d6e28f4472c33efe93e41b138637e5223d7d758c5bceff11df8";
-        assertFalse(basicAuth.isValidPassword("Bad"));
-    }
-
-    @Test
-    void isValidPasswordCryptSha256Invalid() {
-        BasicAuth basicAuth = new BasicAuth();
-        basicAuth.password = "$5$ec04b8cb3cb42d6e28f4472c33efe93e41b138637e5223d7d758c5bceff11df8";
-        assertTrue(basicAuth.isValidPassword("TestAKHQ"));
-    }
-
-    @Test
-    void isValidPasswordCryptSha512Invalid() {
-        BasicAuth basicAuth = new BasicAuth();
-        basicAuth.password = "$6$211e747869b31084a70813d9e1dd8436bbde805db1429a5d322c4a6b1ab0bf304ea66fbb9e5457191f8568db035258845cd5f1b6b7c5439d21d888475fbe1f9c";
-        assertFalse(basicAuth.isValidPassword("Bad"));
-    }
-
-    @Test
-    void isValidPasswordCryptSha512Valid() {
-        BasicAuth basicAuth = new BasicAuth();
-        basicAuth.password = "$6$211e747869b31084a70813d9e1dd8436bbde805db1429a5d322c4a6b1ab0bf304ea66fbb9e5457191f8568db035258845cd5f1b6b7c5439d21d888475fbe1f9c";
         assertTrue(basicAuth.isValidPassword("TestAKHQ"));
     }
 

--- a/src/test/java/org/akhq/configs/BasicAuthTest.java
+++ b/src/test/java/org/akhq/configs/BasicAuthTest.java
@@ -25,6 +25,7 @@ class BasicAuthTest {
     @Test
     void isValidPasswordBCryptInvalid() {
         BasicAuth basicAuth = new BasicAuth();
+        basicAuth.passwordHash = BasicAuth.PasswordHash.BCRYPT;
         basicAuth.password = "$2a$10$AtmQQDDSWnqsskzRxX1vGO0k6txZcJv.XlWRWA13.QOPq1wGB0DjS";
         assertFalse(basicAuth.isValidPassword("Bad"));
     }
@@ -32,6 +33,7 @@ class BasicAuthTest {
     @Test
     void isValidPasswordBCryptValid() {
         BasicAuth basicAuth = new BasicAuth();
+        basicAuth.passwordHash = BasicAuth.PasswordHash.BCRYPT;
         basicAuth.password = "$2a$10$AtmQQDDSWnqsskzRxX1vGO0k6txZcJv.XlWRWA13.QOPq1wGB0DjS";
         assertTrue(basicAuth.isValidPassword("TestAKHQ"));
     }


### PR DESCRIPTION
SHA-256 without salt is considered as breakable.

This pull request adds:
* Crypt format support https://en.wikipedia.org/wiki/Crypt_(C)
* BCrypt password hashing relying on https://www.mindrot.org/projects/jBCrypt/

However it still doesn't support SHA-256 with salt and multiple iterations as https://passlib.readthedocs.io/en/stable/lib/passlib.hash.sha256_crypt.html