### PR TITLE
Run Container as a non-root user by default and update the Helm chart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ FROM openjdk:11-jre-slim
 WORKDIR /app
 COPY docker /
 ENV MICRONAUT_CONFIG_FILES=/app/application.yml
+USER 10001
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["./akhq"]

--- a/helm/akhq/Chart.yaml
+++ b/helm/akhq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: Kafka GUI for Apache Kafka to manage topics, topics data, consumers group, schema registry, connect and more...
 name: akhq
-version: 0.1.2
+version: 0.1.3
 keywords:
   - kafka
   - confluent

--- a/helm/akhq/templates/deployment.yaml
+++ b/helm/akhq/templates/deployment.yaml
@@ -37,6 +37,8 @@ spec:
       imagePullSecrets:
         {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
+      securityContext:
+        {{ toYaml .Values.podSecurityContext }}
       {{- if .Values.initContainers }}
       initContainers:
         {{- range $key, $value := .Values.initContainers }}
@@ -48,6 +50,8 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
+          securityContext:
+            {{ toYaml .Values.containerSecurityContext }}
           env:
           {{- if .Values.secrets }}
           - name: MICRONAUT_ENVIRONMENTS

--- a/helm/akhq/templates/ingress.yaml
+++ b/helm/akhq/templates/ingress.yaml
@@ -1,7 +1,13 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "akhq.fullname" . -}}
 {{- $ingressPaths := .Values.ingress.paths -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -27,14 +33,25 @@ spec:
 {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
+  {{- $pathType := $.Values.ingress.pathType }}
     - host: {{ . | quote }}
       http:
         paths:
 	{{- range $ingressPaths }}
           - path: {{ . }}
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+            pathType: {{ $pathType | default "ImplementationSpecific" }}
+            {{- end }}
             backend:
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
+            {{ else }}
               serviceName: {{ $fullName }}
               servicePort: http
+            {{- end }}
 	{{- end }}
   {{- end }}
 {{- end }}

--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -17,13 +17,12 @@ image:
   #             properties:
   #               bootstrap.servers: "kafka:9092"
 
-
 ## Or you can also use configmap for the configuration...
 configuration: |
   akhq:
     server:
-      access-log: 
-        enabled: false 
+      access-log:
+        enabled: false
         name: org.akhq.log.access
 ##... and secret for connection information
 secrets: |
@@ -47,7 +46,7 @@ extraVolumes: []
 extraVolumeMounts: []
 # Add your own init container or uncomment and modify the example.
 initContainers: {}
-#   create-keystore: 
+#   create-keystore:
 #     image: "openjdk:11-slim"
 #     command: ['sh', '-c', 'keytool']
 #     volumeMounts:
@@ -66,7 +65,8 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  paths: []
+  paths: ["/"]
+  pathType: ImplementationSpecific
   hosts:
     - akhq.demo.com
   tls: []
@@ -87,3 +87,7 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+podSecurityContext: {}
+
+containerSecurityContext: {}


### PR DESCRIPTION
Run container as user 10001 by default. Added options for setting the (pod) securityContext. Added support for ingress v1, if available.