### PR TITLE
add keep search checkbox on topic list

### DIFF
--- a/client/src/components/SearchBar/SearchBar.jsx
+++ b/client/src/components/SearchBar/SearchBar.jsx
@@ -9,8 +9,8 @@ class SearchBar extends Form {
     showPagination: PropTypes.bool,
     showTopicListView: PropTypes.bool,
     showSearch: PropTypes.bool,
-    showConsumerGroup: PropTypes.bool,
-    showFilters: PropTypes.string
+    showFilters: PropTypes.string,
+    showKeepSearch: PropTypes.bool
   };
   state = {
     formData: {},
@@ -38,25 +38,35 @@ class SearchBar extends Form {
   schema = {};
 
   componentDidMount() {
-    const { showSearch, showTopicListView, showConsumerGroup } = this.props;
-    const { formData, errors } = this.state;
+    this.setState({ formData: this.setupProps() });
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const { search, topicListView, keepSearch } = this.props;
+
+    if(search !== prevProps.search || topicListView !== prevProps.topicListView || keepSearch !== prevProps.keepSearch) {
+      this.setupProps();
+    }
+  }
+
+  setupProps() {
+    const { showSearch, showTopicListView, showKeepSearch } = this.props;
+    const { formData } = this.state;
     if (showSearch) {
       const { search } = this.props;
       formData['search'] = search;
       this.schema['search'] = Joi.string().allow('');
     }
-
     if (showTopicListView) {
       const { topicListView } = this.props;
       formData['topicListView'] = topicListView;
       this.schema['topicListView'] = Joi.string().required();
-    } else if (showConsumerGroup) {
-      const { groupListView } = this.props;
-      formData['groupListView'] = groupListView;
-      this.schema['groupListView'] = Joi.string().required();
     }
-
-    this.setState({ formData, errors });
+    if(showKeepSearch) {
+      formData['keepSearch'] = this.props.keepSearch;
+      this.schema['keepSearch'] = Joi.boolean();
+    }
+    return formData;
   }
 
   setValue(value) {
@@ -72,13 +82,14 @@ class SearchBar extends Form {
   }
 
   doSubmit = () => {
-    const { pagination, search, topicListView } = this.state.formData;
+    const { pagination, search, topicListView, keepSearch } = this.state.formData;
     const data = {
       pagination: pagination,
       searchData: {
         search: search,
         topicListView: topicListView
-      }
+      },
+      keepSearch: keepSearch
     };
     this.props.doSubmit(data);
   };
@@ -90,9 +101,10 @@ class SearchBar extends Form {
       this.setState({ showFilters: 'show' });
     }
   }
+
   render() {
-    const { showSearch, showTopicListView } = this.props;
-    const { topicListViewOptions, showFilters } = this.state;
+    const { showSearch, showTopicListView, showKeepSearch } = this.props;
+    const { topicListViewOptions, showFilters, formData } = this.state;
 
     return (
       <React.Fragment>
@@ -143,6 +155,14 @@ class SearchBar extends Form {
               <span className="d-md-none">Search </span>
               <i className="fa fa-search" />
             </button>
+            {showKeepSearch && <span><input
+                type="checkbox"
+                name="keepSearch"
+                id="keepSearch"
+                onClick={(event) => this.props.onKeepSearchChange(event.target.checked)}
+                defaultChecked={formData['keepSearch']}
+              /> Keep search
+            </span>}
           </form>
         </div>
       </React.Fragment>

--- a/client/src/containers/Acl/AclList/Acls.jsx
+++ b/client/src/containers/Acl/AclList/Acls.jsx
@@ -17,14 +17,20 @@ class Acls extends Root {
   };
 
   componentDidMount() {
-    this.getAcls();
+    const { searchData } = this.state;
+    const query =  new URLSearchParams(this.props.location.search);
+    const { clusterId } = this.props.match.params;
+
+    this.setState({ selectedCluster: clusterId, searchData: { search: (query.get('search'))? query.get('search') : searchData.search }}, () => {
+      this.getAcls();
+    });
   }
 
   async getAcls() {
     let acls = [];
-    const { clusterId } = this.props.match.params;
+    const { selectedCluster } = this.state;
 
-    acls = await this.getApi(uriAclsList(clusterId, this.state.searchData.search));
+    acls = await this.getApi(uriAclsList(selectedCluster, this.state.searchData.search));
     this.handleData(acls.data);
   }
 
@@ -44,6 +50,10 @@ class Acls extends Root {
     const { searchData } = data;
     this.setState({ searchData, loading: true }, () => {
       this.getAcls();
+      this.props.history.push({
+        pathname: `/ui/${this.state.selectedCluster}/acls`,
+        search: `search=${searchData.search}`
+      });
     });
   };
 

--- a/client/src/containers/ConsumerGroup/ConsumerGroupList/ConsumerGroupList.jsx
+++ b/client/src/containers/ConsumerGroup/ConsumerGroupList/ConsumerGroupList.jsx
@@ -28,8 +28,11 @@ class ConsumerGroupList extends Root {
   };
 
   componentDidMount() {
-    let { clusterId } = this.props.match.params;
-    this.setState({ selectedCluster: clusterId }, () => {
+    const { clusterId } = this.props.match.params;
+    const { search } = this.state;
+    const query =  new URLSearchParams(this.props.location.search);
+
+    this.setState({ selectedCluster: clusterId, search: (query.get('search'))? query.get('search') : search }, () => {
       this.getConsumerGroup();
     });
   }
@@ -37,6 +40,10 @@ class ConsumerGroupList extends Root {
   handleSearch = data => {
     this.setState({ pageNumber: 1, search: data.searchData.search }, () => {
       this.getConsumerGroup();
+      this.props.history.push({
+        pathname: `/ui/${this.state.selectedCluster}/group`,
+        search: `search=${data.searchData.search}`
+      });
     });
   };
 

--- a/client/src/containers/Schema/SchemaList/SchemaList.jsx
+++ b/client/src/containers/Schema/SchemaList/SchemaList.jsx
@@ -41,8 +41,10 @@ class SchemaList extends Root {
 
   componentDidMount() {
     let { clusterId } = this.props.match.params;
+    const { searchData } = this.state;
+    const query =  new URLSearchParams(this.props.location.search);
 
-    this.setState({ selectedCluster: clusterId }, () => {
+    this.setState({ selectedCluster: clusterId, searchData: { search: (query.get('search'))? query.get('search') : searchData.search }}, () => {
       this.getSchemaRegistry();
     });
   }
@@ -51,6 +53,10 @@ class SchemaList extends Root {
     const { searchData } = data;
     this.setState({ pageNumber: 1, searchData }, () => {
       this.getSchemaRegistry();
+      this.props.history.push({
+        pathname: `/ui/${this.state.selectedCluster}/schema`,
+        search: `search=${searchData.search}`
+      });
     });
   };
 


### PR DESCRIPTION
Add a checkbox "Keep Search" search component.
Enabled the checkbox on topic list search and when chekbox is selected the search is saved on browser local storage.
When entering the topic list page, if exists a saved search is used on topic list.

Also fix #443 for topic list, consumer list, schema list and acl list