### PR TITLE
Add default path to Ingress paths

### DIFF
--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -66,7 +66,8 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  paths: []
+  paths:
+    - /
   hosts:
     - akhq.demo.com
   tls: []


### PR DESCRIPTION
## Problem

For now you are using empty array for ingress `paths` option as a default

In ingress helm template used `range`, so empty array by default renders as invalid k8s Ingress resource and to deploy this chart i have to specify `paths`. In most cases default path is `/`

## Examples
**Some examples** of ingress values, most of them using `/` as default:
- Minio: https://github.com/minio/charts/blob/fe46d0cdf8cd7054aac12cc6870a3416ebc2a6cc/minio/values.yaml#L168
- Grafana: https://github.com/prometheus-community/helm-charts/blob/a72459c5a1a5672c0bcd812a5a078ec4517693d2/charts/kube-prometheus-stack/values.yaml#L542
- ArgoCD: https://github.com/argoproj/argo-helm/blob/9ed4650b9f397414e9e88ca16b0653833be0e963/charts/argo-cd/values.yaml#L469
- RabbitMQ: https://github.com/bitnami/charts/blob/a4b58334911f6994ecce978132a4ee3121dfe155/bitnami/rabbitmq/values.yaml#L623

**Another approach** is to use fallback for paths when empty, but it is overkill for charts is not overriding application path
- Prometheus: https://github.com/prometheus-community/helm-charts/blob/a72459c5a1a5672c0bcd812a5a078ec4517693d2/charts/kube-prometheus-stack/templates/prometheus/ingress.yaml#L5

## That will is fixed
**This fixes** k8s validation error on helm install (Ansible used):
`
fatal: [node1]: FAILED! => {"changed": false, "command": "/usr/local/bin/helm --namespace=akhq --version=0.1.3 upgrade -i --reset-values -f=/tmp/tmpvs_giipm.yml akhq akhq/akhq", "msg": "Failure when executing Helm command. Exited 1.\nstdout: \nstderr: Error: UPGRADE FAILED: error validating \"\": error validating data: ValidationError(Ingress.spec.rules[0].http): missing required field \"paths\" in io.k8s.api.networking.v1beta1.HTTPIngressRuleValue\n", "stderr": "Error: UPGRADE FAILED: error validating \"\": error validating data: ValidationError(Ingress.spec.rules[0].http): missing required field \"paths\" in io.k8s.api.networking.v1beta1.HTTPIngressRuleValue\n", "stderr_lines": ["Error: UPGRADE FAILED: error validating \"\": error validating data: ValidationError(Ingress.spec.rules[0].http): missing required field \"paths\" in io.k8s.api.networking.v1beta1.HTTPIngressRuleValue"], "stdout": "", "stdout_lines": []}
`
