### PR TITLE
Return an empty fragment from rendering when the user/cluster isn't known

### DIFF
--- a/client/src/utils/Routes.js
+++ b/client/src/utils/Routes.js
@@ -111,6 +111,7 @@ class Routes extends Root {
 
     if (this.state.user.length <= 0) {
       this.getCurrentUser();
+      return <></>;
     }
 
     if (
@@ -118,6 +119,7 @@ class Routes extends Root {
       (sessionStorage.getItem('login') === 'true' || this.state.user === 'default')
     ) {
       this.getClusters();
+      return <></>;
     }
 
     if (!clusters.find(el => el.id === this.state.clusterId) && clusterId !== '401') {

--- a/client/src/utils/Routes.js
+++ b/client/src/utils/Routes.js
@@ -60,7 +60,7 @@ class Routes extends Root {
       });
   };
 
-  getCurrentUser(callback = () => {}) {
+  getCurrentUser() {
     sessionStorage.setItem('user', '');
     this.getApi(uriCurrentUser())
       .then(res => {
@@ -83,7 +83,6 @@ class Routes extends Root {
           }
         }
         this.setState({ loading: false });
-        callback();
       })
       .catch(err => {
         console.error('Error:', err);


### PR DESCRIPTION
The `getCurrentUser` and `getClusters` functions trigger an asynchronous request, and there's no point in trying to render further until the state has been updated with the results of these requests.