### PR TITLE
New attribute to filter Connect Configs by regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Define groups with specific roles for your users
   * `- name: group-name` Group identifier
     * `roles`: Roles list for the group
     * `attributes.topics-filter-regexp`: Regexp to filter topics available for current group
+    * `attributes.connects-filter-regexp`: Regexp to filter Connect tasks available for current group
 
 
 3 defaults group are available :
@@ -420,6 +421,7 @@ akhq:
         attributes:
           # Regexp to filter topic available for group
           topics-filter-regexp: "test\\.reader.*"
+          connects-filter-regexp: "^test.*$"
       - name: topic-writer # Group name
         roles:
           - topic/read
@@ -428,6 +430,7 @@ akhq:
           - topic/config/update
         attributes:
           topics-filter-regexp: "test.*"
+          connects-filter-regexp: "^test.*$"
     ldap:
       groups:
         - name: mathematicians

--- a/application.example.yml
+++ b/application.example.yml
@@ -163,6 +163,8 @@ akhq:
         attributes:
           # Regexp to filter topic available for group
           topics-filter-regexp: "test.*"
+          # Regexp to filter connect configs visible for group
+          connects-filter-regexp: "^test.*$"
       - name: topic-reader # Other group
         roles:
           - topic/read

--- a/src/main/java/org/akhq/repositories/AbstractRepository.java
+++ b/src/main/java/org/akhq/repositories/AbstractRepository.java
@@ -19,13 +19,13 @@ abstract public class AbstractRepository {
         return count == split.length;
     }
 
-    public static boolean isTopicMatchRegex(Optional<List<String>> regex, String topic) {
+    public static boolean isMatchRegex(Optional<List<String>> regex, String item) {
         if (regex.isEmpty() || regex.get().isEmpty()) {
             return true;
         }
 
         for (String strRegex : regex.get()) {
-            if (topic.matches(strRegex)) {
+            if (item.matches(strRegex)) {
                 return true;
             }
         }

--- a/src/main/java/org/akhq/repositories/ConnectRepository.java
+++ b/src/main/java/org/akhq/repositories/ConnectRepository.java
@@ -5,10 +5,15 @@ import com.google.common.collect.Iterables;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import io.micronaut.context.ApplicationContext;
 import io.micronaut.retry.annotation.Retryable;
+import io.micronaut.security.authentication.Authentication;
+import io.micronaut.security.utils.SecurityService;
+import org.akhq.configs.SecurityProperties;
 import org.akhq.models.ConnectDefinition;
 import org.akhq.models.ConnectPlugin;
 import org.akhq.modules.KafkaModule;
+import org.akhq.utils.UserGroupUtils;
 import org.sourcelab.kafka.connect.apiclient.request.dto.ConnectorPlugin;
 import org.sourcelab.kafka.connect.apiclient.request.dto.ConnectorPluginConfigDefinition;
 import org.sourcelab.kafka.connect.apiclient.request.dto.NewConnectorDefinition;
@@ -20,11 +25,21 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.regex.Pattern;
 
 @Singleton
 public class ConnectRepository extends AbstractRepository {
     @Inject
     private KafkaModule kafkaModule;
+
+    @Inject
+    private ApplicationContext applicationContext;
+
+    @Inject
+    private UserGroupUtils userGroupUtils;
+
+    @Inject
+    private SecurityProperties securityProperties;
 
     private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
@@ -50,11 +65,19 @@ public class ConnectRepository extends AbstractRepository {
         ResourceNotFoundException.class
     }, delay = "3s", attempts = "5")
     public List<ConnectDefinition> getDefinitions(String clusterId, String connectId) {
-        return this.kafkaModule
+        Collection<String> unfiltered = this.kafkaModule
             .getConnectRestClient(clusterId)
             .get(connectId)
-            .getConnectors()
-            .stream()
+            .getConnectors();
+
+        ArrayList<String> filtered = new ArrayList<String>();
+        for (String item : unfiltered) {
+            if (isMatchRegex(getConnectFilterRegex(), item)) {
+                filtered.add(item);
+            }
+        }
+
+        return filtered.stream()
             .map(s -> getDefinition(clusterId, connectId, s))
             .collect(Collectors.toList());
     }
@@ -206,5 +229,35 @@ public class ConnectRepository extends AbstractRepository {
         String[] split = className.split("\\.");
 
         return split[split.length - 1];
+    }
+
+    private Optional<List<String>> getConnectFilterRegex() {
+
+        List<String> connectFilterRegex = new ArrayList<>();
+
+        if (applicationContext.containsBean(SecurityService.class)) {
+            SecurityService securityService = applicationContext.getBean(SecurityService.class);
+            Optional<Authentication> authentication = securityService.getAuthentication();
+            if (authentication.isPresent()) {
+                Authentication auth = authentication.get();
+                connectFilterRegex.addAll(getConnectFilterRegexFromAttributes(auth.getAttributes()));
+            }
+        }
+        // get Connect filter regex for default groups
+        connectFilterRegex.addAll(getConnectFilterRegexFromAttributes(
+            userGroupUtils.getUserAttributes(Collections.singletonList(securityProperties.getDefaultGroup()))
+        ));
+
+        return Optional.of(connectFilterRegex);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> getConnectFilterRegexFromAttributes(Map<String, Object> attributes) {
+        if (attributes.get("connects-filter-regexp") != null) {
+            if (attributes.get("connects-filter-regexp") instanceof List) {
+                return (List<String>)attributes.get("connects-filter-regexp");
+            }
+        }
+        return new ArrayList<>();
     }
 }

--- a/src/main/java/org/akhq/repositories/ConnectRepository.java
+++ b/src/main/java/org/akhq/repositories/ConnectRepository.java
@@ -48,6 +48,9 @@ public class ConnectRepository extends AbstractRepository {
         ResourceNotFoundException.class
     }, delay = "3s", attempts = "5")
     public ConnectDefinition getDefinition(String clusterId, String connectId, String name) {
+        if (!isMatchRegex(getConnectFilterRegex(), name)) {
+            throw new IllegalArgumentException(String.format("Not allowed to view Connector %s", name));
+        }
         return new ConnectDefinition(
             this.kafkaModule
                 .getConnectRestClient(clusterId)

--- a/src/main/java/org/akhq/repositories/TopicRepository.java
+++ b/src/main/java/org/akhq/repositories/TopicRepository.java
@@ -65,7 +65,7 @@ public class TopicRepository extends AbstractRepository {
         Collection<TopicListing> listTopics = kafkaWrapper.listTopics(clusterId);
 
         for (TopicListing item : listTopics) {
-            if (isSearchMatch(search, item.name()) && isListViewMatch(view, item.name()) && isTopicMatchRegex(
+            if (isSearchMatch(search, item.name()) && isListViewMatch(view, item.name()) && isMatchRegex(
                 getTopicFilterRegex(), item.name())) {
                 list.add(item.name());
             }
@@ -91,7 +91,7 @@ public class TopicRepository extends AbstractRepository {
 
     public Topic findByName(String clusterId, String name) throws ExecutionException, InterruptedException {
         Optional<Topic> topic = Optional.empty();
-        if(isTopicMatchRegex(getTopicFilterRegex(),name)) {
+        if(isMatchRegex(getTopicFilterRegex(),name)) {
             topic = this.findByName(clusterId, Collections.singletonList(name)).stream().findFirst();
         }
 
@@ -107,7 +107,7 @@ public class TopicRepository extends AbstractRepository {
         Optional<List<String>> topicRegex = getTopicFilterRegex();
 
         for (Map.Entry<String, TopicDescription> description : topicDescriptions) {
-            if(isTopicMatchRegex(topicRegex, description.getValue().name())){
+            if(isMatchRegex(topicRegex, description.getValue().name())){
                 list.add(
                     new Topic(
                         description.getValue(),


### PR DESCRIPTION
I followed the same logic you implemented for topics.
It has the sames limitations as your implementation : it only makes sense when the user have Read-Only acces, because the filter is only verified on list and search.
It has the same vulnerability as your implementation : if the user have roles read/create/update/delete, he can create/update/delete connect configs that doesn't follow the regex.

I consider this OK because for our use cases, we use AKHQ as a Read Only support/monitoring tool.
I may be worth mentioning this behavior in the documentation.