### PR TITLE
Add default invalid JWT secret

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,10 @@ micronaut:
         cookie:
           enabled: true
           cookie-same-site: strict
+        signatures:
+          secret:
+            generator:
+              secret: changeme
     redirect:
       login-success: "${micronaut.server.context-path:}/ui"
       forbidden:


### PR DESCRIPTION
Fix for #470 

When launching AKHQ with a default and invalid secret (changeme), I get an authentication Error and no JWT generated.
Reading the logs, I understand it is mandatory to change the JWT.

````
2020-10-26 09:08:51,142 WARN  1-thread-6 .s.t.j.v.JwtTokenValidator JOSEException while generating token The secret length must be at least 256 bits  
2020-10-26 09:08:51,143 WARN  1-thread-6 org.akhq.log.access        [Date: 2020-10-26T09:08:47.24114Z] [Duration: 3902 ms] [Url: POST /login] [Status: 500] [Ip: /198.18.143.226
] [User: Anonymous]
````