### PR TITLE
Run image as a non-root user by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ FROM openjdk:11-jre-slim
 WORKDIR /app
 COPY docker /
 ENV MICRONAUT_CONFIG_FILES=/app/application.yml
+USER 10001
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["./akhq"]


### PR DESCRIPTION
Follow up from #442, using the correct branches this time 😅.

The changes were tested using a custom image build (see https://hub.docker.com/layers/chgl/akhq/0.15.0-rootless/images/sha256-daf750aa2e94e1c3a75b91faf5df08bdda4d6ef8dcf70cd8df7e02cc8b2acfd5?context=explore) and akhq is currently running as a non-root user set via securityContext in a production cluster.