### PR TITLE
Helm typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,17 +140,16 @@ docker run -d \
 ```sh
 helm repo add akhq https://akhq.io/
 ```
-* Install it:
+* Install or upgrade
 ```sh
-helm install --name akhq akhq/akhq
+helm upgrade --install akhq akhq/akhq
 ```
-
 #### Requirements
 
 * Chart version >=0.1.1 requires Kubernetes version >=1.14
 * Chart version 0.1.0 works on previous Kubernetes versions
 ```sh
-helm install --name akhq akhq/akhq --version 0.1.0
+helm install akhq akhq/akhq --version 0.1.0
 ```
 
 ### Using git

--- a/helm/akhq/templates/NOTES.txt
+++ b/helm/akhq/templates/NOTES.txt
@@ -17,5 +17,5 @@
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "akhq.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:8080
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.port }}
 {{- end }}


### PR DESCRIPTION
Motivation

* since helm2 is deprecated, the readme should use helm3 compatible syntax
* helm chart should render notes with proper port defined in `values.yaml`