### PR TITLE
Add TVG to Whos using AKHQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@ Documentation on Confluent 5.5 and schema references can be found [here](https:/
 * [Nuxeo](https://www.nuxeo.com/)
 * [Pipedrive](https://www.pipedrive.com)
 * [BARMER](https://www.barmer.de/)
+* [TVG](https://www.tvg.com)
 
 
 ## Credits


### PR DESCRIPTION
In TVG we are using AKHQ in every environment. For us, it's a must have on the Development and QA phases and also to troubleshoot any potential issue in production. It already has LDAP authentication which we use. We don't use the multiple cluster feature, we just deployed one AKHQ per environment. Feel free to also add our logo to the website. 

Thanks a lot for your and all the contributors efforts on this. Will, for sure, recommend and continue to use it in the future.