### PR TITLE
feat(dev): Run docker image as non-root with 'akhq' user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ FROM openjdk:11-jre-slim
 WORKDIR /app
 COPY docker /
 ENV MICRONAUT_CONFIG_FILES=/app/application.yml
-USER 10001
+# Create user
+RUN useradd -ms /bin/bash akhq
+# Chown to write configuration
+RUN chown -R akhq /app
+# Use the 'akhq' user
+USER akhq
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["./akhq"]


### PR DESCRIPTION
Following pull request #487,to avoid a user with no name we can create a user 'akhq' with proper rights on `/app` directory to write configuration.

The previous configuration use user `10001` which lead to an unnamed user (e.g. `I have no name!@5af14cf2a980:/app$`).