### PR TITLE
Partition auto assign when producing to topic

### DIFF
--- a/client/src/containers/Topic/TopicProduce/TopicProduce.jsx
+++ b/client/src/containers/Topic/TopicProduce/TopicProduce.jsx
@@ -45,9 +45,8 @@ class TopicProduce extends Form {
 
   schema = {
     partition: Joi.number()
-      .min(0)
-      .label('Partition')
-      .required(),
+      .allow(null)
+      .label('Partition'),
     key: Joi.string()
       .allow('')
       .label('Key'),
@@ -69,6 +68,7 @@ class TopicProduce extends Form {
     let partitions = response.data.map(item => {
       return { name: item.id, _id: Number(item.id) };
     });
+    partitions.unshift({name: "auto assign", _id: null});
     this.setState({
       partitions,
       formData: {


### PR DESCRIPTION
Reintroducing the option of letting Kafka library decide where to put a message based on it's key. 

This was possible with the old front end, when leaving partition selector blank on producing a message to a topic. To have this feature back again, and make it's usage more intuitive I though of adding the option "auto assign":

![image](https://user-images.githubusercontent.com/51787541/98442189-8f6f8100-2103-11eb-9b77-537c8e0780a6.png)

What do you say?