### PR TITLE
feat(helm): add option to specify serviceAccountName

### DIFF
--- a/helm/akhq/templates/deployment.yaml
+++ b/helm/akhq/templates/deployment.yaml
@@ -41,6 +41,9 @@ spec:
       securityContext:
         {{ toYaml .Values.securityContext | indent 8 }}
       {{- end }}
+      {{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- end }}
       {{- if .Values.initContainers }}
       initContainers:
         {{- range $key, $value := .Values.initContainers }}

--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -53,6 +53,9 @@ extraVolumes: []
 # Any extra volume mounts to define for the akhq container
 extraVolumeMounts: []
 
+# Specify ServiceAccount for pod
+serviceAccountName: null
+
 # Add your own init container or uncomment and modify the example.
 initContainers: {}
 #   create-keystore: 


### PR DESCRIPTION
At the moment it is possible to specify init containers, but if you need serviceAccount for init container, then there is no way to specify it.