### PR TITLE
fix(auth): Rolling back group configuration to a map format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ out/*
 logs/*
 
 ### Kafka HQ ###
-src/**/*-*.yml
+src/main/*-*.yml
 connects-plugins/
 
 ### Docs

--- a/src/main/java/org/akhq/configs/SecurityProperties.java
+++ b/src/main/java/org/akhq/configs/SecurityProperties.java
@@ -1,28 +1,26 @@
 package org.akhq.configs;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.convert.format.MapFormat;
 import lombok.Data;
 
 import javax.annotation.PostConstruct;
 import java.util.ArrayList;
-import java.util.LinkedList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @ConfigurationProperties("akhq.security")
 @Data
 public class SecurityProperties {
     private List<BasicAuth> basicAuth = new ArrayList<>();
-    private List<Group> basicGroups = new ArrayList<>();
-    private List<Group> groups = new ArrayList<>();
     private String defaultGroup;
+
+    @MapFormat(transformation = MapFormat.MapTransformation.FLAT)
+    private Map<String, Group> groups = new HashMap<>();
 
     @PostConstruct
     public void init() {
-        Map<String, Group> allGroups = basicGroups.stream()
-                .collect(Collectors.toMap(group -> group.name, group -> group));
-        groups.forEach(group -> allGroups.put(group.name, group));
-        groups = new LinkedList<>(allGroups.values());
+        groups.entrySet().forEach(entry -> entry.getValue().setName(entry.getKey()));
     }
 }

--- a/src/main/java/org/akhq/configs/SecurityProperties.java
+++ b/src/main/java/org/akhq/configs/SecurityProperties.java
@@ -1,5 +1,6 @@
 package org.akhq.configs;
 
+import com.google.common.base.Strings;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.convert.format.MapFormat;
 import lombok.Data;
@@ -21,6 +22,10 @@ public class SecurityProperties {
 
     @PostConstruct
     public void init() {
-        groups.entrySet().forEach(entry -> entry.getValue().setName(entry.getKey()));
+        groups.forEach((key, group) -> {
+            if (Strings.isNullOrEmpty(group.getName())) {
+                group.setName(key);
+            }
+        });
     }
 }

--- a/src/main/java/org/akhq/configs/SecurityProperties.java
+++ b/src/main/java/org/akhq/configs/SecurityProperties.java
@@ -3,13 +3,26 @@ package org.akhq.configs;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import lombok.Data;
 
+import javax.annotation.PostConstruct;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @ConfigurationProperties("akhq.security")
 @Data
 public class SecurityProperties {
     private List<BasicAuth> basicAuth = new ArrayList<>();
-    private List<Group> groups;
+    private List<Group> basicGroups = new ArrayList<>();
+    private List<Group> groups = new ArrayList<>();
     private String defaultGroup;
+
+    @PostConstruct
+    public void init() {
+        Map<String, Group> allGroups = basicGroups.stream()
+                .collect(Collectors.toMap(group -> group.name, group -> group));
+        groups.forEach(group -> allGroups.put(group.name, group));
+        groups = new LinkedList<>(allGroups.values());
+    }
 }

--- a/src/main/java/org/akhq/utils/UserGroupUtils.java
+++ b/src/main/java/org/akhq/utils/UserGroupUtils.java
@@ -28,7 +28,7 @@ public class UserGroupUtils {
             return new ArrayList<>();
         }
 
-        return securityProperties.getGroups().stream()
+        return securityProperties.getGroups().values().stream()
             .filter(group -> groups.contains(group.getName()))
             .filter(group -> group.getRoles() != null)
             .flatMap(group -> group.getRoles().stream())
@@ -48,7 +48,7 @@ public class UserGroupUtils {
             return null;
         }
 
-        return securityProperties.getGroups().stream()
+        return securityProperties.getGroups().values().stream()
             .filter(group -> groups.contains(group.getName()))
             .flatMap(group -> (group.getAttributes() != null) ? group.getAttributes().entrySet().stream() : null)
             .collect(Collectors.toMap(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -132,40 +132,40 @@ akhq:
 
   security:
     default-group: admin
-    basic-groups:
-    - name: admin
-      roles:
-      - topic/read
-      - topic/insert
-      - topic/delete
-      - topic/config/update
-      - node/read
-      - node/config/update
-      - topic/data/read
-      - topic/data/insert
-      - topic/data/delete
-      - group/read
-      - group/delete
-      - group/offsets/update
-      - registry/read
-      - registry/insert
-      - registry/update
-      - registry/delete
-      - registry/version/delete
-      - acls/read
-      - connect/read
-      - connect/insert
-      - connect/update
-      - connect/delete
-      - connect/state/update
-    - name: reader
-      roles:
-      - topic/read
-      - node/read
-      - topic/data/read
-      - group/read
-      - registry/read
-      - acls/read
-      - connect/read
-    - name: no-roles
-      roles: []
+    groups:
+      admin:
+        roles:
+        - topic/read
+        - topic/insert
+        - topic/delete
+        - topic/config/update
+        - node/read
+        - node/config/update
+        - topic/data/read
+        - topic/data/insert
+        - topic/data/delete
+        - group/read
+        - group/delete
+        - group/offsets/update
+        - registry/read
+        - registry/insert
+        - registry/update
+        - registry/delete
+        - registry/version/delete
+        - acls/read
+        - connect/read
+        - connect/insert
+        - connect/update
+        - connect/delete
+        - connect/state/update
+      reader:
+        roles:
+        - topic/read
+        - node/read
+        - topic/data/read
+        - group/read
+        - registry/read
+        - acls/read
+        - connect/read
+      no-roles:
+        roles: []

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -134,6 +134,7 @@ akhq:
     default-group: admin
     groups:
       admin:
+        name: admin
         roles:
         - topic/read
         - topic/insert
@@ -159,6 +160,7 @@ akhq:
         - connect/delete
         - connect/state/update
       reader:
+        name: reader
         roles:
         - topic/read
         - node/read
@@ -168,4 +170,5 @@ akhq:
         - acls/read
         - connect/read
       no-roles:
+        name: no-roles
         roles: []

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -132,7 +132,7 @@ akhq:
 
   security:
     default-group: admin
-    groups:
+    basic-groups:
     - name: admin
       roles:
       - topic/read

--- a/src/test/java/org/akhq/configs/SecurityPropertiesTest.java
+++ b/src/test/java/org/akhq/configs/SecurityPropertiesTest.java
@@ -1,0 +1,52 @@
+package org.akhq.configs;
+
+import io.micronaut.context.ApplicationContext;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.CollectionUtils;
+
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SecurityPropertiesTest {
+
+    @Test
+    void shouldReturnAllBasicGroups() {
+        ApplicationContext ctx = ApplicationContext.run(ApplicationContext.class);
+        SecurityProperties securityProperties = ctx.getBean(SecurityProperties.class);
+
+        assertEquals(
+                CollectionUtils.toSet(new String[] {"admin", "limited", "operator", "no-filter"}),
+                securityProperties.getBasicGroups().stream().map(g -> g.name).collect(Collectors.toSet())
+        );
+
+        ctx.close();
+    }
+
+    @Test
+    void shouldReturnAllBasicPlusConfiguredGroups() {
+        ApplicationContext ctx = ApplicationContext.run(ApplicationContext.class, "extragroups");
+        SecurityProperties securityProperties = ctx.getBean(SecurityProperties.class);
+
+        assertEquals(
+                CollectionUtils.toSet(new String[] {"admin", "limited", "operator", "no-filter", "extra", "another"}),
+                securityProperties.getGroups().stream().map(g -> g.name).collect(Collectors.toSet())
+        );
+
+        ctx.close();
+    }
+
+    @Test
+    void shouldOverrideBasicGroups() {
+        ApplicationContext ctx = ApplicationContext.run(ApplicationContext.class, "overridegroups");
+        SecurityProperties securityProperties = ctx.getBean(SecurityProperties.class);
+
+        assertEquals(
+                CollectionUtils.toSet(new String[] {"admin", "limited", "operator", "no-filter", "extra"}),
+                securityProperties.getGroups().stream().map(g -> g.name).collect(Collectors.toSet())
+        );
+
+        ctx.close();
+    }
+
+}

--- a/src/test/java/org/akhq/configs/SecurityPropertiesTest.java
+++ b/src/test/java/org/akhq/configs/SecurityPropertiesTest.java
@@ -4,7 +4,7 @@ import io.micronaut.context.ApplicationContext;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.util.CollectionUtils;
 
-import java.util.stream.Collectors;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -17,7 +17,7 @@ class SecurityPropertiesTest {
 
         assertEquals(
                 CollectionUtils.toSet(new String[] {"admin", "limited", "operator", "no-filter"}),
-                securityProperties.getBasicGroups().stream().map(g -> g.name).collect(Collectors.toSet())
+                securityProperties.getGroups().keySet()
         );
 
         ctx.close();
@@ -30,7 +30,7 @@ class SecurityPropertiesTest {
 
         assertEquals(
                 CollectionUtils.toSet(new String[] {"admin", "limited", "operator", "no-filter", "extra", "another"}),
-                securityProperties.getGroups().stream().map(g -> g.name).collect(Collectors.toSet())
+                securityProperties.getGroups().keySet()
         );
 
         ctx.close();
@@ -43,7 +43,11 @@ class SecurityPropertiesTest {
 
         assertEquals(
                 CollectionUtils.toSet(new String[] {"admin", "limited", "operator", "no-filter", "extra"}),
-                securityProperties.getGroups().stream().map(g -> g.name).collect(Collectors.toSet())
+                securityProperties.getGroups().keySet()
+        );
+        assertEquals(
+                Collections.singletonList("topic/read"),
+                securityProperties.getGroups().get("admin").roles
         );
 
         ctx.close();

--- a/src/test/resources/application-extragroups.yml
+++ b/src/test/resources/application-extragroups.yml
@@ -1,10 +1,10 @@
 akhq:
   security:
     groups:
-      - name: extra
+      extra:
         roles:
           - topic/read
-      - name: another
+      another:
         roles:
           - topic/read
 

--- a/src/test/resources/application-extragroups.yml
+++ b/src/test/resources/application-extragroups.yml
@@ -1,0 +1,10 @@
+akhq:
+  security:
+    groups:
+      - name: extra
+        roles:
+          - topic/read
+      - name: another
+        roles:
+          - topic/read
+

--- a/src/test/resources/application-overridegroups.yml
+++ b/src/test/resources/application-overridegroups.yml
@@ -1,0 +1,13 @@
+akhq:
+  security:
+    groups:
+      - name: admin
+        roles:
+          - topic/read
+      - name: limited
+        roles:
+          - topic/read
+      - name: extra
+        roles:
+          - topic/read
+

--- a/src/test/resources/application-overridegroups.yml
+++ b/src/test/resources/application-overridegroups.yml
@@ -1,13 +1,13 @@
 akhq:
   security:
     groups:
-      - name: admin
+      admin:
         roles:
           - topic/read
-      - name: limited
+      limited:
         roles:
           - topic/read
-      - name: extra
+      extra:
         roles:
           - topic/read
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -77,7 +77,7 @@ akhq:
 
   security:
     default-group: no-filter
-    groups:
+    basic-groups:
       - name: admin
         roles:
           - topic/read

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -77,8 +77,8 @@ akhq:
 
   security:
     default-group: no-filter
-    basic-groups:
-      - name: admin
+    groups:
+      admin:
         roles:
           - topic/read
           - topic/insert
@@ -103,7 +103,7 @@ akhq:
           - connect/update
           - connect/delete
           - connect/state/update
-      - name: limited
+      limited:
         roles:
           - topic/read
           - topic/insert
@@ -111,7 +111,7 @@ akhq:
           - registry/version/delete
         attributes:
           topics-filter-regexp: "test.*"
-      - name: operator
+      operator:
         roles:
           - topic/read
           - topic/data/read
@@ -119,7 +119,7 @@ akhq:
           - topic/data/delete
         attributes:
           topics-filter-regexp: "test-operator.*"
-      - name: no-filter
+      no-filter:
         roles:
           - topic/read
           - topic/insert

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -79,6 +79,7 @@ akhq:
     default-group: no-filter
     groups:
       admin:
+        name: admin
         roles:
           - topic/read
           - topic/insert
@@ -104,6 +105,7 @@ akhq:
           - connect/delete
           - connect/state/update
       limited:
+        name: limited
         roles:
           - topic/read
           - topic/insert
@@ -112,6 +114,7 @@ akhq:
         attributes:
           topics-filter-regexp: "test.*"
       operator:
+        name: operator
         roles:
           - topic/read
           - topic/data/read
@@ -120,6 +123,7 @@ akhq:
         attributes:
           topics-filter-regexp: "test-operator.*"
       no-filter:
+        name: no-filter
         roles:
           - topic/read
           - topic/insert


### PR DESCRIPTION
Hi @tchiotludo 

This is a proposed fix for an issue with 0.16.0 that happens when you configure security groups (akhq.security.groups). I believe it's related to [this issue](https://github.com/tchiotludo/akhq/issues/524).

The root cause is, since the groups are now configured as a list (and not a map) the configuration that takes precedence (according to the Micronaut rules for precedence) will override all other configurations for that key. In other words, if you configure any group under `akqh.security.groups`, the default `admin`, `reader` and `no-roles` groups (defined in the resources/application.yml) will be overriden.

**A mitigation** for the users waiting for a fix is to add the basic groups to their own configuration (basically copy them from https://github.com/tchiotludo/akhq/blob/dev/src/main/resources/application.yml).

**The ideal solution** in my opinion would be to revert to using a map instead of a list for configuring groups, but I understand that might be troublesome for you.

**The solution in this PR** is a middle-ground. It renames the default groups configured in `resources/application.yml` to `basic-groups` and merges them with the ones configured by the user. There is a limitation though, only one environment is supported (https://docs.micronaut.io/latest/guide/index.html#environments). This should cover 90% if not all use cases, though, and is already a limitation in the current 0.16.0.

Hope this is helpful and apologies for not introducing myself first.