### PR TITLE
Horizontal scroll on Firefox

### DIFF
--- a/client/src/css/templates/layout.scss
+++ b/client/src/css/templates/layout.scss
@@ -56,6 +56,7 @@ h3.logo {
 }
 
 .khq-sticky {
+    @-moz-document url-prefix() { position: initial }
     position: sticky;
     z-index: 100;
     top: 0;


### PR DESCRIPTION
Fix #474

Just removed the sticky position for search section on Firefox.
I didn't found other solution for now.

