### PR TITLE
Fix timestamp formatting

### DIFF
--- a/client/src/containers/ConsumerGroup/ConsumerGroupDetail/ConsumerGroupUpdate/ConsumerGroupUpdate.jsx
+++ b/client/src/containers/ConsumerGroup/ConsumerGroupDetail/ConsumerGroupUpdate/ConsumerGroupUpdate.jsx
@@ -54,7 +54,7 @@ class ConsumerGroupUpdate extends Form {
               second: momentValue.second(),
               milli: momentValue.millisecond()
             },
-            'YYYY-MM-DDThh:mm:ss.SSS'
+            'YYYY-MM-DDTHH:mm:ss.SSS'
           ) + 'Z'
         : '';
 

--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -161,7 +161,7 @@ class TopicData extends Root {
               second: timestamp.second(),
               milli: timestamp.millisecond()
             },
-            'YYYY-MM-DDThh:mm:ss.SSS',
+            'YYYY-MM-DDTHH:mm:ss.SSS',
             true
           ) + 'Z';
       filters.push(`timestamp=${timestamp}`);


### PR DESCRIPTION
When filtering topic data by `timestamp` and also when fetching offsets for consumer groups by `datetime` we seem to be formatting the hour of the timestamp using `hh`. In moment.js, this causes the hour to always have a range between [0-12](https://momentjs.com/docs/#/displaying/format/) even though even though the api expects a range between 0-24. This prevents filtering of timestamp or fetching of offsets for any time greater than 12:59 on any given day.

This PR corrects this by changing `hh` to `HH` on the formatting calls.

Fixes https://github.com/tchiotludo/akhq/issues/550