### PR TITLE
Update  OIDC group/role mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,11 +547,14 @@ akhq:
         google:
           label: "Login with Google"
           username-field: preferred_username
+          # specifies the field name in the oidc claim containig the use assigned group (eg. in keycloak this would be the Token Claim Name you set in your Client Role Mapper)
           groups-field: roles
           default-group: topic-reader
           groups:
+            # the name of the user role set in your oidc provider and associated with your user (eg. in keycloak this would be a client role)
             - name: mathematicians
               groups:
+                # the corresponding akhq groups (eg. topic-reader/writer or akhq default groups like admin/reader/no-role)
                 - topic-reader
             - name: scientists
               groups:

--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ akhq:
         google:
           label: "Login with Google"
           username-field: preferred_username
-          # specifies the field name in the oidc claim containig the use assigned group (eg. in keycloak this would be the Token Claim Name you set in your Client Role Mapper)
+          # specifies the field name in the oidc claim containig the use assigned role (eg. in keycloak this would be the Token Claim Name you set in your Client Role Mapper)
           groups-field: roles
           default-group: topic-reader
           groups:

--- a/src/main/java/org/akhq/modules/OidcUserDetailsMapper.java
+++ b/src/main/java/org/akhq/modules/OidcUserDetailsMapper.java
@@ -128,6 +128,16 @@ public class OidcUserDetailsMapper extends DefaultOpenIdUserDetailsMapper {
         List<String> akhqGroups = getAkhqGroups(providerName, openIdClaims, username);
         List<String> roles = userGroupUtils.getUserRoles(akhqGroups);
         Map<String, Object> attributes = buildAttributes(providerName, tokenResponse, openIdClaims, akhqGroups);
+
+        /**
+        * In case of OIDC the user roles are not correctly mapped to corresponding roles in akhq,
+        * If we find a groups-field in the user attributes override it with the correctly mapped
+        * roles that match the associated akhq group
+        */
+        Oidc.Provider provider = oidc.getProvider(providerName);
+        if (attributes.containsKey(provider.getGroupsField())) {
+            attributes.put(provider.getGroupsField(), roles);
+        }
         return new UserDetails(username, roles, attributes);
     }
 }


### PR DESCRIPTION
closes https://github.com/tchiotludo/akhq/issues/534

I think most of this are just wording issues. We have:
- akhq roles
- akhq groups
- oidc client roles

Oidc client roles are assigned to a use and should map to a corresponding group in akhq. the group in akhq then maps to its internal roles (eg: topic/reader, topic/writer...). I tried to also explain this a bit better in the readme. I only have access to keycloak so i used this as reference in my explanations.

