### PR TITLE
Add schema registry client configs to restservice to allow SSL connections

### DIFF
--- a/src/main/java/org/akhq/modules/KafkaModule.java
+++ b/src/main/java/org/akhq/modules/KafkaModule.java
@@ -156,6 +156,7 @@ public class KafkaModule {
 
             if (connection.getSchemaRegistry().getProperties() != null
                     && !connection.getSchemaRegistry().getProperties().isEmpty()) {
+
                 Map<String, Object> sslConfigs =
                         (Map) connection.getSchemaRegistry().getProperties().entrySet().stream().filter((e) -> {
                     return ((String) e.getKey()).startsWith("schema.registry.");

--- a/src/main/java/org/akhq/modules/KafkaModule.java
+++ b/src/main/java/org/akhq/modules/KafkaModule.java
@@ -5,6 +5,7 @@ import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
+import io.confluent.kafka.schemaregistry.client.security.SslFactory;
 import io.confluent.kafka.schemaregistry.client.security.basicauth.BasicAuthCredentialProvider;
 import io.confluent.kafka.schemaregistry.client.security.basicauth.BasicAuthCredentialProviderFactory;
 import io.confluent.kafka.schemaregistry.client.security.basicauth.UserInfoCredentialProvider;
@@ -152,6 +153,21 @@ public class KafkaModule {
             RestService restService = new RestService(
                 connection.getSchemaRegistry().getUrl()
             );
+
+            if (connection.getSchemaRegistry().getProperties() != null
+                    && !connection.getSchemaRegistry().getProperties().isEmpty()) {
+                Map<String, Object> sslConfigs =
+                        (Map) connection.getSchemaRegistry().getProperties().entrySet().stream().filter((e) -> {
+                    return ((String) e.getKey()).startsWith("schema.registry.");
+                }).collect(Collectors.toMap((e) -> {
+                    return ((String) e.getKey()).substring("schema.registry.".length());
+                }, Map.Entry::getValue));
+
+                SslFactory sslFactory = new SslFactory(sslConfigs);
+                if (sslFactory != null && sslFactory.sslContext() != null) {
+                    restService.setSslSocketFactory(sslFactory.sslContext().getSocketFactory());
+                }
+            }
 
             restService.setHttpHeaders(Collections.singletonMap("Accept", "application/json"));
 


### PR DESCRIPTION
Hi, I was trying to connect to my Schema Registry through HTTPS and I realized that i wasn't working although I was using the right configuration:

```yaml
akhq:
  connections:
    kafka:  
      schema-registry:
         url: "http://schema-registry:8081" 
         basic-auth-username: basic-auth-user 
         basic-auth-password: basic-auth-pass
         properties: 
           schema.registry.ssl.truststore.location: /etc/CA-truststore.jks
           schema.registry.ssl.truststore.password: password 
```

I saw that the properties beginning with `schema.registry` are being used to configure the SSlFactory of the RestService in the constructor of the object CachedSchemaRegistryClient. Here is the [link](https://github.com/confluentinc/schema-registry/blob/1cc5c9dea893a28823a4a46cef9e5e52e5e56629/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java#L169)

So, when AKHQ [instantiates only the RestService object](https://github.com/tchiotludo/akhq/blob/9646c0a7294a68323b300b4c16918cc1d0b05259/src/main/java/org/akhq/modules/KafkaModule.java#L148), these properties are not being configured, and t is when the one way SSL connection fails.

THe PR contains the same code than the CachedSchemaRegistryClient to apply these properties to the RestService. Another option would be to use the wrapper of the CachedSchemaRegistryClient and reuse it to make all the requests instead of creating an [instance of the RestService every time](https://github.com/tchiotludo/akhq/blob/9646c0a7294a68323b300b4c16918cc1d0b05259/src/main/java/org/akhq/modules/KafkaModule.java#L152).