### PR TITLE
fix connect update permissions

### DIFF
--- a/client/src/containers/Connect/ConnectDetail/ConnectConfigs/ConnectConfigs.jsx
+++ b/client/src/containers/Connect/ConnectDetail/ConnectConfigs/ConnectConfigs.jsx
@@ -139,6 +139,7 @@ class ConnectConfigs extends Form {
     let title = '';
     let { formData } = this.state;
     const errors = [];
+    const roles = this.state.roles || {};
     const errorMessage = this.validateProperty({ name: plugin.name, value: formData[plugin.name] });
     if (errorMessage) {
       errors[plugin.name] = errorMessage;
@@ -200,7 +201,7 @@ class ConnectConfigs extends Form {
             className="form-control"
             value={formData[plugin.name]}
             name={plugin.name}
-            disabled={plugin.name === 'name' || plugin.name === 'connector.class'}
+            disabled={plugin.name === 'name' || plugin.name === 'connector.class' || !(roles.connect && roles.connect['connect/update']) }
             placeholder={plugin.defaultValue > 0 ? plugin.defaultValue : ''}
             onChange={({ currentTarget: input }) => {
               let { formData } = this.state;
@@ -261,6 +262,7 @@ class ConnectConfigs extends Form {
     group.forEach(element => {
       const rows = this.renderTableRows(element);
       const errors = [];
+      const roles = this.state.roles || {};
 
       groupDisplay.push(<tr>{rows}</tr>);
       if (element.name === 'transforms') {
@@ -305,6 +307,7 @@ class ConnectConfigs extends Form {
                   this.setState({ formData });
                 }}
                 name="UNIQUE_ID_OF_DIV"
+                readOnly={!(roles.connect && roles.connect['connect/update'])}
                 editorProps={{ $blockScrolling: true }}
                 style={{ width: '100%', minHeight: '25vh' }}
               />

--- a/client/src/containers/Connect/ConnectDetail/ConnectConfigs/ConnectConfigs.jsx
+++ b/client/src/containers/Connect/ConnectDetail/ConnectConfigs/ConnectConfigs.jsx
@@ -27,7 +27,8 @@ class ConnectConfigs extends Form {
     plugin: {},
     config: {},
     selectedType: '',
-    display: ''
+    display: '',
+    roles: JSON.parse(sessionStorage.getItem('roles'))
   };
 
   schema = {};
@@ -368,7 +369,7 @@ class ConnectConfigs extends Form {
   render() {
     const { plugin, display } = this.state;
     const { name } = this.state.formData;
-
+    const roles = this.state.roles || {};
     return (
       <div>
         <form
@@ -410,16 +411,18 @@ class ConnectConfigs extends Form {
                   <tbody>{display}</tbody>
                 </table>
               </div>
-              <div style={{ left: 0, width: '100%' }} className="khq-submit">
-                <button
-                  type={'submit'}
-                  className="btn btn-primary"
-                  style={{ marginRight: '2%' }}
-                  disabled={this.validate()}
-                >
-                  Update
-                </button>
-              </div>
+              {roles.connect && roles.connect['connect/update'] && (
+                <div style={{ left: 0, width: '100%' }} className="khq-submit">
+                  <button
+                    type={'submit'}
+                    className="btn btn-primary"
+                    style={{ marginRight: '2%' }}
+                    disabled={this.validate()}
+                  >
+                    Update
+                  </button>
+                </div>
+              )}
             </React.Fragment>
           )}
         </form>

--- a/client/src/containers/Connect/ConnectList/ConnectList.jsx
+++ b/client/src/containers/Connect/ConnectList/ConnectList.jsx
@@ -101,7 +101,7 @@ class ConnectList extends Root {
     const roles = this.state.roles || {};
     let actions = [];
 
-    if (roles.connect && roles.connect['connect/update']) {
+    if (roles.connect && roles.connect['connect/read']) {
       actions.push(constants.TABLE_DETAILS);
     }
     if (roles.connect && roles.connect['connect/delete']) {

--- a/client/src/utils/Routes.js
+++ b/client/src/utils/Routes.js
@@ -240,7 +240,7 @@ class Routes extends Root {
               {roles && roles.connect && roles.connect['connect/read'] && (
                 <Route exact path="/ui/:clusterId/connect/:connectId" component={ConnectList} />
               )}
-              {roles && roles.connect && roles.connect['connect/update'] && (
+              {roles && roles.connect && roles.connect['connect/read'] && (
                 <Route
                   exact
                   path="/ui/:clusterId/connect/:connectId/definition/:definitionId/:tab?"


### PR DESCRIPTION
Hi, I want to allow a user to modify the state of a connector/task (resume, pause, restart) and not allow him to update the configs of the connector.

The first requirement is covered by the role `connect/state/update` and the second requirement by the role `connect/update`

The problem is that if I don't assign the role `connect/update` to the user, the search icon that redirects to the tasks tab where you can pause/resume is hidden.
![connectList](https://user-images.githubusercontent.com/31214345/110305842-6c93a180-7ffd-11eb-983f-ced1da75fb35.png)

Here is the tab that cannot be accessed without the `connect/update` role.
![tasks](https://user-images.githubusercontent.com/31214345/110315590-c5693700-8009-11eb-8442-d980e169d6aa.png)

My suggestion is that the role `connect/update` only should apply when trying to update the configs (making the button disappear) and allow users with the role `connect/state/update` to change the state. 
![configs](https://user-images.githubusercontent.com/31214345/110315685-e0d44200-8009-11eb-865a-75ebe5de0b61.png)







