### PR TITLE
FIX-pagination-schema-registry 

### DIFF
--- a/client/src/containers/Schema/SchemaList/SchemaList.jsx
+++ b/client/src/containers/Schema/SchemaList/SchemaList.jsx
@@ -87,9 +87,12 @@ class SchemaList extends Root {
       endpoints.uriSchemaRegistry(selectedCluster, search, pageNumber)
     );
 
-    let schemasRegistry = response.data ? response.data.results || [] : [];
-    this.handleSchemaRegistry(schemasRegistry);
-    this.setState({ selectedCluster, totalPageNumber: response.page });
+    if (response.data.results) {
+      this.handleSchemaRegistry(response.data.results);
+      this.setState({ selectedCluster, totalPageNumber: response.data.page });
+    } else {
+      this.setState({ selectedCluster, schemasRegistry: [], totalPageNumber: 0, loading: false });
+    }
   }
 
   handleSchemaRegistry(schemas) {


### PR DESCRIPTION
Hello 

During my work on the Kafka connect part, I can see there is also a bug on the Schema Registry screen.

The totalPage doesn't appear and we can continue on the next page even if it doesn't exist (and Java doesn't seem to like that) 

![image](https://user-images.githubusercontent.com/9429197/110381639-07ba6480-805a-11eb-84ea-62fc4cc75e7d.png)

![image](https://user-images.githubusercontent.com/9429197/110381652-0be68200-805a-11eb-8c93-eb1bb164f8a1.png)

I think this code will fix the problem 