### PR TITLE
Add kafkaSecrets via Helm Chart

### DIFF
--- a/helm/akhq/templates/secret.yaml
+++ b/helm/akhq/templates/secret.yaml
@@ -11,4 +11,9 @@ metadata:
 type: Opaque
 data:
   application-secrets.yml: {{.Values.secrets| b64enc | quote }}
-{{- end }}
+  {{- if .Values.kafkaSecrets }}
+  {{- range $key, $value := .Values.kafkaSecrets }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+  {{- end }}

--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -50,6 +50,9 @@ secrets: |
             basic-auth-username: basic-auth-user
             basic-auth-password: basic-auth-pass
 
+kafkaSecrets: []
+#Provide extra base64 encoded kubernetes secrets (keystore/truststore)
+
 # Any extra volumes to define for the pod (like keystore/truststore)
 extraVolumes: []
 


### PR DESCRIPTION
Support providing extra base64 encoded kubernetes secrets (keystore/truststore) in helm chart