### PR TITLE
Fix for kafka volume mount 

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -58,7 +58,7 @@ services:
   kafka:
     image: confluentinc/cp-kafka
     volumes:
-      - kafka-data:/var/lib/kafka:Z
+      - kafka-data:/var/lib/kafka/data:Z
     environment:
       KAFKA_BROKER_ID: '0'
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
   kafka:
     image: confluentinc/cp-kafka
     volumes:
-      - kafka-data:/var/lib/kafka:Z
+      - kafka-data:/var/lib/kafka/data:Z
     environment:
       KAFKA_BROKER_ID: '0'
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'


### PR DESCRIPTION
Fixed a problem where kafka-logs data is stored in a new volume hash instead of a "kafka-data"volume.