### PR TITLE
Ensure topic existence after creating new topic

### DIFF
--- a/application.example.yml
+++ b/application.example.yml
@@ -148,6 +148,10 @@ akhq:
       - "^.*-rekey$"
     skip-consumer-groups: false # Skip loading consumer group information when showing topics
     skip-last-record: false # Skip loading last record date information when showing topics
+    # Retry options for topic operations
+    retry:
+      topic-exists: # Delay between retries when checking for existence of newly created topics. This is needed as it might take the kafka broker a few seconds to create new topics.
+        delay: "3s"
 
   # Topic display data options (optional)
   topic-data:

--- a/src/main/java/org/akhq/repositories/TopicRepository.java
+++ b/src/main/java/org/akhq/repositories/TopicRepository.java
@@ -2,6 +2,7 @@ package org.akhq.repositories;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Value;
+import io.micronaut.retry.annotation.Retryable;
 import io.micronaut.security.authentication.Authentication;
 import io.micronaut.security.utils.SecurityService;
 import org.akhq.configs.SecurityProperties;
@@ -19,6 +20,7 @@ import javax.inject.Singleton;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 
 @Singleton
 public class TopicRepository extends AbstractRepository {
@@ -140,11 +142,20 @@ public class TopicRepository extends AbstractRepository {
 
     public void create(String clusterId, String name, int partitions, short replicationFactor, List<org.akhq.models.Config> configs) throws ExecutionException, InterruptedException {
         kafkaWrapper.createTopics(clusterId, name, partitions, replicationFactor);
+        checkIfTopicExists(clusterId, name);
         configRepository.updateTopic(clusterId, name, configs);
     }
 
     public void delete(String clusterId, String name) throws ExecutionException, InterruptedException {
         kafkaWrapper.deleteTopics(clusterId, name);
+    }
+
+    @Retryable(
+        includes = {
+            UnknownTopicOrPartitionException.class
+        }, delay = "${akhq.retry.topic-exists.delay:3s}")
+    void checkIfTopicExists(String clusterId, String name) throws ExecutionException {
+        kafkaWrapper.describeTopics(clusterId, Collections.singletonList(name));
     }
 
     private Optional<List<String>> getTopicFilterRegex() {

--- a/src/main/java/org/akhq/repositories/TopicRepository.java
+++ b/src/main/java/org/akhq/repositories/TopicRepository.java
@@ -153,7 +153,7 @@ public class TopicRepository extends AbstractRepository {
     @Retryable(
         includes = {
             UnknownTopicOrPartitionException.class
-        }, delay = "${akhq.retry.topic-exists.delay:3s}")
+        }, delay = "${akhq.topic.retry.topic-exists.delay:3s}")
     void checkIfTopicExists(String clusterId, String name) throws ExecutionException {
         kafkaWrapper.describeTopics(clusterId, Collections.singletonList(name));
     }

--- a/src/test/java/org/akhq/repositories/TopicRepositoryTest.java
+++ b/src/test/java/org/akhq/repositories/TopicRepositoryTest.java
@@ -6,7 +6,6 @@ import io.micronaut.security.authentication.DefaultAuthentication;
 import io.micronaut.security.utils.DefaultSecurityService;
 import io.micronaut.security.utils.SecurityService;
 import org.apache.kafka.common.config.TopicConfig;
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.codehaus.httpcache4j.uri.URIBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,9 +26,7 @@ import javax.inject.Inject;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -126,7 +123,7 @@ public class TopicRepositoryTest extends AbstractTest {
     @Test
     public void findByNameWithTopicRegex() throws ExecutionException, InterruptedException {
         mockApplicationContext();
-        assertThrows(NoSuchElementException.class, () -> {
+        Assertions.assertThrows(NoSuchElementException.class, () -> {
             topicRepository.findByName(KafkaTestCluster.CLUSTER_ID,"compacted");
         });
 
@@ -168,20 +165,6 @@ public class TopicRepositoryTest extends AbstractTest {
     @Test
     public void partition() throws ExecutionException, InterruptedException {
         assertEquals(3, topicRepository.findByName(KafkaTestCluster.CLUSTER_ID, KafkaTestCluster.TOPIC_COMPACTED).getPartitions().size());
-    }
-
-    @Test
-    public void shouldThrowIfTopicDoesNotExist() {
-        final String topicName = "unknownTopic";
-        assertThrows(UnknownTopicOrPartitionException.class, () -> topicRepository.checkIfTopicExists(KafkaTestCluster.CLUSTER_ID, topicName));
-    }
-
-    @Test
-    public void shouldNotThrowIfTopicExists() throws ExecutionException, InterruptedException {
-        final String topicName = "knownTopic";
-        topicRepository.create(KafkaTestCluster.CLUSTER_ID, topicName, 8, (short) 1, Collections.emptyList());
-        assertDoesNotThrow(() -> topicRepository.checkIfTopicExists(KafkaTestCluster.CLUSTER_ID, topicName));
-        topicRepository.delete(KafkaTestCluster.CLUSTER_ID, topicName);
     }
 
     private void mockApplicationContext() {

--- a/src/test/java/org/akhq/repositories/TopicRepositoryTest.java
+++ b/src/test/java/org/akhq/repositories/TopicRepositoryTest.java
@@ -6,6 +6,7 @@ import io.micronaut.security.authentication.DefaultAuthentication;
 import io.micronaut.security.utils.DefaultSecurityService;
 import io.micronaut.security.utils.SecurityService;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.codehaus.httpcache4j.uri.URIBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,7 +27,9 @@ import javax.inject.Inject;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -123,7 +126,7 @@ public class TopicRepositoryTest extends AbstractTest {
     @Test
     public void findByNameWithTopicRegex() throws ExecutionException, InterruptedException {
         mockApplicationContext();
-        Assertions.assertThrows(NoSuchElementException.class, () -> {
+        assertThrows(NoSuchElementException.class, () -> {
             topicRepository.findByName(KafkaTestCluster.CLUSTER_ID,"compacted");
         });
 
@@ -165,6 +168,20 @@ public class TopicRepositoryTest extends AbstractTest {
     @Test
     public void partition() throws ExecutionException, InterruptedException {
         assertEquals(3, topicRepository.findByName(KafkaTestCluster.CLUSTER_ID, KafkaTestCluster.TOPIC_COMPACTED).getPartitions().size());
+    }
+
+    @Test
+    public void shouldThrowIfTopicDoesNotExist() {
+        final String topicName = "unknownTopic";
+        assertThrows(UnknownTopicOrPartitionException.class, () -> topicRepository.checkIfTopicExists(KafkaTestCluster.CLUSTER_ID, topicName));
+    }
+
+    @Test
+    public void shouldNotThrowIfTopicExists() throws ExecutionException, InterruptedException {
+        final String topicName = "knownTopic";
+        topicRepository.create(KafkaTestCluster.CLUSTER_ID, topicName, 8, (short) 1, Collections.emptyList());
+        assertDoesNotThrow(() -> topicRepository.checkIfTopicExists(KafkaTestCluster.CLUSTER_ID, topicName));
+        topicRepository.delete(KafkaTestCluster.CLUSTER_ID, topicName);
     }
 
     private void mockApplicationContext() {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -152,7 +152,3 @@ akhq:
         - username: user2
           groups:
             - operator
-
-  retry:
-      topic-exists:
-          delay: "0.1s"

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -153,3 +153,6 @@ akhq:
           groups:
             - operator
 
+  retry:
+      topic-exists:
+          delay: "0.1s"


### PR DESCRIPTION
- Fixes #403
- We add a retry to ensure a topic exists after a `createTopics` command is issued.
- We need this due to delays that could be involved in topic reation. From the Kafka docs:

> It may take several seconds after CreateTopicsResult returns success for all the brokers to become aware that the topics have been created. During this time, listTopics() and describeTopics(Collection) may not return information about the new topics.