### PR TITLE
Use Joi.string().required() for passwords

### DIFF
--- a/client/src/containers/Connect/ConnectDetail/ConnectConfigs/ConnectConfigs.jsx
+++ b/client/src/containers/Connect/ConnectDetail/ConnectConfigs/ConnectConfigs.jsx
@@ -105,7 +105,7 @@ class ConnectConfigs extends Form {
           def = Joi.number().required();
           break;
         case constants.TYPES.PASSWORD:
-          def = Joi.password().required();
+          def = Joi.string().required();
           break;
         case constants.TYPES.BOOLEAN:
           def = Joi.boolean().required();


### PR DESCRIPTION
As far as I have seen there is no method `Joi.password`. For passwords it makes sense that you treat them as a simple string.

Solves #680