### PR TITLE
issue #635 fix -- auto overflow on sidebar

### DIFF
--- a/client/src/css/templates/sidebar.scss
+++ b/client/src/css/templates/sidebar.scss
@@ -10,6 +10,7 @@
     z-index: 2;
     display: flex;
     flex-direction: column;
+    overflow-y: auto;
 
     .sidebar-header {
         padding: 5px 10px;


### PR DESCRIPTION

After overflow applied but not needed:
![Screen Shot 2021-04-23 at 4 50 02 PM](https://user-images.githubusercontent.com/53791781/115928631-74e05880-a454-11eb-8270-4a01952cebd6.png)

When overflow is needed:
![Screen Shot 2021-04-23 at 4 51 17 PM](https://user-images.githubusercontent.com/53791781/115929361-b02f5700-a455-11eb-9cf5-9ed67c35f8d6.png)


After overflow is applied:
![Screen Shot 2021-04-23 at 4 50 36 PM](https://user-images.githubusercontent.com/53791781/115929465-dead3200-a455-11eb-91c1-bf55b6229645.png)

Sorry for the ugly blackouts XD