### PR TITLE
chore(build): Get Gradle version from Git

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,10 +10,13 @@ plugins {
     id 'com.github.psxpaul.execfork' version '0.1.15'
     id "com.github.ben-manes.versions" version "0.38.0"
     id "com.github.davidmc24.gradle.plugin.avro" version "1.2.0"
+    id "com.palantir.git-version" version "0.12.3"
 }
 
 group "org.akhq"
-version "0.1"
+// Grab version from last Git tag with git-version plugin
+def gitVersionDetails = versionDetails()
+version gitVersionDetails.lastTag
 mainClassName = "org.akhq.App"
 sourceCompatibility = 11
 


### PR DESCRIPTION
Fixes #696 