### PR TITLE
Fix secrets value from map to string

### DIFF
--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -35,7 +35,7 @@ configuration: |
 ##... and secret for connection information
 existingSecrets: ""
 # name of the existingSecret
-secrets: {}
+secrets: |
 #  akhq:
 #    connections:
 #      my-cluster-plain-text:


### PR DESCRIPTION
secrets must be string so that it can be converted to base64 in secrets.yaml