### PR TITLE
Changed condition to display Login Form

### DIFF
--- a/src/main/java/org/akhq/configs/Ldap.java
+++ b/src/main/java/org/akhq/configs/Ldap.java
@@ -13,8 +13,4 @@ public class Ldap {
     private String defaultGroup;
     private List<GroupMapping> groups = new ArrayList<>();
     private List<UserMapping> users = new ArrayList<>();
-
-    public boolean isEnabled() {
-        return StringUtils.hasText(defaultGroup) || !getGroups().isEmpty() || !getUsers().isEmpty();
-    }
 }

--- a/src/main/java/org/akhq/controllers/AkhqController.java
+++ b/src/main/java/org/akhq/controllers/AkhqController.java
@@ -1,5 +1,6 @@
 package org.akhq.controllers;
 
+import io.micronaut.configuration.security.ldap.configuration.LdapConfiguration;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.http.HttpResponse;
@@ -30,9 +31,6 @@ public class AkhqController extends AbstractController {
 
     @Inject
     private ApplicationContext applicationContext;
-
-    @Inject
-    private Ldap ldap;
 
     @Inject
     private SecurityProperties securityProperties;
@@ -69,7 +67,9 @@ public class AkhqController extends AbstractController {
 
         if (applicationContext.containsBean(SecurityService.class)) {
             authDefinition.loginEnabled = true;
-            authDefinition.formEnabled = securityProperties.getBasicAuth().size() > 0 || ldap.isEnabled();
+            // Display login form if there are LocalUsers OR Ldap is enabled
+            authDefinition.formEnabled = securityProperties.getBasicAuth().size() > 0 ||
+                    applicationContext.containsBean(LdapConfiguration.class);
         }
 
         if (oidc.isEnabled()) {

--- a/src/test/java/org/akhq/controllers/AkhqControllerTest.java
+++ b/src/test/java/org/akhq/controllers/AkhqControllerTest.java
@@ -32,6 +32,7 @@ class AkhqControllerTest extends AbstractTest {
         );
 
         assertTrue(result.isLoginEnabled());
+        assertTrue(result.isFormEnabled());
     }
 
     @Test

--- a/src/test/java/org/akhq/modules/OidcAuthenticationProviderTest.java
+++ b/src/test/java/org/akhq/modules/OidcAuthenticationProviderTest.java
@@ -14,6 +14,7 @@ import io.micronaut.test.annotation.MockBean;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.reactivex.Flowable;
 import lombok.extern.slf4j.Slf4j;
+import org.akhq.controllers.AkhqController;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
@@ -45,6 +46,9 @@ public class OidcAuthenticationProviderTest {
 
     @Inject
     DefaultOpenIdProviderMetadata defaultOpenIdProviderMetadata;
+
+    @Inject
+    AkhqController akhqController;
 
     @Named("oidc")
     @MockBean(TokenEndpointClient.class)
@@ -229,5 +233,14 @@ public class OidcAuthenticationProviderTest {
 
         assertThat(authenticationException.getResponse(), instanceOf(AuthenticationFailed.class));
         assertFalse(authenticationException.getResponse().isAuthenticated());
+    }
+
+    @Test
+    void noLoginForm(){
+        AkhqController.AuthDefinition actual = akhqController.auths();
+
+        assertTrue(actual.isLoginEnabled(), "Login must be enabled with OIDC");
+        assertFalse(actual.isFormEnabled(), "Login Form must not be active if only OIDC is enabled");
+        assertFalse(actual.getOidcAuths().isEmpty());
     }
 }


### PR DESCRIPTION
Login Form must be visible when LDAP is enabled within Micronaut instead of "LDAP to Akhq mapping" class