### PR TITLE
Make ingress annotations templatable

### DIFF
--- a/helm/akhq/templates/ingress.yaml
+++ b/helm/akhq/templates/ingress.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
 {{- if .Values.ingress.tls }}


### PR DESCRIPTION
The PR just passes the annotations field in the ingress through the `tpl` function. The use case is to embed the namespace name `$.Release.Namespace` in a custom nginx configuration snippet.

Other charts do something similar, see:

https://github.com/bitnami/charts/blob/b6f75f4f646578fd6945fc4e041a6e96cad9c8e7/bitnami/phpmyadmin/templates/ingress.yaml#L16

https://github.com/bitnami/charts/blob/b6f75f4f646578fd6945fc4e041a6e96cad9c8e7/bitnami/common/templates/_tplvalues.tpl#L11