### PR TITLE
fix(helm): Use yaml goTemplate for secrets

### DIFF
--- a/helm/akhq/templates/secret.yaml
+++ b/helm/akhq/templates/secret.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
-  application-secrets.yml: {{.Values.secrets| b64enc | quote }}
+  application-secrets.yml: {{ toYaml .Values.secrets | b64enc | quote }}
   {{- if .Values.kafkaSecrets }}
   {{- range $key, $value := .Values.kafkaSecrets }}
   {{ $key }}: {{ $value | quote }}


### PR DESCRIPTION
Hi,

By using secrets with yaml, I found a `toYaml` was missing.