### PR TITLE
feat(helm): allow setting container securityContext and use Chart.AppVersion as image tag

### DIFF
--- a/helm/akhq/Chart.yaml
+++ b/helm/akhq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.18.0"
 description: Kafka GUI for Apache Kafka to manage topics, topics data, consumers group, schema registry, connect and more...
 name: akhq
-version: 0.2.2
+version: 0.2.3
 keywords:
   - kafka
   - confluent

--- a/helm/akhq/templates/deployment.yaml
+++ b/helm/akhq/templates/deployment.yaml
@@ -53,8 +53,12 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
+          {{- if .Values.containerSecurityContext }}
+          securityContext:
+            {{ toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- end }}
           env:
             {{- if .Values.extraEnv }}{{ toYaml .Values.extraEnv | trim | nindent 12 }}{{ end }}
             {{- if or (.Values.existingSecrets) (.Values.secrets) }}

--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -2,7 +2,7 @@
 #  - name: my-repository-secret
 image:
   repository: tchiotludo/akhq
-  tag: latest
+  tag: "" # uses Chart.AppVersion by default
 
 # custom annotations (example: for prometheus)
 annotations: {}
@@ -73,13 +73,23 @@ initContainers: {}
 #      - mountPath: /tmp
 #        name: certs
 
+# Configure the Pod Security Context
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 securityContext: {}
-#  capabilities:
-#    drop:
-#      - ALL
-#  # readOnlyRootFilesystem: true
-#  runAsNonRoot: true
-#  runAsUser: 1000
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# Configure the Container Security Context
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+containerSecurityContext: {}
+  # allowPrivilegeEscalation: false
+  # privileged: false
+  # capabilities:
+  #   drop:
+  #     - ALL
+  # runAsNonRoot: true
+  # runAsUser: 1001
+  # readOnlyRootFilesystem: true
 
 service:
   enabled: true


### PR DESCRIPTION
This adds 2 changes to the helm chart:

1. make the container security context configurable as well - besides the current PodSecurityContext
2. uses the image tag corresponding to the Chart's AppVersion. This avoids using the discouraged use of the `latest` tag.

Thank you for your great work!