### PR TITLE
Stop schema registry use for internal topics

### DIFF
--- a/src/main/java/org/akhq/controllers/TopicController.java
+++ b/src/main/java/org/akhq/controllers/TopicController.java
@@ -150,7 +150,8 @@ public class TopicController extends AbstractController {
             schemaRegistryRepository.getSchemaRegistryType(cluster),
             key.map(String::getBytes).orElse(null),
             value.getBytes(),
-            headers
+            headers,
+            topicRepository.findByName(cluster, topicName)
         );
     }
 
@@ -280,7 +281,8 @@ public class TopicController extends AbstractController {
             schemaRegistryRepository.getSchemaRegistryType(cluster),
             Base64.getDecoder().decode(key),
             null,
-            new HashMap<>()
+            new HashMap<>(),
+            topicRepository.findByName(cluster, topicName)
         );
     }
 


### PR DESCRIPTION
For #654 @PLarboulette. I think this might be a first attempt to stop the schema registry use, which is indeed wrong.

Next step might be using the specialized serialization mentioned by @LiamClarkeNZ, but that might be a tad more difficult to achieve.

Either way this seems a step in the right direction: we should no longer see incorrect deserialization attempts using schema registry.