### PR TITLE
Add multi-message produce feature

### DIFF
--- a/client/src/components/Form/Form.jsx
+++ b/client/src/components/Form/Form.jsx
@@ -112,8 +112,9 @@ class Form extends Root {
     );
   };
 
-  renderJSONInput = (name, label, onChange) => {
+  renderJSONInput = (name, label, onChange, textMode, options) => {
     const { formData, errors } = this.state;
+    const inputMode = textMode ? "text" : (formData.schemaType === "PROTOBUF" ? "protobuf"  : "json")
     return (
       <div className="form-group row">
         {label !== '' ? (
@@ -125,7 +126,7 @@ class Form extends Root {
         )}
         <div className="col-sm-10" style={{ height: '100%' }}>
           <AceEditor
-            mode={ formData.schemaType === "PROTOBUF"? "protobuf"  : "json" }
+            mode={ inputMode }
             id={name}
             theme="merbivore_soft"
             value={formData[name]}
@@ -134,6 +135,7 @@ class Form extends Root {
             }}
             name="UNIQUE_ID_OF_DIV"
             editorProps={{ $blockScrolling: true }}
+            setOptions={options}
             style={{ width: '100%', minHeight: '25vh' }}
           />
           {errors[name] && <div className="alert alert-danger mt-1 p-1">{errors[name]}</div>}

--- a/client/src/components/Form/Form.jsx
+++ b/client/src/components/Form/Form.jsx
@@ -240,6 +240,21 @@ class Form extends Root {
       </React.Fragment>
     );
   };
+
+  renderCheckbox = (name, label, isChecked, onChange, isDefaultChecked) => {
+    return (
+        <input
+        type="checkbox"
+        name={name}
+        id={name}
+        class="form-input-check"
+        checked={isChecked}
+        onChange={onChange}
+        defaultChecked={ isDefaultChecked ? isDefaultChecked : false}
+        />
+    );
+  };
 }
 
 export default Form;
+ 

--- a/client/src/components/Form/styles.scss
+++ b/client/src/components/Form/styles.scss
@@ -25,3 +25,12 @@ input.placeholder{
     width: 100%;
     padding: 0px;
 }
+
+.ace_active-line {
+    opacity: 0.2;
+}
+
+.ace_placeholder {
+    font-family: "Source Code Pro",SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
+    transform: scale(1);
+}

--- a/client/src/components/Form/styles.scss
+++ b/client/src/components/Form/styles.scss
@@ -34,3 +34,8 @@ input.placeholder{
     font-family: "Source Code Pro",SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
     transform: scale(1);
 }
+
+.form-input-check{
+    margin-block: auto;
+}
+ 

--- a/client/src/containers/Topic/TopicProduce/TopicProduce.jsx
+++ b/client/src/containers/Topic/TopicProduce/TopicProduce.jsx
@@ -117,7 +117,7 @@ class TopicProduce extends Form {
       partition: formData.partition,
       key: formData.key,
       timestamp: datetime.toISOString(),
-      value: formData.value,
+      value: multiMessage ? formData.value : JSON.parse(JSON.stringify(formData.value)),
       keySchema: schemaKeyToSend ? schemaKeyToSend.id : '',
       valueSchema: schemaValueToSend ? schemaValueToSend.id : '',
       multiMessage: multiMessage,

--- a/client/src/containers/Topic/TopicProduce/TopicProduce.jsx
+++ b/client/src/containers/Topic/TopicProduce/TopicProduce.jsx
@@ -343,8 +343,7 @@ class TopicProduce extends Form {
       valueSchema,
       valueSchemaSearchValue,
       selectedValueSchema,
-      multiMessage,
-      valuePlaceholder
+      multiMessage
     } = this.state;
     let date = moment(datetime);
     return (

--- a/src/main/java/org/akhq/controllers/TopicController.java
+++ b/src/main/java/org/akhq/controllers/TopicController.java
@@ -123,7 +123,7 @@ public class TopicController extends AbstractController {
     @Secured(Role.ROLE_TOPIC_DATA_INSERT)
     @Post(value = "api/{cluster}/topic/{topicName}/data")
     @Operation(tags = {"topic data"}, summary = "Produce data to a topic")
-    public Record produce(
+    public List<Record> produce(
         HttpRequest<?> request,
         String cluster,
         String topicName,
@@ -133,9 +133,13 @@ public class TopicController extends AbstractController {
         Optional<String> timestamp,
         Map<String, String> headers,
         Optional<Integer> keySchema,
-        Optional<Integer> valueSchema
+        Optional<Integer> valueSchema,
+        Boolean multiMessage,
+        Optional<String> messageSeparator,
+        Optional<String> keyValueSeparator
     ) throws ExecutionException, InterruptedException {
-        return new Record(
+        Topic targetTopic = topicRepository.findByName(cluster, topicName);
+        return
             this.recordRepository.produce(
                 cluster,
                 topicName,
@@ -145,14 +149,17 @@ public class TopicController extends AbstractController {
                 partition,
                 timestamp.map(r -> Instant.parse(r).toEpochMilli()),
                 keySchema,
-                valueSchema
-            ),
-            schemaRegistryRepository.getSchemaRegistryType(cluster),
-            key.map(String::getBytes).orElse(null),
-            value.getBytes(),
-            headers,
-            topicRepository.findByName(cluster, topicName)
-        );
+                valueSchema,
+                multiMessage,
+                messageSeparator,
+                keyValueSeparator).stream()
+                    .map(recordMetadata -> new Record(recordMetadata,
+                            schemaRegistryRepository.getSchemaRegistryType(cluster),
+                            key.map(String::getBytes).orElse(null),
+                            value.getBytes(),
+                            headers,
+                            targetTopic))
+                    .collect(Collectors.toList());
     }
 
     @Secured(Role.ROLE_TOPIC_DATA_READ)

--- a/src/main/java/org/akhq/controllers/TopicController.java
+++ b/src/main/java/org/akhq/controllers/TopicController.java
@@ -135,7 +135,6 @@ public class TopicController extends AbstractController {
         Optional<Integer> keySchema,
         Optional<Integer> valueSchema,
         Boolean multiMessage,
-        Optional<String> messageSeparator,
         Optional<String> keyValueSeparator
     ) throws ExecutionException, InterruptedException {
         Topic targetTopic = topicRepository.findByName(cluster, topicName);

--- a/src/main/java/org/akhq/controllers/TopicController.java
+++ b/src/main/java/org/akhq/controllers/TopicController.java
@@ -151,7 +151,6 @@ public class TopicController extends AbstractController {
                 keySchema,
                 valueSchema,
                 multiMessage,
-                messageSeparator,
                 keyValueSeparator).stream()
                     .map(recordMetadata -> new Record(recordMetadata,
                             schemaRegistryRepository.getSchemaRegistryType(cluster),
@@ -511,3 +510,4 @@ public class TopicController extends AbstractController {
         private long offset;
     }
 }
+ 

--- a/src/main/java/org/akhq/models/KeyValue.java
+++ b/src/main/java/org/akhq/models/KeyValue.java
@@ -1,0 +1,14 @@
+package org.akhq.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Represents a simple key-value pair of any type
+ */
+@Getter
+@AllArgsConstructor
+public class KeyValue<K,V> {
+    K key;
+    V value;
+}

--- a/src/test/java/org/akhq/controllers/TopicControllerTest.java
+++ b/src/test/java/org/akhq/controllers/TopicControllerTest.java
@@ -11,7 +11,9 @@ import org.apache.kafka.common.config.TopicConfig;
 import org.junit.jupiter.api.*;
 import org.akhq.models.Record;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 
@@ -153,24 +155,24 @@ class TopicControllerTest extends AbstractTest {
     @Test
     @Order(3)
     void produce() {
-        Record record = this.retrieve(HttpRequest.POST(
-            CREATE_TOPIC_URL + "/data",
-            ImmutableMap.of(
-                "value", "my-value",
-                "key", "my-key",
-                "partition", 1,
-                "headers", ImmutableMap.of(
-                    "my-header-1", "1",
-                    "my-header-2", "2"
-                )
-            )
+        Map<String, Object> paramMap = new HashMap<>();
+        paramMap.put("value", "my-value");
+        paramMap.put("key", "my-key");
+        paramMap.put("partition", 1);
+        paramMap.put("headers", ImmutableMap.of(
+                "my-header-1", "1",
+                "my-header-2", "2"));
+        paramMap.put("multiMessage", false);
+        List<Record> response = this.retrieveList(HttpRequest.POST(
+            CREATE_TOPIC_URL + "/data", paramMap
         ), Record.class);
 
-        assertEquals("my-key", record.getKey());
-        assertEquals("my-value", record.getValue());
-        assertEquals(1, record.getPartition());
-        assertEquals(2, record.getHeaders().size());
-        assertEquals("1", record.getHeaders().get("my-header-1"));
+        assertEquals(1, response.size());
+        assertEquals("my-key", response.get(0).getKey());
+        assertEquals("my-value", response.get(0).getValue());
+        assertEquals(1, response.get(0).getPartition());
+        assertEquals(2, response.get(0).getHeaders().size());
+        assertEquals("1", response.get(0).getHeaders().get("my-header-1"));
     }
 
     @Test
@@ -206,6 +208,46 @@ class TopicControllerTest extends AbstractTest {
 
     @Test
     @Order(6)
+    void produceMultipleMessagesLineBreak() {
+        Map<String, Object> paramMap = new HashMap<String, Object>();
+        paramMap.put("value", "key1_{\"test_1\":1}\n"
+                            + "key2_{\"test_1\":2}\n"
+                            + "key3_{\"test_1\":3}");
+        paramMap.put("multiMessage", true);
+        paramMap.put("messageSeparator", "lineBreak");
+        paramMap.put("keyValueSeparator", "underscore");
+        List<Record> response = this.retrieveList(HttpRequest.POST(
+            CREATE_TOPIC_URL + "/data", paramMap
+        ), Record.class);
+
+        assertEquals(3, response.size());
+        assertTrue(response.get(0).getValue().contains("key1_{\"test_1\":1}"));
+        assertTrue(response.get(1).getValue().contains("key2_{\"test_1\":2}"));
+        assertTrue(response.get(2).getValue().contains("key3_{\"test_1\":3}"));
+    }
+
+    @Test
+    @Order(7)
+    void produceMultipleMessagesSemicolon() {
+        Map<String, Object> paramMap = new HashMap<String, Object>();
+        paramMap.put("value", "key1-{\"test_1\":1};"
+                            + "key2-{\"test_1\":2};"
+                            + "key3-{\"test_1\":-3}");
+        paramMap.put("multiMessage", true);
+        paramMap.put("messageSeparator", "semicolon");
+        paramMap.put("keyValueSeparator", "dash");
+        List<Record> response = this.retrieveList(HttpRequest.POST(
+            CREATE_TOPIC_URL + "/data", paramMap
+        ), Record.class);
+
+        assertEquals(3, response.size());
+        assertTrue(response.get(0).getValue().contains("key1-{\"test_1\":1}"));
+        assertTrue(response.get(1).getValue().contains("key2-{\"test_1\":2}"));
+        assertTrue(response.get(2).getValue().contains("key3-{\"test_1\":-3}"));
+    }
+
+    @Test
+    @Order(8)
     void delete() {
         this.exchange(
             HttpRequest.DELETE(CREATE_TOPIC_URL)

--- a/src/test/java/org/akhq/controllers/TopicControllerTest.java
+++ b/src/test/java/org/akhq/controllers/TopicControllerTest.java
@@ -208,14 +208,13 @@ class TopicControllerTest extends AbstractTest {
 
     @Test
     @Order(6)
-    void produceMultipleMessagesLineBreak() {
+    void produceMultipleMessages() {
         Map<String, Object> paramMap = new HashMap<String, Object>();
         paramMap.put("value", "key1_{\"test_1\":1}\n"
                             + "key2_{\"test_1\":2}\n"
                             + "key3_{\"test_1\":3}");
         paramMap.put("multiMessage", true);
-        paramMap.put("messageSeparator", "lineBreak");
-        paramMap.put("keyValueSeparator", "underscore");
+        paramMap.put("keyValueSeparator", "_");
         List<Record> response = this.retrieveList(HttpRequest.POST(
             CREATE_TOPIC_URL + "/data", paramMap
         ), Record.class);
@@ -224,26 +223,6 @@ class TopicControllerTest extends AbstractTest {
         assertTrue(response.get(0).getValue().contains("key1_{\"test_1\":1}"));
         assertTrue(response.get(1).getValue().contains("key2_{\"test_1\":2}"));
         assertTrue(response.get(2).getValue().contains("key3_{\"test_1\":3}"));
-    }
-
-    @Test
-    @Order(7)
-    void produceMultipleMessagesSemicolon() {
-        Map<String, Object> paramMap = new HashMap<String, Object>();
-        paramMap.put("value", "key1-{\"test_1\":1};"
-                            + "key2-{\"test_1\":2};"
-                            + "key3-{\"test_1\":-3}");
-        paramMap.put("multiMessage", true);
-        paramMap.put("messageSeparator", "semicolon");
-        paramMap.put("keyValueSeparator", "dash");
-        List<Record> response = this.retrieveList(HttpRequest.POST(
-            CREATE_TOPIC_URL + "/data", paramMap
-        ), Record.class);
-
-        assertEquals(3, response.size());
-        assertTrue(response.get(0).getValue().contains("key1-{\"test_1\":1}"));
-        assertTrue(response.get(1).getValue().contains("key2-{\"test_1\":2}"));
-        assertTrue(response.get(2).getValue().contains("key3-{\"test_1\":-3}"));
     }
 
     @Test


### PR DESCRIPTION
Hi @tchiotludo,

This feature allows the user to input multiple records as key-value pairs at once as one-liners like:
```
key1:{"value": 41}
key2:{"value": 42}
```
or
```
key1_{"value": 41};key2_{"value": 42}
```

This can help when dealing with larger sets of generated data - there is a limit for the request size, though :D  
Multiple key-value separators can be chosen from, to support various naming conventions people might have.

Looks like this on the front end:
![image](https://user-images.githubusercontent.com/51787541/129459383-a0f804c0-7f70-48ce-8220-a2173ae06990.png)
The "Key" field gets disabled when "Multiple messages" is selected, the multi-message fields for standard "Single message" producing. Placeholders for both modes are added to give some guidance.

What do you say? Could this be useful in general?