### PR TITLE
feat(auth): allow limiting header authentication to list of configured IP addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,7 +617,7 @@ The username field can be any string field, the roles field has to be a JSON arr
 
 ### Header configuration (reverse proxy)
 
-To enable Header authentification in the application, you'll have to configure the header that will resolve users & groups:
+To enable Header authentication in the application, you'll have to configure the header that will resolve users & groups:
 
 ```yaml
 akhq:
@@ -627,6 +627,7 @@ akhq:
       user-header: x-akhq-user # mandatory (the header name that will contain username)
       groups-header: x-akhq-group # optional (the header name that will contain groups separated by groups-header-separator)
       groups-header-separator: , # optional (separator, defaults to ',')
+      ip-patterns: [0.0.0.0] # optional (Java regular expressions for matching trusted IP addresses, '0.0.0.0' matches all addresses)
       users: # optional, the users list to allow, if empty we only rely on `groups-header`
         - username: header-user # username matching the `user-header` value
           groups: # list of group for current users
@@ -636,10 +637,11 @@ akhq:
             - admin
 ```
 
-* The `user-header` is mandatory in order to map the user with `users` list or to display the user on the ui if no `users` is provided.
-* The `groups-header` is optional and can be used in order to inject a list of groups for all the users. This list will be merged with `groups` for the current users.
-* The `groups-header-separator` is optional and can be used to customize group separator used when parsing `groups-header` header, defaults to `,`.
-* The `users` is a list of allowed users.
+* `user-header` is mandatory in order to map the user with `users` list or to display the user on the ui if no `users` is provided.
+* `groups-header` is optional and can be used in order to inject a list of groups for all the users. This list will be merged with `groups` for the current users.
+* `groups-header-separator` is optional and can be used to customize group separator used when parsing `groups-header` header, defaults to `,`.
+* `ip-patterns` limits the IP addresses that header authentication will accept, given as a list of Java regular expressions, omit or set to `[0.0.0.0]` to allow all addresses
+* `users` is a list of allowed users.
 
 ### External roles and attributes mapping
 

--- a/application.example.yml
+++ b/application.example.yml
@@ -14,7 +14,7 @@ micronaut:
         groups:
           enabled: true
           base: "dc=example,dc=com"
-    # OIDC authentification configuration
+    # OIDC authentication configuration
     oauth2:
       enabled: true
       clients:
@@ -265,6 +265,7 @@ akhq:
       user-header: x-akhq-user # mandatory (the header name that will contain username)
       groups-header: x-akhq-group # optional (the header name that will contain groups separated by groups-header-separator)
       groups-header-separator: , # optional (separator, defaults to ',')
+      ip-patterns: [127.0.0.*] # optional (Java regular expressions for matching trusted IP addresses, '0.0.0.0' matches all addresses)
       users: # optional, the users list to allow, if empty we only rely on `groups-header`
         - username: header-user # username matching the `user-header` value
           groups: # list of group for current users

--- a/src/main/java/org/akhq/configs/HeaderAuth.java
+++ b/src/main/java/org/akhq/configs/HeaderAuth.java
@@ -1,9 +1,11 @@
 package org.akhq.configs;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.security.config.SecurityConfigurationProperties;
 import lombok.Data;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Data
@@ -13,6 +15,7 @@ public class HeaderAuth {
     String groupsHeader;
     String groupsHeaderSeparator = ",";
     List<Users> users;
+    List<String> ipPatterns = Collections.singletonList(SecurityConfigurationProperties.ANYWHERE);
 
     @Data
     public static class Users {

--- a/src/test/java/org/akhq/controllers/HeaderAuthControllerTest.java
+++ b/src/test/java/org/akhq/controllers/HeaderAuthControllerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import javax.inject.Inject;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class HeaderAuthControllerTest extends AbstractTest {
     @Inject
@@ -87,6 +88,27 @@ class HeaderAuthControllerTest extends AbstractTest {
 
             assertEquals("header-user", result.getUsername());
             assertEquals(3, result.getRoles().size());
+        }
+    }
+
+    @MicronautTest(environments = "header-ip-disallow")
+    public static class UntrustedIp extends AbstractTest {
+        @Inject
+        @Client("/")
+        protected RxHttpClient client;
+
+        @Test
+        void invalidIp() {
+            AkhqController.AuthUser result = client.toBlocking().retrieve(
+                HttpRequest
+                    .GET("/api/me")
+                    .header("x-akhq-user", "header-user")
+                    .header("x-akhq-group", "limited,extra"),
+                AkhqController.AuthUser.class
+            );
+
+            assertNull(result.getUsername());
+            assertNull(result.getRoles());
         }
     }
 }

--- a/src/test/resources/application-header-ip-disallow.yml
+++ b/src/test/resources/application-header-ip-disallow.yml
@@ -1,0 +1,7 @@
+akhq:
+  security:
+    header-auth:
+      user-header: x-akhq-user
+      groups-header: x-akhq-group
+      ip-patterns: ["none"]
+    default-group: invalid-group


### PR DESCRIPTION
Adds `akhq.security.header-auth.ip-patterns` option that limits IP addresses which are allowed to use header authentication