### PR TITLE
feat(auth): added support for redirecting to initial page after login #719

### DIFF
--- a/client/src/components/Root/Root.jsx
+++ b/client/src/components/Root/Root.jsx
@@ -1,4 +1,4 @@
-import {Component} from 'react';
+import { Component } from 'react';
 import axios from 'axios';
 import { get, put, post, remove } from '../../utils/api';
 
@@ -7,6 +7,12 @@ class Root extends Component {
   cancel = axios.CancelToken.source();
 
   componentWillUnmount() {
+    const pathname = window.location.pathname;
+
+    if (pathname !== '/ui/login') {
+      sessionStorage.setItem('returnTo', pathname + (window.location.search || ''));
+    }
+
     this.cancelAxiosRequests();
   }
 
@@ -21,16 +27,16 @@ class Root extends Component {
   }
 
   getApi(url) {
-    return get(url, {cancelToken: this.cancel.token})
+    return get(url, { cancelToken: this.cancel.token })
   }
   postApi(url, body) {
-    return post(url, body,{cancelToken: this.cancel.token})
+    return post(url, body, { cancelToken: this.cancel.token })
   }
   putApi(url, body) {
-    return put(url, body,{cancelToken: this.cancel.token})
+    return put(url, body, { cancelToken: this.cancel.token })
   }
   removeApi(url, body) {
-    return remove(url, body, {cancelToken: this.cancel.token})
+    return remove(url, body, { cancelToken: this.cancel.token })
   }
 
 }

--- a/client/src/containers/Login/Login.jsx
+++ b/client/src/containers/Login/Login.jsx
@@ -58,11 +58,14 @@ class Login extends Form {
       sessionStorage.setItem('login', true);
       sessionStorage.setItem('user', currentUserData.username);
       sessionStorage.setItem('roles', organizeRoles(currentUserData.roles));
+
       const returnTo = sessionStorage.getItem('returnTo');
       sessionStorage.removeItem('returnTo');
+
       this.props.history.push({
-        pathname: returnTo || '/ui',
+        pathname: (returnTo || '/ui'),
       });
+
       window.location.reload(true);
     } else {
       toast.error('Wrong Username or Password!');

--- a/client/src/containers/Login/Login.jsx
+++ b/client/src/containers/Login/Login.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import logo from '../../images/logo.svg';
-import {uriCurrentUser, uriLogin, uriOidc} from '../../utils/endpoints';
+import { uriCurrentUser, uriLogin, uriOidc } from '../../utils/endpoints';
 import { organizeRoles } from '../../utils/converters';
 import { login } from '../../utils/api';
 import Form from '../../components/Form/Form';
@@ -58,9 +58,10 @@ class Login extends Form {
       sessionStorage.setItem('login', true);
       sessionStorage.setItem('user', currentUserData.username);
       sessionStorage.setItem('roles', organizeRoles(currentUserData.roles));
-
+      const returnTo = sessionStorage.getItem('returnTo');
+      sessionStorage.removeItem('returnTo');
       this.props.history.push({
-        pathname: '/ui',
+        pathname: returnTo || '/ui',
       });
       window.location.reload(true);
     } else {
@@ -70,9 +71,9 @@ class Login extends Form {
 
   componentDidMount() {
     const auths = JSON.parse(sessionStorage.getItem('auths'));
-    if(auths && auths.loginEnabled) {
-      const {loginEnabled, ...config} = auths;
-      this.setState({config});
+    if (auths && auths.loginEnabled) {
+      const { loginEnabled, ...config } = auths;
+      this.setState({ config });
     } else {
       this.props.history.push({
         pathname: '/ui',
@@ -86,9 +87,9 @@ class Login extends Form {
       <>
         <div className="input-group mb-3">
           <div className="input-group-prepend">
-              <span className="input-group-text">
-                <i className="fa fa-user" />
-              </span>
+            <span className="input-group-text">
+              <i className="fa fa-user" />
+            </span>
           </div>
           <input
             type="text"

--- a/client/src/utils/Routes.js
+++ b/client/src/utils/Routes.js
@@ -98,6 +98,10 @@ class Routes extends Root {
       } else {
         sessionStorage.setItem('user', '');
         sessionStorage.setItem('roles', JSON.stringify({}));
+        const pathname = window.location.pathname;
+        if (pathname !== '/ui/login') {
+          sessionStorage.setItem ('returnTo', pathname+window.location.search);
+        }
         this.setState({ user: 'not_logged' });
       }
     }

--- a/client/src/utils/Routes.js
+++ b/client/src/utils/Routes.js
@@ -98,10 +98,6 @@ class Routes extends Root {
       } else {
         sessionStorage.setItem('user', '');
         sessionStorage.setItem('roles', JSON.stringify({}));
-        const pathname = window.location.pathname;
-        if (pathname !== '/ui/login') {
-          sessionStorage.setItem ('returnTo', pathname+window.location.search);
-        }
         this.setState({ user: 'not_logged' });
       }
     }


### PR DESCRIPTION
This PR should implement the feature request from issue #719.

When checking if the user has a session, before redirecting to `/ui/login` it will check if the URL is different than `/ui/login` and stores it in `sessionStorage.setItem("returnTo")`.

Once the user has logged in, it will check if there is a value in `sessionStorage.setItem("returnTo")` and sets this instead of the default `/ui` for the `pathname`.