### PR TITLE
Fix: Parsing timestamps fails when producing messages

### DIFF
--- a/src/test/java/org/akhq/utils/AvroSerializerTest.java
+++ b/src/test/java/org/akhq/utils/AvroSerializerTest.java
@@ -53,8 +53,20 @@ class AvroSerializerTest {
             }
 
             @Test
+            void testParseDateTime_micros_offset_short() {
+                assertEquals(AvroSerializer.parseDateTime("2021-07-16T21:30:12.345678+08"),
+                        Instant.parse("2021-07-16T13:30:12.345678Z"));
+            }
+
+            @Test
             void testParseDateTime_millis_offset() {
                 assertEquals(AvroSerializer.parseDateTime("2021-07-16T21:30:12.345+08:00"),
+                        Instant.parse("2021-07-16T13:30:12.345Z"));
+            }
+
+            @Test
+            void testParseDateTime_millis_offset_short() {
+                assertEquals(AvroSerializer.parseDateTime("2021-07-16T21:30:12.345+08"),
                         Instant.parse("2021-07-16T13:30:12.345Z"));
             }
 
@@ -65,8 +77,20 @@ class AvroSerializerTest {
             }
 
             @Test
+            void testParseDateTime_seconds_offset_short() {
+                assertEquals(AvroSerializer.parseDateTime("2021-07-16T21:30:12+08"),
+                        Instant.parse("2021-07-16T13:30:12Z"));
+            }
+
+            @Test
             void testParseDateTime_minutes_offset() {
                 assertEquals(AvroSerializer.parseDateTime("2021-07-16T21:30+08:00"),
+                        Instant.parse("2021-07-16T13:30:00Z"));
+            }
+
+            @Test
+            void testParseDateTime_minutes_offset_short() {
+                assertEquals(AvroSerializer.parseDateTime("2021-07-16T21:30+08"),
                         Instant.parse("2021-07-16T13:30:00Z"));
             }
 


### PR DESCRIPTION
The commit fixes two related problems that prevent producing messages if AVRO contains a timestamp field. Production of such messages wasn't possible at all in AKHQ version 0.18.0, but the major problems have been fixed since then. However, some problems still remain.

Let's have an AVRO like this:
```
{
  "type": "record",
  "name": "myrecord",
  "fields": [
    {
      "name": "cas",
      "type": {
        "type": "long",
        "logicalType": "timestamp-millis"
      }
    }
  ]
}
```

1. The message 
```
{
  "cas": 12345
}
```
fails to be produced because Integer cannot be converted to Instant.

2. The message 
```
{
  "cas": "2021-09-05T20:31:53.582+02"
}
```
cannot be produced because the parser cannot parse short time-zones.

This patch fixes both problems. Timestamp strings without time-zone can still be parsed, Even negative numbers (Integers and Longs) can be parsed.