### PR TITLE
add option to create a service account and specify a default user id in securityContext

### DIFF
--- a/helm/akhq/Chart.yaml
+++ b/helm/akhq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.18.0"
 description: Kafka GUI for Apache Kafka to manage topics, topics data, consumers group, schema registry, connect and more...
 name: akhq
-version: 0.2.2
+version: 0.2.3
 keywords:
   - kafka
   - confluent

--- a/helm/akhq/templates/_helpers.tpl
+++ b/helm/akhq/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "akhq.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "akhq.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "akhq.fullname" .) .Values.serviceAccountName }}
+{{- else }}
+{{- default "default" .Values.serviceAccountName }}
+{{- end }}
+{{- end }}

--- a/helm/akhq/templates/deployment.yaml
+++ b/helm/akhq/templates/deployment.yaml
@@ -44,6 +44,9 @@ spec:
       {{- if .Values.serviceAccountName }}
       serviceAccountName: {{ .Values.serviceAccountName }}
       {{- end }}
+      {{- if .Values.serviceAccountCreate }}
+      serviceAccountName: {{ include "akhq.name" . }}
+      {{- end }}
       {{- if .Values.initContainers }}
       initContainers:
         {{- range $key, $value := .Values.initContainers }}

--- a/helm/akhq/templates/deployment.yaml
+++ b/helm/akhq/templates/deployment.yaml
@@ -41,12 +41,7 @@ spec:
       securityContext:
         {{ toYaml .Values.securityContext | nindent 8 }}
       {{- end }}
-      {{- if .Values.serviceAccountName }}
-      serviceAccountName: {{ .Values.serviceAccountName }}
-      {{- end }}
-      {{- if .Values.serviceAccountCreate }}
-      serviceAccountName: {{ include "akhq.name" . }}
-      {{- end }}
+      serviceAccountName: {{ include "akhq.serviceAccountName" . }}
       {{- if .Values.initContainers }}
       initContainers:
         {{- range $key, $value := .Values.initContainers }}

--- a/helm/akhq/templates/serviceaccount.yaml
+++ b/helm/akhq/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "akhq.name" . }}
+    helm.sh/chart: {{ include "akhq.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  name: {{ include "akhq.fullname" . }}
+{{- end }}

--- a/helm/akhq/templates/serviceaccount.yaml
+++ b/helm/akhq/templates/serviceaccount.yaml
@@ -11,5 +11,5 @@ metadata:
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
-  name: {{ include "akhq.fullname" . }}
+  name: {{ include "akhq.serviceAccountName" . }}
 {{- end }}

--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -63,6 +63,10 @@ extraVolumeMounts: []
 
 # Specify ServiceAccount for pod
 serviceAccountName: null
+serviceAccount:
+  create: false
+  #annotations:
+  #  eks.amazonaws.com/role-arn: arn:aws:iam::123456789000:role/iam-role-name-here
 
 # Add your own init container or uncomment and modify the example.
 initContainers: {}
@@ -73,13 +77,15 @@ initContainers: {}
 #      - mountPath: /tmp
 #        name: certs
 
-securityContext: {}
+securityContext:
+  fsGroup: 1000
+  runAsGroup: 1000
+  runAsUser: 1000
 #  capabilities:
 #    drop:
 #      - ALL
 #  # readOnlyRootFilesystem: true
 #  runAsNonRoot: true
-#  runAsUser: 1000
 
 service:
   enabled: true


### PR DESCRIPTION
I had two problems trying to use `avhq` in AWS EKS:
- Lack of `ServiceAccount` in the helm chart
- The container was running with the `akhq` user (uid=1000 gid=1000) but it wasn't specified in the `securityContext` so AWS created the token file with strict permissions (only the root user could read it)

This PR adds an option to automatically create the `ServiceAccount` and specify some options in the `securitContext` by default