### PR TITLE
Custom deserializer for avro raw format

### DIFF
--- a/src/main/java/org/akhq/configs/AvroTopicsMapping.java
+++ b/src/main/java/org/akhq/configs/AvroTopicsMapping.java
@@ -1,0 +1,14 @@
+package org.akhq.configs;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AvroTopicsMapping {
+    String topicRegex;
+    String keySchemaFile;
+    String valueSchemaFile;
+}

--- a/src/main/java/org/akhq/configs/Connection.java
+++ b/src/main/java/org/akhq/configs/Connection.java
@@ -18,7 +18,7 @@ import java.util.Map;
 public class Connection extends AbstractProperties {
     SchemaRegistry schemaRegistry;
     List<Connect> connect;
-    ProtobufDeserializationTopicsMapping deserialization;
+    Deserialization deserialization;
     UiOptions uiOptions = new UiOptions();
 
     public Connection(@Parameter String name) {
@@ -38,11 +38,24 @@ public class Connection extends AbstractProperties {
     }
 
     @Getter
-    @Data
-    @ConfigurationProperties("deserialization.protobuf")
-    public static class ProtobufDeserializationTopicsMapping {
-        String descriptorsFolder;
-        List<TopicsMapping> topicsMapping = new ArrayList<>();
+    @ConfigurationProperties("deserialization")
+    public static class Deserialization {
+        ProtobufDeserializationTopicsMapping protobuf;
+        AvroDeserializationTopicsMapping avroRaw;
+
+        @Data
+        @ConfigurationProperties("protobuf")
+        public static class ProtobufDeserializationTopicsMapping {
+            String descriptorsFolder;
+            List<TopicsMapping> topicsMapping = new ArrayList<>();
+        }
+
+        @Data
+        @ConfigurationProperties("avro-raw")
+        public static class AvroDeserializationTopicsMapping {
+            String schemasFolder;
+            List<AvroTopicsMapping> topicsMapping = new ArrayList<>();
+        }
     }
 
     @Data

--- a/src/main/java/org/akhq/models/Record.java
+++ b/src/main/java/org/akhq/models/Record.java
@@ -10,6 +10,7 @@ import io.confluent.kafka.schemaregistry.json.JsonSchema;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import lombok.*;
 import org.akhq.configs.SchemaRegistryType;
+import org.akhq.utils.AvroToJsonDeserializer;
 import org.akhq.utils.AvroToJsonSerializer;
 import org.akhq.utils.ProtobufToJsonDeserializer;
 import org.apache.avro.generic.GenericRecord;
@@ -53,6 +54,8 @@ public class Record {
 
     private ProtobufToJsonDeserializer protobufToJsonDeserializer;
 
+    private AvroToJsonDeserializer avroToJsonDeserializer;
+
     @Getter(AccessLevel.NONE)
     private byte[] bytesKey;
 
@@ -88,7 +91,7 @@ public class Record {
 
     public Record(SchemaRegistryClient client, ConsumerRecord<byte[], byte[]> record, SchemaRegistryType schemaRegistryType, Deserializer kafkaAvroDeserializer,
                   Deserializer kafkaJsonDeserializer, Deserializer kafkaProtoDeserializer, AvroToJsonSerializer avroToJsonSerializer,
-                  ProtobufToJsonDeserializer protobufToJsonDeserializer, byte[] bytesValue, Topic topic) {
+                  ProtobufToJsonDeserializer protobufToJsonDeserializer, AvroToJsonDeserializer avroToJsonDeserializer, byte[] bytesValue, Topic topic) {
         if (schemaRegistryType == SchemaRegistryType.TIBCO) {
             this.MAGIC_BYTE = (byte) 0x80;
         } else {
@@ -110,6 +113,7 @@ public class Record {
 
         this.kafkaAvroDeserializer = kafkaAvroDeserializer;
         this.protobufToJsonDeserializer = protobufToJsonDeserializer;
+        this.avroToJsonDeserializer = avroToJsonDeserializer;
         this.kafkaProtoDeserializer = kafkaProtoDeserializer;
         this.avroToJsonSerializer = avroToJsonSerializer;
         this.kafkaJsonDeserializer = kafkaJsonDeserializer;
@@ -187,6 +191,19 @@ public class Record {
             if (protobufToJsonDeserializer != null) {
                 try {
                     String record = protobufToJsonDeserializer.deserialize(topic.getName(), payload, isKey);
+                    if (record != null) {
+                        return record;
+                    }
+                } catch (Exception exception) {
+                    this.exceptions.add(exception.getMessage());
+
+                    return new String(payload);
+                }
+            }
+
+            if (avroToJsonDeserializer != null) {
+                try {
+                    String record = avroToJsonDeserializer.deserialize(topic.getName(), payload, isKey);
                     if (record != null) {
                         return record;
                     }

--- a/src/main/java/org/akhq/repositories/CustomDeserializerRepository.java
+++ b/src/main/java/org/akhq/repositories/CustomDeserializerRepository.java
@@ -1,6 +1,8 @@
 package org.akhq.repositories;
 
 import org.akhq.modules.KafkaModule;
+import org.akhq.utils.AvroToJsonDeserializer;
+import org.akhq.utils.AvroToJsonSerializer;
 import org.akhq.utils.ProtobufToJsonDeserializer;
 
 import javax.inject.Inject;
@@ -12,15 +14,28 @@ import java.util.Map;
 public class CustomDeserializerRepository {
     @Inject
     private KafkaModule kafkaModule;
+    @Inject
+    private AvroToJsonSerializer avroToJsonSerializer;
     private final Map<String, ProtobufToJsonDeserializer> protobufToJsonDeserializers = new HashMap<>();
+    private final Map<String, AvroToJsonDeserializer> avroToJsonDeserializers = new HashMap<>();
 
     public ProtobufToJsonDeserializer getProtobufToJsonDeserializer(String clusterId) {
         if (!this.protobufToJsonDeserializers.containsKey(clusterId)) {
             this.protobufToJsonDeserializers.put(
                     clusterId,
-                    new ProtobufToJsonDeserializer(this.kafkaModule.getConnection(clusterId).getDeserialization())
+                    new ProtobufToJsonDeserializer(this.kafkaModule.getConnection(clusterId).getDeserialization().getProtobuf())
             );
         }
         return this.protobufToJsonDeserializers.get(clusterId);
+    }
+
+    public AvroToJsonDeserializer getAvroToJsonDeserializer(String clusterId) {
+        if (!this.avroToJsonDeserializers.containsKey(clusterId)) {
+            this.avroToJsonDeserializers.put(
+                clusterId,
+                new AvroToJsonDeserializer(this.kafkaModule.getConnection(clusterId).getDeserialization().getAvroRaw(), this.avroToJsonSerializer)
+            );
+        }
+        return this.avroToJsonDeserializers.get(clusterId);
     }
 }

--- a/src/main/java/org/akhq/repositories/RecordRepository.java
+++ b/src/main/java/org/akhq/repositories/RecordRepository.java
@@ -440,6 +440,7 @@ public class RecordRepository extends AbstractRepository {
             schemaRegistryType == SchemaRegistryType.CONFLUENT? this.schemaRegistryRepository.getKafkaProtoDeserializer(clusterId):null,
             this.avroToJsonSerializer,
             this.customDeserializerRepository.getProtobufToJsonDeserializer(clusterId),
+            this.customDeserializerRepository.getAvroToJsonDeserializer(clusterId),
             avroWireFormatConverter.convertValueToWireFormat(record, client,
                     this.schemaRegistryRepository.getSchemaRegistryType(clusterId)),
             topic
@@ -458,6 +459,7 @@ public class RecordRepository extends AbstractRepository {
             schemaRegistryType == SchemaRegistryType.CONFLUENT? this.schemaRegistryRepository.getKafkaProtoDeserializer(options.clusterId):null,
             this.avroToJsonSerializer,
             this.customDeserializerRepository.getProtobufToJsonDeserializer(options.clusterId),
+            this.customDeserializerRepository.getAvroToJsonDeserializer(options.clusterId),
             avroWireFormatConverter.convertValueToWireFormat(record, client,
                     this.schemaRegistryRepository.getSchemaRegistryType(options.clusterId)),
             topic
@@ -1262,4 +1264,4 @@ public class RecordRepository extends AbstractRepository {
         private final KafkaConsumer<byte[], byte[]> consumer;
     }
 }
- 
+

--- a/src/main/java/org/akhq/utils/AvroDeserializer.java
+++ b/src/main/java/org/akhq/utils/AvroDeserializer.java
@@ -41,7 +41,7 @@ public class AvroDeserializer {
             .getFields()
             .stream()
             .collect(
-                HashMap::new,
+                LinkedHashMap::new, // preserve schema field order
                 (m, v) -> m.put(
                     v.name(),
                     AvroDeserializer.objectDeserializer(record.get(v.name()), v.schema())

--- a/src/main/java/org/akhq/utils/AvroToJsonDeserializer.java
+++ b/src/main/java/org/akhq/utils/AvroToJsonDeserializer.java
@@ -1,0 +1,150 @@
+package org.akhq.utils;
+
+import io.micronaut.core.serialize.exceptions.SerializationException;
+import lombok.extern.slf4j.Slf4j;
+import org.akhq.configs.AvroTopicsMapping;
+import org.akhq.configs.Connection;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DecoderFactory;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Class for deserialization of messages in Avro raw data binary format using topics mapping config.
+ */
+@Slf4j
+public class AvroToJsonDeserializer {
+    private final DecoderFactory decoderFactory = DecoderFactory.get();
+    private final Map<String, Schema> keySchemas;
+    private final Map<String, Schema> valueSchemas;
+    private final List<AvroTopicsMapping> topicsMapping;
+    private final String avroSchemasFolder;
+    private final AvroToJsonSerializer avroToJsonSerializer;
+
+    public AvroToJsonDeserializer(Connection.Deserialization.AvroDeserializationTopicsMapping avroDeserializationTopicsMapping, AvroToJsonSerializer avroToJsonSerializer) {
+        if (avroDeserializationTopicsMapping == null) {
+            this.keySchemas = new HashMap<>();
+            this.valueSchemas = new HashMap<>();
+            this.topicsMapping = new ArrayList<>();
+            this.avroSchemasFolder = null;
+            this.avroToJsonSerializer = null;
+        } else {
+            this.avroSchemasFolder = avroDeserializationTopicsMapping.getSchemasFolder();
+            this.topicsMapping = avroDeserializationTopicsMapping.getTopicsMapping();
+            this.keySchemas = buildSchemas(AvroTopicsMapping::getKeySchemaFile);
+            this.valueSchemas = buildSchemas(AvroTopicsMapping::getValueSchemaFile);
+            this.avroToJsonSerializer = avroToJsonSerializer;
+        }
+    }
+
+    /**
+     * Load Avro schemas from schema folder
+     *
+     * @return map where keys are topic regexes and value is Avro schema
+     */
+    private Map<String, Schema> buildSchemas(Function<AvroTopicsMapping, String> schemaFileMapper) {
+        Map<String, Schema> allSchemas = new HashMap<>();
+        for (AvroTopicsMapping mapping : topicsMapping) {
+            String schemaFile = schemaFileMapper.apply(mapping);
+
+            if (schemaFile != null) {
+                try {
+                    Schema schema = loadSchemaFile(mapping, schemaFile);
+                    allSchemas.put(mapping.getTopicRegex(), schema);
+                } catch (IOException e) {
+                    throw new RuntimeException(String.format("Cannot get a schema file for the topics regex [%s]", mapping.getTopicRegex()), e);
+                }
+            }
+        }
+        return allSchemas;
+    }
+
+    Schema loadSchemaFile(AvroTopicsMapping mapping, String schemaFile) throws IOException {
+        if (avroSchemasFolder != null && Files.exists(Path.of(avroSchemasFolder))) {
+            String fullPath = avroSchemasFolder + File.separator + schemaFile;
+            return new Schema.Parser().parse(Path.of(fullPath).toFile());
+        }
+        throw new FileNotFoundException("Avro schema file is not found for topic regex [" +
+            mapping.getTopicRegex() + "]. Folder is not specified or doesn't exist.");
+    }
+
+    /**
+     * Deserialize from Avro raw data binary format to Json.
+     * Messages must have been encoded directly with {@link org.apache.avro.io.DatumWriter}, not {@link org.apache.avro.file.DataFileWriter} or {@link org.apache.avro.message.BinaryMessageEncoder}.
+     * Topic name should match topic-regex from {@code akhq.connections.[clusterName].deserialization.avro.topics-mapping} config
+     * and schema should be set for key or value in that config.
+     *
+     * @param topic  current topic name
+     * @param buffer binary data to decode
+     * @param isKey  is this data represent key or value
+     * @return {@code null} if cannot deserialize or configuration is not matching, return decoded string otherwise
+     */
+    public String deserialize(String topic, byte[] buffer, boolean isKey) {
+        AvroTopicsMapping matchingConfig = findMatchingConfig(topic);
+        if (matchingConfig == null) {
+            log.debug("Avro deserialization config is not found for topic [{}]", topic);
+            return null;
+        }
+
+        if (matchingConfig.getKeySchemaFile() == null && matchingConfig.getValueSchemaFile() == null) {
+            throw new SerializationException(String.format("Avro deserialization is configured for topic [%s], " +
+                    "but schema is not specified neither for a key, nor for a value.", topic));
+        }
+
+        Schema schema;
+        if (isKey) {
+            schema = keySchemas.get(matchingConfig.getTopicRegex());
+        } else {
+            schema = valueSchemas.get(matchingConfig.getTopicRegex());
+        }
+
+        if (schema == null) {
+            return null;
+        }
+
+        String result;
+        try {
+            result = tryToDeserializeWithSchemaFile(buffer, schema);
+        } catch (Exception e) {
+            throw new SerializationException(String.format("Cannot deserialize message with Avro deserializer " +
+                    "for topic [%s] and schema [%s]", topic, schema.getFullName()), e);
+        }
+        return result;
+    }
+
+    private AvroTopicsMapping findMatchingConfig(String topic) {
+        for (AvroTopicsMapping mapping : topicsMapping) {
+            if (topic.matches(mapping.getTopicRegex())) {
+                return new AvroTopicsMapping(
+                        mapping.getTopicRegex(),
+                        mapping.getKeySchemaFile(), mapping.getValueSchemaFile());
+            }
+        }
+        return null;
+    }
+
+    private String tryToDeserializeWithSchemaFile(byte[] buffer, Schema schema) throws IOException {
+        DatumReader<?> reader = new GenericDatumReader<>(schema);
+        Object result = reader.read(null, decoderFactory.binaryDecoder(buffer, null));
+
+        //for primitive avro type
+        if (!(result instanceof GenericRecord)) {
+            return String.valueOf(result);
+        }
+
+        GenericRecord record = (GenericRecord) result;
+        return avroToJsonSerializer.toJson(record);
+    }
+}

--- a/src/main/java/org/akhq/utils/ProtobufToJsonDeserializer.java
+++ b/src/main/java/org/akhq/utils/ProtobufToJsonDeserializer.java
@@ -29,7 +29,7 @@ public class ProtobufToJsonDeserializer {
     private final List<TopicsMapping> topicsMapping;
     private final String protobufDescriptorsFolder;
 
-    public ProtobufToJsonDeserializer(Connection.ProtobufDeserializationTopicsMapping protobufDeserializationTopicsMapping) {
+    public ProtobufToJsonDeserializer(Connection.Deserialization.ProtobufDeserializationTopicsMapping protobufDeserializationTopicsMapping) {
         if (protobufDeserializationTopicsMapping == null) {
             this.descriptors = new HashMap<>();
             this.topicsMapping = new ArrayList<>();

--- a/src/test/avro/Album.avsc
+++ b/src/test/avro/Album.avsc
@@ -1,0 +1,11 @@
+{
+    "name": "AlbumAvro",
+    "namespace": "org.akhq",
+    "type": "record",
+    "fields" : [
+        {"name": "title", "type": "string"},
+        {"name": "artist", "type": {"type": "array", "items": "string"}},
+        {"name": "releaseYear", "type": "int"},
+        {"name": "songTitle", "type": {"type": "array", "items": "string"}}
+    ]
+}

--- a/src/test/avro/Film.avsc
+++ b/src/test/avro/Film.avsc
@@ -1,0 +1,12 @@
+{
+    "name": "FilmAvro",
+    "namespace": "org.akhq",
+    "type": "record",
+    "fields" : [
+        {"name": "name", "type": "string"},
+        {"name": "producer", "type": "string"},
+        {"name": "releaseYear", "type": "int"},
+        {"name": "duration", "type": "int"},
+        {"name": "starring", "type": {"type": "array", "items": "string"}}
+    ]
+}

--- a/src/test/java/org/akhq/utils/AvroToJsonDeserializerTest.java
+++ b/src/test/java/org/akhq/utils/AvroToJsonDeserializerTest.java
@@ -1,0 +1,162 @@
+package org.akhq.utils;
+
+import org.akhq.AlbumAvro;
+import org.akhq.FilmAvro;
+import org.akhq.configs.AvroTopicsMapping;
+import org.akhq.configs.Connection;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AvroToJsonDeserializerTest {
+    Connection.Deserialization.AvroDeserializationTopicsMapping avroDeserializationTopicsMapping;
+    AlbumAvro albumAvro;
+    FilmAvro filmAvro;
+
+    @BeforeEach
+    void before() throws URISyntaxException {
+        createTopicAvroDeserializationMapping();
+        createAlbumObject();
+        createFilmObject();
+    }
+
+    private void createTopicAvroDeserializationMapping() throws URISyntaxException {
+        avroDeserializationTopicsMapping = new Connection.Deserialization.AvroDeserializationTopicsMapping();
+
+        URI uri = ClassLoader.getSystemResource("avro").toURI();
+        String avroSchemaFolder = Paths.get(uri).toString();
+        avroDeserializationTopicsMapping.setSchemasFolder(avroSchemaFolder);
+
+        AvroTopicsMapping albumTopicsMapping = new AvroTopicsMapping();
+        albumTopicsMapping.setTopicRegex("album.*");
+        albumTopicsMapping.setValueSchemaFile("Album.avsc");
+
+        AvroTopicsMapping filmTopicsMapping = new AvroTopicsMapping();
+        filmTopicsMapping.setTopicRegex("film.*");
+        filmTopicsMapping.setValueSchemaFile("Film.avsc");
+
+        // Do not specify schema neither for a key, nor for a value
+        AvroTopicsMapping incorrectTopicsMapping = new AvroTopicsMapping();
+        incorrectTopicsMapping.setTopicRegex("incorrect.*");
+
+        avroDeserializationTopicsMapping.setTopicsMapping(
+            Arrays.asList(albumTopicsMapping, filmTopicsMapping, incorrectTopicsMapping));
+    }
+
+    private void createAlbumObject() {
+        List<String> artists = Collections.singletonList("Imagine Dragons");
+        List<String> songTitles = Arrays.asList("Birds", "Zero", "Natural", "Machine");
+        Album album = new Album("Origins", artists, 2018, songTitles);
+        albumAvro = AlbumAvro.newBuilder()
+            .setTitle(album.getTitle())
+            .setArtist(album.getArtists())
+            .setReleaseYear(album.getReleaseYear())
+            .setSongTitle(album.getSongsTitles())
+            .build();
+    }
+
+    private void createFilmObject() {
+        List<String> starring = Arrays.asList("Harrison Ford", "Mark Hamill", "Carrie Fisher", "Adam Driver", "Daisy Ridley");
+        Film film = new Film("Star Wars: The Force Awakens", "J. J. Abrams", 2015, 135, starring);
+        filmAvro = FilmAvro.newBuilder()
+            .setName(film.getName())
+            .setProducer(film.getProducer())
+            .setReleaseYear(film.getReleaseYear())
+            .setDuration(film.getDuration())
+            .setStarring(film.getStarring())
+            .build();
+    }
+
+    @Test
+    void deserializeAlbum() throws IOException, URISyntaxException {
+        AvroToJsonDeserializer avroToJsonDeserializer = new AvroToJsonDeserializer(avroDeserializationTopicsMapping, new AvroToJsonSerializer(null));
+        final byte[] binaryAlbum = toByteArray("Album.avsc", albumAvro);
+        String decodedAlbum = avroToJsonDeserializer.deserialize("album.topic.name", binaryAlbum, false);
+        String expectedAlbum = "{" +
+            "\"title\":\"Origins\"," +
+            "\"artist\":[\"Imagine Dragons\"]," +
+            "\"releaseYear\":2018," +
+            "\"songTitle\":[\"Birds\",\"Zero\",\"Natural\",\"Machine\"]" +
+            "}";
+        assertEquals(expectedAlbum, decodedAlbum);
+    }
+
+    @Test
+    void deserializeFilm() throws IOException, URISyntaxException {
+        AvroToJsonDeserializer avroToJsonDeserializer = new AvroToJsonDeserializer(avroDeserializationTopicsMapping, new AvroToJsonSerializer(null));
+        final byte[] binaryFilm = toByteArray("Film.avsc", filmAvro);
+        String decodedFilm = avroToJsonDeserializer.deserialize("film.topic.name", binaryFilm, false);
+        String expectedFilm = "{" +
+            "\"name\":\"Star Wars: The Force Awakens\"," +
+            "\"producer\":\"J. J. Abrams\"," +
+            "\"releaseYear\":2015," +
+            "\"duration\":135," +
+            "\"starring\":[\"Harrison Ford\",\"Mark Hamill\",\"Carrie Fisher\",\"Adam Driver\",\"Daisy Ridley\"]" +
+            "}";
+        assertEquals(expectedFilm, decodedFilm);
+    }
+
+    @Test
+    void deserializeForNotMatchingTopic() throws IOException, URISyntaxException {
+        AvroToJsonDeserializer avroToJsonDeserializer = new AvroToJsonDeserializer(avroDeserializationTopicsMapping, new AvroToJsonSerializer(null));
+        final byte[] binaryFilm = toByteArray("Film.avsc", filmAvro);
+        String decodedFilm = avroToJsonDeserializer.deserialize("random.topic.name", binaryFilm, false);
+        assertNull(decodedFilm);
+    }
+
+    @Test
+    void deserializeForKeyWhenItsTypeNotSet() throws IOException, URISyntaxException {
+        AvroToJsonDeserializer avroToJsonDeserializer = new AvroToJsonDeserializer(avroDeserializationTopicsMapping, new AvroToJsonSerializer(null));
+        final byte[] binaryFilm = toByteArray("Film.avsc", filmAvro);
+        String decodedFilm = avroToJsonDeserializer.deserialize("film.topic.name", binaryFilm, true);
+        assertNull(decodedFilm);
+    }
+
+    @Test
+    void deserializeWhenTypeNotSetForKeyAndValue() throws IOException, URISyntaxException {
+        AvroToJsonDeserializer avroToJsonDeserializer = new AvroToJsonDeserializer(avroDeserializationTopicsMapping, new AvroToJsonSerializer(null));
+        final byte[] binaryFilm = toByteArray("Film.avsc", filmAvro);
+        Exception exception = assertThrows(RuntimeException.class, () -> {
+            avroToJsonDeserializer.deserialize("incorrect.topic.name", binaryFilm, true);
+        });
+        String expectedMessage = "schema is not specified neither for a key, nor for a value";
+        String actualMessage = exception.getMessage();
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    private <T> byte[] toByteArray(String schemaName, T datum) throws IOException, URISyntaxException {
+        Schema schema = resolveSchema(schemaName);
+
+        DatumWriter<T> writer = new GenericDatumWriter<>(schema);
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        Encoder encoder = EncoderFactory.get().binaryEncoder(bos, null);
+        writer.write(datum, encoder);
+        encoder.flush();
+        bos.close();
+
+        return bos.toByteArray();
+    }
+
+    private Schema resolveSchema(String schemaName) throws URISyntaxException, IOException {
+        URI uri = ClassLoader.getSystemResource("avro").toURI();
+        File schemaFile = Paths.get(uri).resolve(schemaName).toFile();
+
+        return new Schema.Parser().parse(schemaFile);
+    }
+}

--- a/src/test/java/org/akhq/utils/ProtobufToJsonDeserializerTest.java
+++ b/src/test/java/org/akhq/utils/ProtobufToJsonDeserializerTest.java
@@ -3,7 +3,7 @@ package org.akhq.utils;
 import com.google.protobuf.Any;
 import com.google.protobuf.DoubleValue;
 import com.google.protobuf.StringValue;
-import org.akhq.configs.Connection.ProtobufDeserializationTopicsMapping;
+import org.akhq.configs.Connection.Deserialization.ProtobufDeserializationTopicsMapping;
 import org.akhq.configs.TopicsMapping;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/resources/avro/Album.avsc
+++ b/src/test/resources/avro/Album.avsc
@@ -1,0 +1,11 @@
+{
+    "name": "AlbumAvro",
+    "namespace": "org.akhq",
+    "type": "record",
+    "fields" : [
+        {"name": "title", "type": "string"},
+        {"name": "artist", "type": {"type": "array", "items": "string"}},
+        {"name": "releaseYear", "type": "int"},
+        {"name": "songTitle", "type": {"type": "array", "items": "string"}}
+    ]
+}

--- a/src/test/resources/avro/Film.avsc
+++ b/src/test/resources/avro/Film.avsc
@@ -1,0 +1,12 @@
+{
+    "name": "FilmAvro",
+    "namespace": "org.akhq",
+    "type": "record",
+    "fields" : [
+        {"name": "name", "type": "string"},
+        {"name": "producer", "type": "string"},
+        {"name": "releaseYear", "type": "int"},
+        {"name": "duration", "type": "int"},
+        {"name": "starring", "type": {"type": "array", "items": "string"}}
+    ]
+}


### PR DESCRIPTION
This PR implements #833. 

It allows the decoding of Avro raw binary format, with a mapping configuration similar to what already exists for Protobuf, for example:

```
        akhq:
          connections:
            my-cluster:
              deserialization:
                avro-raw:
                  schemas-folder: "/app/avro_schemas"
                  topics-mapping:
                    - topic-regex: "data.*"
                      value-schema-file: "Schema.avsc"
```

A couple of remarks regarding this PR:
- it only addresses Avro "raw" binary format, that is objects encoded with low-level `DatumWriter` (no header), which is my use case. It could be extended to support single-object encoding (https://avro.apache.org/docs/current/spec.html#single_object_encoding) and it could also be interesting to decode object container files (https://avro.apache.org/docs/current/spec.html#Object+Container+Files) which embed the schema
- there is no support for schema referencing another schemas
- I'm not a Gradle specialist but I didn't manage to have Avro schemas used for unit tests that are compiled by Gradle Avro plugin as well as also packaged as resources, so I ended up duplicating the files...
- I modified `AvroDeserializer` so that displayed JSON keeps the same field order than Avro schema. This is convenient for unit tests and I think it is also for the user
