### PR TITLE
Support JSONSchema while producing message

### DIFF
--- a/src/main/java/org/akhq/configs/SchemaRegistryType.java
+++ b/src/main/java/org/akhq/configs/SchemaRegistryType.java
@@ -1,6 +1,15 @@
 package org.akhq.configs;
 
+import lombok.Getter;
+
+@Getter
 public enum SchemaRegistryType {
-    CONFLUENT,
-    TIBCO
+    CONFLUENT((byte) 0x0),
+    TIBCO((byte) 0x80);
+
+    private byte magicByte;
+
+    SchemaRegistryType(byte magicByte) {
+        this.magicByte = magicByte;
+    }
 }

--- a/src/main/java/org/akhq/controllers/SchemaController.java
+++ b/src/main/java/org/akhq/controllers/SchemaController.java
@@ -128,7 +128,9 @@ public class SchemaController extends AbstractController {
         String cluster,
         Integer id
     ) throws IOException, RestClientException, ExecutionException, InterruptedException {
-        return this.schemaRepository.getById(cluster, id);
+        return this.schemaRepository
+            .getById(cluster, id)
+            .orElse(null);
     }
 
     @Get("api/{cluster}/schema/{subject}/version")

--- a/src/main/java/org/akhq/models/Record.java
+++ b/src/main/java/org/akhq/models/Record.java
@@ -78,11 +78,7 @@ public class Record {
     private byte MAGIC_BYTE;
 
     public Record(RecordMetadata record, SchemaRegistryType schemaRegistryType, byte[] bytesKey, byte[] bytesValue, Map<String, String> headers, Topic topic) {
-        if (schemaRegistryType == SchemaRegistryType.TIBCO) {
-            this.MAGIC_BYTE = (byte) 0x80;
-        } else {
-            this.MAGIC_BYTE = 0x0;
-        }
+        this.MAGIC_BYTE = schemaRegistryType.getMagicByte();
         this.topic = topic;
         this.partition = record.partition();
         this.offset = record.offset();

--- a/src/main/java/org/akhq/modules/schemaregistry/JsonSchemaSerializer.java
+++ b/src/main/java/org/akhq/modules/schemaregistry/JsonSchemaSerializer.java
@@ -1,0 +1,70 @@
+package org.akhq.modules.schemaregistry;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
+import io.confluent.kafka.serializers.json.AbstractKafkaJsonSchemaSerializer;
+import lombok.extern.slf4j.Slf4j;
+import org.akhq.configs.SchemaRegistryType;
+import org.everit.json.schema.ValidationException;
+import org.json.JSONObject;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+@Slf4j
+public class JsonSchemaSerializer extends AbstractKafkaJsonSchemaSerializer<String> implements SchemaSerializer {
+    private final int schemaId;
+    private final JsonSchema jsonSchema;
+    private final SchemaRegistryType schemaRegistryType;
+
+    public static JsonSchemaSerializer newInstance(int schemaId, ParsedSchema parsedSchema, SchemaRegistryType schemaRegistryType) {
+        if (supports(parsedSchema)) {
+            return new JsonSchemaSerializer(schemaId, (JsonSchema) parsedSchema, schemaRegistryType);
+        }
+        String errorMsg = String.format("Schema %s has not supported schema type expected %s but found %s", parsedSchema.name(), JsonSchema.TYPE, parsedSchema.schemaType());
+        throw new IllegalArgumentException(errorMsg);
+    }
+
+    @Override
+    public byte[] serialize(String json) {
+        try {
+            JSONObject jsonObject = new JSONObject(json);
+            jsonSchema.validate(jsonObject);
+        } catch (JsonProcessingException e) {
+            String errorMsg = String.format("Provided json [%s] is not valid according to schema", json);
+            log.error(errorMsg);
+            throw new RuntimeException(errorMsg, e);
+        } catch (ValidationException e) {
+            String validationErrorMsg = String.format(
+                "Provided json message is not valid according to jsonSchema (id=%d): %s",
+                schemaId,
+                e.getMessage()
+            );
+            throw new IllegalArgumentException(validationErrorMsg);
+        }
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            out.write(schemaRegistryType.getMagicByte());
+            out.write(ByteBuffer.allocate(idSize).putInt(schemaId).array());
+            out.write(json.getBytes(StandardCharsets.UTF_8));
+            byte[] bytes = out.toByteArray();
+            out.close();
+            return bytes;
+        } catch (IOException e) {
+            throw new RuntimeException(String.format("Could not serialize json [%s]", json), e);
+        }
+    }
+
+    public static boolean supports(ParsedSchema parsedSchema) {
+        return Objects.equals(JsonSchema.TYPE, parsedSchema.schemaType());
+    }
+
+    private JsonSchemaSerializer(int schemaId, JsonSchema jsonSchema, SchemaRegistryType schemaRegistryType) {
+        this.schemaId = schemaId;
+        this.jsonSchema = jsonSchema;
+        this.schemaRegistryType = schemaRegistryType;
+    }
+}

--- a/src/main/java/org/akhq/modules/schemaregistry/RecordWithSchemaSerializerFactory.java
+++ b/src/main/java/org/akhq/modules/schemaregistry/RecordWithSchemaSerializerFactory.java
@@ -1,0 +1,57 @@
+package org.akhq.modules.schemaregistry;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.akhq.configs.Connection;
+import org.akhq.configs.SchemaRegistryType;
+import org.akhq.modules.KafkaModule;
+
+import javax.inject.Singleton;
+import java.io.IOException;
+
+@Singleton
+@RequiredArgsConstructor
+@Slf4j
+public class RecordWithSchemaSerializerFactory {
+    private final KafkaModule kafkaModule;
+
+    public SchemaSerializer createSerializer(String clusterId, int schemaId) {
+        ParsedSchema parsedSchema = retrieveSchema(clusterId, schemaId);
+        SchemaRegistryType schemaRegistryType = getSchemaRegistryType(clusterId);
+        return createSerializer(schemaId, parsedSchema, schemaRegistryType);
+    }
+
+    public SchemaSerializer createSerializer(int schemaId, ParsedSchema parsedSchema, SchemaRegistryType schemaRegistryType) {
+        if (JsonSchemaSerializer.supports(parsedSchema)) {
+            return JsonSchemaSerializer.newInstance(schemaId, parsedSchema, schemaRegistryType);
+        } if (AvroSerializer.supports(parsedSchema)) {
+            return AvroSerializer.newInstance(schemaId, parsedSchema, schemaRegistryType);
+        } else {
+            String errorMsg = String.format("Schema with id %d has unsupported schema type %s", schemaId, parsedSchema.schemaType());
+            throw new IllegalStateException(errorMsg);
+        }
+    }
+
+    private ParsedSchema retrieveSchema(String clusterId, int schemaId) {
+        SchemaRegistryClient registryClient = kafkaModule.getRegistryClient(clusterId);
+        try {
+            return registryClient.getSchemaById(schemaId);
+        } catch (IOException|RestClientException e) {
+            String errorMsg = String.format("Can't retrieve schema %d in registry", schemaId);
+            log.error(errorMsg, e);
+            throw new RuntimeException(errorMsg, e);
+        }
+    }
+
+    private SchemaRegistryType getSchemaRegistryType(String clusterId) {
+        SchemaRegistryType schemaRegistryType = SchemaRegistryType.CONFLUENT;
+        Connection.SchemaRegistry schemaRegistry = this.kafkaModule.getConnection(clusterId).getSchemaRegistry();
+        if (schemaRegistry != null) {
+            schemaRegistryType = schemaRegistry.getType();
+        }
+        return schemaRegistryType;
+    }
+}

--- a/src/main/java/org/akhq/modules/schemaregistry/SchemaSerializer.java
+++ b/src/main/java/org/akhq/modules/schemaregistry/SchemaSerializer.java
@@ -1,0 +1,7 @@
+package org.akhq.modules.schemaregistry;
+
+public interface SchemaSerializer {
+
+    byte[] serialize(String value);
+
+}

--- a/src/test/java/org/akhq/KafkaTestCluster.java
+++ b/src/test/java/org/akhq/KafkaTestCluster.java
@@ -54,6 +54,7 @@ public class KafkaTestCluster implements Runnable, Stoppable {
     public static final String TOPIC_STREAM_MAP = "stream-map";
     public static final String TOPIC_STREAM_COUNT = "stream-count";
     public static final String TOPIC_CONNECT = "connect-sink";
+    public static final String TOPIC_JSON_SCHEMA = "json-schema-topic";
 
     public static final int TOPIC_ALL_COUNT = 19;
     public static final int TOPIC_HIDE_INTERNAL_COUNT = 11;

--- a/src/test/java/org/akhq/KafkaTestCluster.java
+++ b/src/test/java/org/akhq/KafkaTestCluster.java
@@ -56,10 +56,10 @@ public class KafkaTestCluster implements Runnable, Stoppable {
     public static final String TOPIC_CONNECT = "connect-sink";
     public static final String TOPIC_JSON_SCHEMA = "json-schema-topic";
 
-    public static final int TOPIC_ALL_COUNT = 19;
-    public static final int TOPIC_HIDE_INTERNAL_COUNT = 11;
-    public static final int TOPIC_HIDE_INTERNAL_STREAM_COUNT = 9;
-    public static final int TOPIC_HIDE_STREAM_COUNT = 17;
+    public static final int TOPIC_ALL_COUNT = 20;
+    public static final int TOPIC_HIDE_INTERNAL_COUNT = 12;
+    public static final int TOPIC_HIDE_INTERNAL_STREAM_COUNT = 10;
+    public static final int TOPIC_HIDE_STREAM_COUNT = 18;
     public static final int CONSUMER_GROUP_COUNT = 6;
 
     public static final String CONSUMER_STREAM_TEST = "stream-test-example";
@@ -291,6 +291,10 @@ public class KafkaTestCluster implements Runnable, Stoppable {
             testUtils.produceRecords(randomDatas(1000, 0), TOPIC_HUGE, partition);
         }
         log.debug("Huge topic created");
+
+        // empty topic
+        testUtils.createTopic(TOPIC_JSON_SCHEMA, 3, (short) 1);
+        log.debug("{} topic created", TOPIC_JSON_SCHEMA);
 
         // consumer groups
         for (int c = 0; c < 5; c++) {

--- a/src/test/java/org/akhq/modules/AvroSchemaSerializerTest.java
+++ b/src/test/java/org/akhq/modules/AvroSchemaSerializerTest.java
@@ -1,13 +1,13 @@
 package org.akhq.modules;
 
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import org.akhq.configs.SchemaRegistryType;
+import org.akhq.modules.schemaregistry.AvroSerializer;
 import org.apache.avro.SchemaBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
@@ -15,11 +15,10 @@ import java.nio.ByteBuffer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AvroSchemaSerializerTest {
+    private static final int SCHEMA_ID = 3;
 
     private final org.apache.avro.Schema SCHEMA = SchemaBuilder
             .record("schema1").namespace("org.akhq")
@@ -41,35 +40,30 @@ class AvroSchemaSerializerTest {
             "  \"rating\": 2.5\n" +
             "}";
 
-    private AvroSerializer cut;
-
-    @Mock
-    private SchemaRegistryClient schemaRegistryClient;
+    private AvroSerializer avroSerializer;
 
     @BeforeEach
-    void setUp() throws IOException, RestClientException {
-        cut = new AvroSerializer(schemaRegistryClient, SchemaRegistryType.CONFLUENT);
-        when(schemaRegistryClient.getById(anyInt())).thenReturn(SCHEMA);
+    void setUp() {
+        avroSerializer = AvroSerializer.newInstance(SCHEMA_ID, new AvroSchema(SCHEMA), SchemaRegistryType.CONFLUENT);
     }
 
     @Test
     void shouldSerializeSchemaId() {
-        int schemaId = 3;
-        byte[] bytes = cut.toAvro(VALID_JSON, schemaId);
+        byte[] bytes = avroSerializer.serialize(VALID_JSON);
 
         ByteBuffer buffer = ByteBuffer.wrap(bytes);
         byte magicBytes = buffer.get();
         int serializedSchemaId = buffer.getInt();
 
         assertEquals(0, magicBytes);
-        assertEquals(schemaId, serializedSchemaId);
+        assertEquals(SCHEMA_ID, serializedSchemaId);
     }
 
     @Test
     void shouldFailIfDoesntMatchSchemaId() {
         assertThrows(NullPointerException.class, () -> {
             int schemaId = 3;
-            cut.toAvro(INVALID_JSON, schemaId);
+            avroSerializer.serialize(INVALID_JSON);
         });
     }
 

--- a/src/test/java/org/akhq/modules/schemaregistry/JsonSchemaSerializerTest.java
+++ b/src/test/java/org/akhq/modules/schemaregistry/JsonSchemaSerializerTest.java
@@ -1,0 +1,50 @@
+package org.akhq.modules.schemaregistry;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
+import org.akhq.configs.SchemaRegistryType;
+import org.akhq.utils.Album;
+import org.akhq.utils.ResourceTestUtil;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JsonSchemaSerializerTest {
+
+    @Test
+    public void serializeJsonStringWithMagicByteAndSchemaId() throws IOException {
+        JsonSchema jsonSchema = createJsonSchema("json_schema/album.json");
+        JsonSchemaSerializer jsonSchemaSerializer = JsonSchemaSerializer.newInstance(1, jsonSchema, SchemaRegistryType.CONFLUENT);
+        Album objectSatisfyingJsonSchema = new Album("title", List.of("artist_1", "artist_2"), 1989, List.of("song_1", "song_2"));
+        String recordAsJsonString = new ObjectMapper().writeValueAsString(objectSatisfyingJsonSchema);
+
+        byte[] serialize = jsonSchemaSerializer.serialize(recordAsJsonString);
+
+        assertEquals(SchemaRegistryType.CONFLUENT.getMagicByte(), serialize[0]);
+    }
+
+    @Test
+    public void failsWhenObjectDoesNotAdhereToSchema() throws IOException {
+        JsonSchema jsonSchema = createJsonSchema("json_schema/album.json");
+        JsonSchemaSerializer jsonSchemaSerializer = JsonSchemaSerializer.newInstance(1, jsonSchema, SchemaRegistryType.CONFLUENT);
+
+        JSONObject notSchemaValidObject = new JSONObject(Collections.singletonMap("any_property", "property value"));
+        try {
+            jsonSchemaSerializer.serialize(notSchemaValidObject.toString());
+            fail("Exception should be thrown");
+        } catch (Exception e) {
+            assertEquals(IllegalArgumentException.class, e.getClass());
+        }
+    }
+
+    private JsonSchema createJsonSchema(String resourcePath) throws IOException {
+        String schemaAsString = ResourceTestUtil.resourceAsString(resourcePath);
+        return new JsonSchema(schemaAsString);
+    }
+
+}

--- a/src/test/java/org/akhq/utils/ResourceTestUtil.java
+++ b/src/test/java/org/akhq/utils/ResourceTestUtil.java
@@ -1,0 +1,18 @@
+package org.akhq.utils;
+
+import com.google.common.io.CharStreams;
+import org.junit.platform.commons.util.ClassLoaderUtils;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class ResourceTestUtil {
+
+    public static String resourceAsString(String resourcePath) throws IOException {
+        try (
+            InputStreamReader isr = new InputStreamReader(ClassLoaderUtils.getDefaultClassLoader().getResourceAsStream(resourcePath))
+        ) {
+            return CharStreams.toString(isr);
+        }
+    }
+}

--- a/src/test/resources/json_schema/album.json
+++ b/src/test/resources/json_schema/album.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "releaseYear": {
+      "type": "number"
+    },
+    "artists": {
+      "type": "array",
+      "items": {
+        "type" : "string"
+      }
+    },
+    "songsTitles": {
+      "type": "array",
+      "items": {
+        "type" : "string"
+      }
+    }
+  },
+  "required": [
+    "title",
+    "releaseYear",
+    "artists",
+    "songsTitles"
+  ]
+}

--- a/src/test/resources/json_schema/key.json
+++ b/src/test/resources/json_schema/key.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "The unique identifier for a message",
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "required": [ "id" ]
+}


### PR DESCRIPTION
Currently it is not possible to produce message to a topic while JSON Schema is chosen as key or value schema.
For producing message to a topic `RecordRepository` is used. In case schema id was present `AvroSchemaSerializer` was used regardless of schema type.

`RecordWithSchemaSerializerFactory` was introduced to take care of fetching schema from schema registry and create proper serializer. AvroSerializer is no longer responsible for fetching schema itself - it is not longer a bean but it is created on demand for specific schema.

A test not related to the functionality (`SchemaRegistryRepositoryTest#register`) was change because it was influenced by adding schema to schema registry by new `RecordRepositoryTest`