### PR TITLE
[Documentation] Fix "context-path"

### DIFF
--- a/application.example.yml
+++ b/application.example.yml
@@ -32,7 +32,7 @@ micronaut:
 
   server:
     context-path: "" # if behind a reverse proxy, path to akhq without trailing slash (optional). Example: akhq is
-                     # behind a reverse proxy with url http://my-server/akhq, set base-path: "/akhq".
+                     # behind a reverse proxy with url http://my-server/akhq, set context-path: "/akhq".
                      # Not needed if you're behind a reverse proxy with subdomain http://akhq.my-server/
 akhq:
   server:

--- a/docs/docs/configuration/others.md
+++ b/docs/docs/configuration/others.md
@@ -1,9 +1,9 @@
 # Others
 
 ## Server
-* `micronaut.server.context-path`: if behind a reverse proxy, path to akhq with trailing slash (optional). Example:
-  akhq is behind a reverse proxy with url <http://my-server/akhq>, set base-path: "/akhq/". Not needed if you're
-  behind a reverse proxy with subdomain <http://akhq.my-server/>
+* `micronaut.server.context-path`: if behind a reverse proxy, path to akhq without trailing slash (optional).
+  Example: akhq is behind a reverse proxy with url <http://my-server/akhq>, set `context-path: "/akhq"`.
+  Not needed if you're behind a reverse proxy with subdomain <http://akhq.my-server/>
 
 ## Kafka admin / producer / consumer default properties
 * `akhq.clients-defaults.{{admin|producer|consumer}}.properties`: default configuration for admin producer or


### PR DESCRIPTION
It seems the `context-path` must be set without a trailing slash.