### PR TITLE
fix: When no consumer groups, you can click on next, throws error

### DIFF
--- a/client/src/containers/ConsumerGroup/ConsumerGroupList/ConsumerGroupList.jsx
+++ b/client/src/containers/ConsumerGroup/ConsumerGroupList/ConsumerGroupList.jsx
@@ -71,7 +71,7 @@ class ConsumerGroupList extends Root {
           })
       );
     } else {
-      this.setState({ selectedCluster, consumerGroups: [], totalPageNumber: 0, loading: false });
+      this.setState({ selectedCluster, consumerGroups: [], totalPageNumber: 1, loading: false });
     }
   }
 


### PR DESCRIPTION
Resolves #976

In function getConsumerGroup of ConsumerGroupList, when retrieving consuming groups and the response was empty, it was setting the totalPageNumber state variable as setting as 0 when, by default must be 1, allowing to change to "next" page when it did not exist.