### PR TITLE
add support for ingressClassName to helm chart

### DIFF
--- a/helm/akhq/templates/ingress.yaml
+++ b/helm/akhq/templates/ingress.yaml
@@ -15,6 +15,9 @@ metadata:
     {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
+{{- if and .Values.ingress.ingressClassName (eq (include "akhq.ingress.apiVersion" $) "networking.k8s.io/v1") }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}

--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -114,6 +114,7 @@ service:
 
 ingress:
   enabled: false
+  ingressClassName: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
## What

- Add support for `.spec.ingressClassName` to the ingress template in the helm chart

