### PR TITLE
Link consumergroup topics offset to data single

### DIFF
--- a/client/src/containers/ConsumerGroup/ConsumerGroupDetail/ConsumerGroupTopics/ConsumerGroupTopics.jsx
+++ b/client/src/containers/ConsumerGroup/ConsumerGroupDetail/ConsumerGroupTopics/ConsumerGroupTopics.jsx
@@ -90,7 +90,14 @@ class ConsumerGroupTopics extends Root {
               colName: 'Offset',
               type: 'text',
               cell: obj => {
-                return this.handleOptional(obj.offset);
+                if (obj.offset !== undefined && obj.offset !== '') {
+                  return (
+                    <Link to={`/ui/${this.state.selectedCluster}/topic/${obj.name}/data?single=true&partition=${obj.partition}&offset=${obj.offset}`}>
+                      {obj.offset}
+                    </Link>
+                  );
+                }
+                return <label>-</label>;
               }
             },
             {


### PR DESCRIPTION
Fixes #992 

Have very little experience with React & jsx , so this should be considered a rough first attempt.

Also was not yet able to verify locally, as [the development server](https://akhq.io/docs/dev.html#development-server) environment does not have any consumer groups by default; and I didn't yet find the time to create a topic & consumer. Might be nice to expand the development environment with [the test data seen here](https://github.com/tchiotludo/akhq/blob/dev/docker-compose.yml#L102).