### PR TITLE
Handle logical types local-timestamp-millis and local-timestamp-micros

### DIFF
--- a/src/main/java/org/akhq/utils/AvroDeserializer.java
+++ b/src/main/java/org/akhq/utils/AvroDeserializer.java
@@ -14,6 +14,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -26,6 +27,8 @@ public class AvroDeserializer {
     private static final String TIME_MICROS = "time-micros";
     private static final String TIMESTAMP_MILLIS = "timestamp-millis";
     private static final String TIMESTAMP_MICROS = "timestamp-micros";
+    private static final String LOCAL_TIMESTAMP_MILLIS = "local-timestamp-millis";
+    private static final String LOCAL_TIMESTAMP_MICROS = "local-timestamp-micros";
 
     private static final DecimalConversion DECIMAL_CONVERSION = new DecimalConversion();
     private static final UUIDConversion UUID_CONVERSION = new UUIDConversion();
@@ -34,6 +37,8 @@ public class AvroDeserializer {
     private static final TimeMillisConversion TIME_MILLIS_CONVERSION = new TimeMillisConversion();
     private static final TimestampMicrosConversion TIMESTAMP_MICROS_CONVERSION = new TimestampMicrosConversion();
     private static final TimestampMillisConversion TIMESTAMP_MILLIS_CONVERSION = new TimestampMillisConversion();
+    private static final LocalTimestampMicrosConversion LOCAL_TIMESTAMP_MICROS_CONVERSION = new LocalTimestampMicrosConversion();
+    private static final LocalTimestampMillisConversion LOCAL_TIMESTAMP_MILLIS_CONVERSION = new LocalTimestampMillisConversion();
 
     public static Map<String, Object> recordDeserializer(GenericRecord record) {
         return record
@@ -68,6 +73,10 @@ public class AvroDeserializer {
                     return AvroDeserializer.timestampMicrosDeserializer(value, schema, primitiveType, logicalType);
                 case TIMESTAMP_MILLIS:
                     return AvroDeserializer.timestampMillisDeserializer(value, schema, primitiveType, logicalType);
+                case LOCAL_TIMESTAMP_MICROS:
+                    return AvroDeserializer.localTimestampMicrosDeserializer(value, schema, primitiveType, logicalType);
+                case LOCAL_TIMESTAMP_MILLIS:
+                    return AvroDeserializer.localTimestampMillisDeserializer(value, schema, primitiveType, logicalType);
                 case UUID:
                     return AvroDeserializer.uuidDeserializer(value, schema, primitiveType, logicalType);
                 default:
@@ -148,6 +157,23 @@ public class AvroDeserializer {
     private static Instant timestampMillisDeserializer(Object value, Schema schema, Type primitiveType, LogicalType logicalType) {
         if (primitiveType == Type.LONG) {
             return AvroDeserializer.TIMESTAMP_MILLIS_CONVERSION.fromLong((Long) value, schema, logicalType);
+        }
+
+        throw new IllegalStateException("Unexpected value: " + primitiveType);
+    }
+
+    private static LocalDateTime localTimestampMicrosDeserializer(Object value, Schema schema, Type primitiveType, LogicalType logicalType) {
+        switch (primitiveType) {
+            case LONG:
+                return AvroDeserializer.LOCAL_TIMESTAMP_MICROS_CONVERSION.fromLong((Long) value, schema, logicalType);
+            default:
+                throw new IllegalStateException("Unexpected value: " + primitiveType);
+        }
+    }
+
+    private static LocalDateTime localTimestampMillisDeserializer(Object value, Schema schema, Type primitiveType, LogicalType logicalType) {
+        if (primitiveType == Type.LONG) {
+            return AvroDeserializer.LOCAL_TIMESTAMP_MILLIS_CONVERSION.fromLong((Long) value, schema, logicalType);
         }
 
         throw new IllegalStateException("Unexpected value: " + primitiveType);

--- a/src/test/java/org/akhq/utils/AvroDeserializerTest.java
+++ b/src/test/java/org/akhq/utils/AvroDeserializerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.math.BigDecimal;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,10 +41,12 @@ class AvroDeserializerTest {
             Arguments.of(UUID.randomUUID(), "{\"type\": \"string\", \"logicalType\": \"uuid\"}"),
             Arguments.of(LocalDate.now(), "{\"type\": \"int\", \"logicalType\": \"date\"}"),
             Arguments.of(LocalTime.now(Clock.tickMillis(ZoneId.of("UTC"))), "{\"type\": \"int\", \"logicalType\": \"time-millis\"}"),
-            Arguments.of(LocalTime.now(), "{\"type\": \"long\", \"logicalType\": \"time-micros\"}"),
+            Arguments.of(LocalTime.now().truncatedTo(ChronoUnit.MICROS), "{\"type\": \"long\", \"logicalType\": \"time-micros\"}"),
             Arguments.of(Instant.now(Clock.tickMillis(ZoneId.of("UTC"))), "{\"type\": \"long\", \"logicalType\": \"timestamp-millis\"}"),
-            Arguments.of(Instant.now(), "{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}"),
-            Arguments.of(Instant.now(), "[\"null\", {\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}]")
+            Arguments.of(Instant.now().truncatedTo(ChronoUnit.MICROS), "{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}"),
+            Arguments.of(Instant.now().truncatedTo(ChronoUnit.MICROS), "[\"null\", {\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}]"),
+            Arguments.of(LocalDateTime.now().truncatedTo(ChronoUnit.MICROS), "{\"type\": \"long\", \"logicalType\": \"local-timestamp-micros\"}"),
+            Arguments.of(LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS), "{\"type\": \"long\", \"logicalType\": \"local-timestamp-millis\"}")
         );
     }
 
@@ -70,8 +73,10 @@ class AvroDeserializerTest {
 
     static Stream<Arguments> convertionSource() {
         UUID uuid = UUID.randomUUID();
-        LocalTime localTime = LocalTime.now();
-        Instant now = Instant.now();
+        LocalTime localTime = LocalTime.now().truncatedTo(ChronoUnit.MICROS);
+        Instant now = Instant.now().truncatedTo(ChronoUnit.MICROS);
+        LocalDateTime localDateTimeMicros = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS);
+        LocalDateTime localDateTimeMillis = LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS);
 
         return Stream.of(
             Arguments.of("abc", "\"bytes\"", "abc".getBytes()),
@@ -81,7 +86,9 @@ class AvroDeserializerTest {
             Arguments.of(uuid.toString(), "{\"type\": \"string\", \"logicalType\": \"uuid\"}", uuid),
             Arguments.of(LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE), "{\"type\": \"int\", \"logicalType\": \"date\"}", LocalDate.now()),
             Arguments.of(localTime.format(DateTimeFormatter.ISO_LOCAL_TIME), "{\"type\": \"long\", \"logicalType\": \"time-micros\"}", localTime),
-            Arguments.of(now.atZone(ZoneId.systemDefault()).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME), "{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", now)
+            Arguments.of(now.atZone(ZoneId.systemDefault()).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME), "{\"type\": \"long\", \"logicalType\": \"timestamp-micros\"}", now),
+            Arguments.of(localDateTimeMicros.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME), "{\"type\": \"long\", \"logicalType\": \"local-timestamp-micros\"}", localDateTimeMicros),
+            Arguments.of(localDateTimeMillis.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME), "{\"type\": \"long\", \"logicalType\": \"local-timestamp-millis\"}", localDateTimeMillis)
         );
     }
 


### PR DESCRIPTION
Avro specification defines additional logical types, which are not yet supported by akhq ([Avro specification](https://avro.apache.org/docs/current/spec.html#Logical+Types)):
- local-timestamp-millis
- local-timestamp-micros

When using schema with logical types of the above, akhq fails to convert the messages to JSON and visualize them.

This PR adds support for handling the mentioned logical types.