### PR TITLE
feat/fix: Toggle "time ago" and timestamp with interactive tooltip

### DIFF
--- a/application.example.yml
+++ b/application.example.yml
@@ -105,6 +105,7 @@ akhq:
           show-all-consumer-groups: true # Expand list of consumer groups instead of showing one. Overrides default.
         topic-data:
           sort: NEWEST # default sort order (OLDEST, NEWEST) (default: OLDEST).  Overrides default
+          date-format: ISO # format of message timestamps (RELATIVE, ISO) (default: RELATIVE)
 
     my-cluster-ssl:
       properties:

--- a/application.example.yml
+++ b/application.example.yml
@@ -105,7 +105,7 @@ akhq:
           show-all-consumer-groups: true # Expand list of consumer groups instead of showing one. Overrides default.
         topic-data:
           sort: NEWEST # default sort order (OLDEST, NEWEST) (default: OLDEST).  Overrides default
-          date-format: ISO # format of message timestamps (RELATIVE, ISO) (default: RELATIVE)
+          date-time-format: ISO # format of message timestamps (RELATIVE, ISO) (default: RELATIVE)
 
     my-cluster-ssl:
       properties:

--- a/client/src/components/DateTime/DateTime.jsx
+++ b/client/src/components/DateTime/DateTime.jsx
@@ -29,8 +29,8 @@ class DateTime extends Component {
 }
 
 DateTime.propTypes = {
-  isoDateTimeString: PropTypes.string,
-  dateTimeFormat: PropTypes.string,
+  isoDateTimeString: PropTypes.string.isRequired,
+  dateTimeFormat: PropTypes.string.isRequired,
 };
 
 export default DateTime;

--- a/client/src/components/DateTime/DateTime.jsx
+++ b/client/src/components/DateTime/DateTime.jsx
@@ -1,0 +1,36 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import TimeAgo from 'react-timeago';
+import { Tooltip } from '@material-ui/core';
+
+import { SETTINGS_VALUES } from '../../utils/constants';
+
+class DateTime extends Component {
+
+  render() {
+    const isoDate = this.props.isoDateTimeString;
+    const TimeAgoComp = <TimeAgo date={Date.parse(isoDate)} title={''}/>
+    return (
+      <Tooltip arrow title={
+        this.props.dateTimeFormat === SETTINGS_VALUES.TOPIC_DATA.DATE_FORMAT.ISO ?
+          TimeAgoComp :
+          isoDate
+        } interactive>
+        <span>{
+          this.props.dateTimeFormat === SETTINGS_VALUES.TOPIC_DATA.DATE_FORMAT.ISO ?
+            isoDate :
+            TimeAgoComp
+        }</span>
+      </Tooltip>   
+    );
+  }
+
+}
+
+DateTime.propTypes = {
+  isoDateTimeString: PropTypes.string,
+  dateTimeFormat: PropTypes.string,
+};
+
+export default DateTime;

--- a/client/src/components/DateTime/DateTime.jsx
+++ b/client/src/components/DateTime/DateTime.jsx
@@ -13,12 +13,12 @@ class DateTime extends Component {
     const TimeAgoComp = <TimeAgo date={Date.parse(isoDate)} title={''}/>
     return (
       <Tooltip arrow title={
-        this.props.dateTimeFormat === SETTINGS_VALUES.TOPIC_DATA.DATE_FORMAT.ISO ?
+        this.props.dateTimeFormat === SETTINGS_VALUES.TOPIC_DATA.DATE_TIME_FORMAT.ISO ?
           TimeAgoComp :
           isoDate
         } interactive>
         <span>{
-          this.props.dateTimeFormat === SETTINGS_VALUES.TOPIC_DATA.DATE_FORMAT.ISO ?
+          this.props.dateTimeFormat === SETTINGS_VALUES.TOPIC_DATA.DATE_TIME_FORMAT.ISO ?
             isoDate :
             TimeAgoComp
         }</span>

--- a/client/src/components/DateTime/index.js
+++ b/client/src/components/DateTime/index.js
@@ -1,0 +1,3 @@
+import DateTime from './DateTime';
+
+export default DateTime;

--- a/client/src/components/SearchBar/SearchBar.jsx
+++ b/client/src/components/SearchBar/SearchBar.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Joi from 'joi-browser';
 import PropTypes from 'prop-types';
 import Form from '../Form/Form';
+import { SETTINGS_VALUES } from '../../utils/constants';
 import './styles.scss';
 
 class SearchBar extends Form {
@@ -17,19 +18,19 @@ class SearchBar extends Form {
     errors: {},
     topicListViewOptions: [
       {
-        _id: 'ALL',
+        _id: SETTINGS_VALUES.TOPIC.TOPIC_DEFAULT_VIEW.ALL,
         name: 'Show all topics'
       },
       {
-        _id: 'HIDE_INTERNAL',
+        _id: SETTINGS_VALUES.TOPIC.TOPIC_DEFAULT_VIEW.HIDE_INTERNAL,
         name: 'Hide internal topics'
       },
       {
-        _id: 'HIDE_INTERNAL_STREAM',
+        _id: SETTINGS_VALUES.TOPIC.TOPIC_DEFAULT_VIEW.HIDE_INTERNAL_STREAM,
         name: 'Hide internal & stream topics'
       },
       {
-        _id: 'HIDE_STREAM',
+        _id: SETTINGS_VALUES.TOPIC.TOPIC_DEFAULT_VIEW.HIDE_STREAM,
         name: 'Hide stream topics'
       }
     ]

--- a/client/src/components/Table/Table.jsx
+++ b/client/src/components/Table/Table.jsx
@@ -431,7 +431,7 @@ class Table extends Component {
   colspan() {
     const { actions, columns } = this.props;
 
-    return columns.length + (actions && actions.length ? actions.length : 0)
+    return columns.filter(column => !column.extraRow).length + (actions && actions.length ? actions.length : 0)
   }
 
   render() {

--- a/client/src/containers/Settings/Settings.jsx
+++ b/client/src/containers/Settings/Settings.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Joi from 'joi-browser';
 import Form from '../../components/Form/Form';
 import Header from '../Header';
+import { SETTINGS_VALUES } from '../../utils/constants';
 import {getUIOptions, setUIOptions} from '../../utils/localstorage';
 import './styles.scss';
 import {toast} from 'react-toastify';
@@ -20,10 +21,12 @@ class Settings extends Form {
     errors: {}
   };
 
-  topicDefaultView = [ { _id: 'ALL', name: 'ALL' }, { _id: 'HIDE_INTERNAL', name: 'HIDE_INTERNAL' },
-    { _id: 'HIDE_INTERNAL_STREAM', name: 'HIDE_INTERNAL_STREAM' }, { _id: 'HIDE_STREAM', name: 'HIDE_STREAM' } ];
-  topicDataSort = [ { _id: 'OLDEST', name: 'OLDEST' }, { _id: 'NEWEST', name: 'NEWEST' } ];
-  topicDataDateFormat = [ { _id: 'RELATIVE', name: 'RELATIVE' }, { _id: 'ISO', name: 'ISO' } ];
+  topicDefaultView = Object.entries(SETTINGS_VALUES.TOPIC.TOPIC_DEFAULT_VIEW)
+                        .map(([value]) => ({_id: value, name: value}));
+  topicDataSort = Object.entries(SETTINGS_VALUES.TOPIC_DATA.SORT)
+                        .map(([value]) => ({_id: value, name: value}));
+  topicDataDateFormat = Object.entries(SETTINGS_VALUES.TOPIC_DATA.DATE_FORMAT)
+                        .map(([value]) => ({_id: value, name: value}));
 
   schema = {
     topicDefaultView: Joi.string().optional(),

--- a/client/src/containers/Settings/Settings.jsx
+++ b/client/src/containers/Settings/Settings.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import Joi from 'joi-browser';
 import Form from '../../components/Form/Form';
 import Header from '../Header';
-import {getUIOptions, setUIOptions} from "../../utils/localstorage";
+import {getUIOptions, setUIOptions} from '../../utils/localstorage';
 import './styles.scss';
-import {toast} from "react-toastify";
+import {toast} from 'react-toastify';
 
 class Settings extends Form {
   state = {
@@ -12,6 +12,7 @@ class Settings extends Form {
     formData: {
       topicDefaultView: '',
       topicDataSort: '',
+      topicDataDateFormat: '',
       skipConsumerGroups: false,
       skipLastRecord: false,
       showAllConsumerGroups: true
@@ -22,10 +23,12 @@ class Settings extends Form {
   topicDefaultView = [ { _id: 'ALL', name: 'ALL' }, { _id: 'HIDE_INTERNAL', name: 'HIDE_INTERNAL' },
     { _id: 'HIDE_INTERNAL_STREAM', name: 'HIDE_INTERNAL_STREAM' }, { _id: 'HIDE_STREAM', name: 'HIDE_STREAM' } ];
   topicDataSort = [ { _id: 'OLDEST', name: 'OLDEST' }, { _id: 'NEWEST', name: 'NEWEST' } ];
+  topicDataDateFormat = [ { _id: 'RELATIVE', name: 'RELATIVE' }, { _id: 'ISO', name: 'ISO' } ];
 
   schema = {
     topicDefaultView: Joi.string().optional(),
     topicDataSort: Joi.string().optional(),
+    topicDataDateFormat: Joi.string().required(),
     skipConsumerGroups: Joi.boolean().optional(),
     skipLastRecord: Joi.boolean().optional(),
     showAllConsumerGroups: Joi.boolean().optional()
@@ -39,6 +42,7 @@ class Settings extends Form {
     this.setState({ clusterId, formData: {
         topicDefaultView: (uiOptions && uiOptions.topic)? uiOptions.topic.defaultView : '',
         topicDataSort: (uiOptions && uiOptions.topicData)? uiOptions.topicData.sort : '',
+        topicDataDateFormat: (uiOptions && uiOptions.topicData)? uiOptions.topicData.dateFormat : '',
         skipConsumerGroups: (uiOptions && uiOptions.topic)? uiOptions.topic.skipConsumerGroups : false,
         skipLastRecord: (uiOptions && uiOptions.topic)? uiOptions.topic.skipLastRecord : false,
         showAllConsumerGroups: (uiOptions && uiOptions.topic)? uiOptions.topic.showAllConsumerGroups : false
@@ -64,7 +68,8 @@ class Settings extends Form {
             showAllConsumerGroups: formData.showAllConsumerGroups
           },
           topicData: {
-            sort: formData.topicDataSort
+            sort: formData.topicDataSort,
+            dateFormat: formData.topicDataDateFormat
           }
         });
     toast.success(`Settings for cluster '${clusterId}' updated successfully.`);
@@ -144,6 +149,20 @@ class Settings extends Form {
                 ({ currentTarget: input }) => {
                   const { formData } = this.state;
                   formData.topicDataSort = input.value;
+                  this.setState({formData});
+                },
+                'col-sm-10',
+                'select-wrapper settings-wrapper',
+                true,
+                { className: 'form-control' }
+            )}
+            {this.renderSelect(
+                'topicDataDateFormat',
+                'Date Format',
+                this.topicDataDateFormat,
+                ({ currentTarget: input }) => {
+                  const { formData } = this.state;
+                  formData.topicDataDateFormat = input.value;
                   this.setState({formData});
                 },
                 'col-sm-10',

--- a/client/src/containers/Settings/Settings.jsx
+++ b/client/src/containers/Settings/Settings.jsx
@@ -13,7 +13,7 @@ class Settings extends Form {
     formData: {
       topicDefaultView: '',
       topicDataSort: '',
-      topicDataDateFormat: '',
+      topicDataDateTimeFormat: '',
       skipConsumerGroups: false,
       skipLastRecord: false,
       showAllConsumerGroups: true
@@ -25,13 +25,13 @@ class Settings extends Form {
                         .map(([value]) => ({_id: value, name: value}));
   topicDataSort = Object.entries(SETTINGS_VALUES.TOPIC_DATA.SORT)
                         .map(([value]) => ({_id: value, name: value}));
-  topicDataDateFormat = Object.entries(SETTINGS_VALUES.TOPIC_DATA.DATE_FORMAT)
+  topicDataDateTimeFormat = Object.entries(SETTINGS_VALUES.TOPIC_DATA.DATE_TIME_FORMAT)
                         .map(([value]) => ({_id: value, name: value}));
 
   schema = {
     topicDefaultView: Joi.string().optional(),
     topicDataSort: Joi.string().optional(),
-    topicDataDateFormat: Joi.string().required(),
+    topicDataDateTimeFormat: Joi.string().required(),
     skipConsumerGroups: Joi.boolean().optional(),
     skipLastRecord: Joi.boolean().optional(),
     showAllConsumerGroups: Joi.boolean().optional()
@@ -45,7 +45,7 @@ class Settings extends Form {
     this.setState({ clusterId, formData: {
         topicDefaultView: (uiOptions && uiOptions.topic)? uiOptions.topic.defaultView : '',
         topicDataSort: (uiOptions && uiOptions.topicData)? uiOptions.topicData.sort : '',
-        topicDataDateFormat: (uiOptions && uiOptions.topicData)? uiOptions.topicData.dateFormat : '',
+        topicDataDateTimeFormat: (uiOptions && uiOptions.topicData)? uiOptions.topicData.dateTimeFormat : '',
         skipConsumerGroups: (uiOptions && uiOptions.topic)? uiOptions.topic.skipConsumerGroups : false,
         skipLastRecord: (uiOptions && uiOptions.topic)? uiOptions.topic.skipLastRecord : false,
         showAllConsumerGroups: (uiOptions && uiOptions.topic)? uiOptions.topic.showAllConsumerGroups : false
@@ -72,7 +72,7 @@ class Settings extends Form {
           },
           topicData: {
             sort: formData.topicDataSort,
-            dateFormat: formData.topicDataDateFormat
+            dateTimeFormat: formData.topicDataDateTimeFormat
           }
         });
     toast.success(`Settings for cluster '${clusterId}' updated successfully.`);
@@ -160,12 +160,12 @@ class Settings extends Form {
                 { className: 'form-control' }
             )}
             {this.renderSelect(
-                'topicDataDateFormat',
-                'Date Format',
-                this.topicDataDateFormat,
+                'topicDataDateTimeFormat',
+                'Time Format',
+                this.topicDataDateTimeFormat,
                 ({ currentTarget: input }) => {
                   const { formData } = this.state;
-                  formData.topicDataDateFormat = input.value;
+                  formData.topicDataDateTimeFormat = input.value;
                   this.setState({formData});
                 },
                 'col-sm-10',

--- a/client/src/containers/Tail/Tail.jsx
+++ b/client/src/containers/Tail/Tail.jsx
@@ -70,9 +70,11 @@ class Tail extends Root {
   initDateTimeFormat = async () => {
     const { clusterId } = this.props.match.params;
     const uiOptions = await getClusterUIOptions(clusterId)
-    this.setState(({
-      dateTimeFormat: uiOptions.topicData.dateTimeFormat
-    }));
+    if(uiOptions.topicData && uiOptions.topicData.dateTimeFormat) {
+      this.setState(({
+        dateTimeFormat: uiOptions.topicData.dateTimeFormat
+      }));
+    }
   }
 
   componentWillUnmount = () => {

--- a/client/src/containers/Tail/Tail.jsx
+++ b/client/src/containers/Tail/Tail.jsx
@@ -33,7 +33,7 @@ class Tail extends Root {
     maxRecords: 50,
     data: [],
     showFilters: '',
-    dateFormat: SETTINGS_VALUES.TOPIC_DATA.DATE_FORMAT.RELATIVE
+    dateTimeFormat: SETTINGS_VALUES.TOPIC_DATA.DATE_TIME_FORMAT.RELATIVE
   };
   eventSource;
 
@@ -64,14 +64,14 @@ class Tail extends Root {
       });
     }
 
-    this.initDateFormat();
+    this.initDateTimeFormat();
   }
 
-  initDateFormat = async () => {
+  initDateTimeFormat = async () => {
     const { clusterId } = this.props.match.params;
     const uiOptions = await getClusterUIOptions(clusterId)
     this.setState(({
-      dateFormat: uiOptions.topicData.dateFormat
+      dateTimeFormat: uiOptions.topicData.dateTimeFormat
     }));
   }
 
@@ -422,7 +422,7 @@ class Tail extends Root {
                     <div className="tail-headers">
                       <DateTime 
                         isoDateTimeString={obj.timestamp} 
-                        dateTimeFormat={this.state.dateFormat} 
+                        dateTimeFormat={this.state.dateTimeFormat}
                       />                
                     </div>
                   );

--- a/client/src/containers/Tail/Tail.jsx
+++ b/client/src/containers/Tail/Tail.jsx
@@ -3,14 +3,16 @@ import Dropdown from 'react-bootstrap/Dropdown';
 import _ from 'lodash';
 import Input from '../../components/Form/Input';
 import Header from '../Header';
-import {uriLiveTail, uriTopicsName} from '../../utils/endpoints';
+import { SETTINGS_VALUES } from '../../utils/constants';
+import { getClusterUIOptions } from '../../utils/functions';
+import { uriLiveTail, uriTopicsName } from '../../utils/endpoints';
 import Table from '../../components/Table';
 import AceEditor from 'react-ace';
 import 'ace-builds/webpack-resolver';
 import 'ace-builds/src-noconflict/mode-json';
 import 'ace-builds/src-noconflict/theme-merbivore_soft';
 import Root from '../../components/Root';
-import TimeAgo from 'react-timeago';
+import DateTime from '../../components/DateTime';
 
 const STATUS = {
   STOPPED: 'STOPPED',
@@ -30,7 +32,8 @@ class Tail extends Root {
     selectedStatus: 'STOPPED',
     maxRecords: 50,
     data: [],
-    showFilters: ''
+    showFilters: '',
+    dateFormat: SETTINGS_VALUES.TOPIC_DATA.DATE_FORMAT.RELATIVE
   };
   eventSource;
 
@@ -60,6 +63,16 @@ class Tail extends Root {
         }
       });
     }
+
+    this.initDateFormat();
+  }
+
+  initDateFormat = async () => {
+    const { clusterId } = this.props.match.params;
+    const uiOptions = await getClusterUIOptions(clusterId)
+    this.setState(({
+      dateFormat: uiOptions.topicData.dateFormat
+    }));
   }
 
   componentWillUnmount = () => {
@@ -405,7 +418,14 @@ class Tail extends Root {
                 colName: 'Date',
                 type: 'text',
                 cell: obj => {
-                  return (<div className="tail-headers"><TimeAgo date={Date.parse(obj.timestamp)} title={obj.timestamp}/></div>);
+                  return (
+                    <div className="tail-headers">
+                      <DateTime 
+                        isoDateTimeString={obj.timestamp} 
+                        dateTimeFormat={this.state.dateFormat} 
+                      />                
+                    </div>
+                  );
                 }
               },
               {

--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -67,7 +67,7 @@ class TopicData extends Root {
     percent: 0,
     loading: true,
     canDownload: false,
-    dateFormat: constants.SETTINGS_VALUES.TOPIC_DATA.DATE_FORMAT.RELATIVE
+    dateTimeFormat: constants.SETTINGS_VALUES.TOPIC_DATA.DATE_TIME_FORMAT.RELATIVE
   };
 
   searchFilterTypes = [
@@ -112,8 +112,8 @@ class TopicData extends Root {
           search: this._buildSearchFromQueryString(query),
           offsets: (query.get('offset'))? this._getOffsetsByOffset(query.get('partition'), query.get('offset')) :
               ((query.get('after'))? this._getOffsetsByAfterString(query.get('after')): this.state.offsets),
-          dateFormat: (uiOptions && uiOptions.topicData && uiOptions.topicData.dateFormat)?
-              uiOptions.topicData.dateFormat : constants.SETTINGS_VALUES.TOPIC_DATA.DATE_FORMAT.RELATIVE
+          dateTimeFormat: (uiOptions && uiOptions.topicData && uiOptions.topicData.dateTimeFormat)?
+              uiOptions.topicData.dateTimeFormat : constants.SETTINGS_VALUES.TOPIC_DATA.DATE_TIME_FORMAT.RELATIVE
         },
         () => {
             if(query.get('single') !== null) {
@@ -369,17 +369,17 @@ class TopicData extends Root {
     a.remove();
   }
 
-  async _handleOnDateFormatChanged(newDateFormat) {
+  async _handleOnDateTimeFormatChanged(newDateTimeFormat) {
     const { clusterId } = this.props.match.params;
     this.setState(({
-      dateFormat: newDateFormat
+      dateTimeFormat: newDateTimeFormat
     }));
     const currentUiOptions = await getClusterUIOptions(clusterId);
     const newUiOptions = {
       ...currentUiOptions,
       topicData: {
         ...(currentUiOptions.topicData),
-        dateFormat: newDateFormat
+        dateTimeFormat: newDateTimeFormat
       }
     }
     setUIOptions(clusterId, newUiOptions);
@@ -874,16 +874,20 @@ class TopicData extends Root {
                 <li>
                   <Dropdown>
                     <Dropdown.Toggle className="nav-link dropdown-toggle">
-                      <strong>Date Format:</strong> ({this.state.dateFormat})
+                      <strong>Time Format:</strong> ({this.state.dateTimeFormat})
                     </Dropdown.Toggle>
                     <Dropdown.Menu>
                       <Dropdown.Item onClick={() =>
-                          this._handleOnDateFormatChanged(constants.SETTINGS_VALUES.TOPIC_DATA.DATE_FORMAT.RELATIVE)
+                          this._handleOnDateTimeFormatChanged(
+                            constants.SETTINGS_VALUES.TOPIC_DATA.DATE_TIME_FORMAT.RELATIVE
+                          )
                         }>
                         Show relative time
                       </Dropdown.Item>
                       <Dropdown.Item onClick={() =>
-                          this._handleOnDateFormatChanged(constants.SETTINGS_VALUES.TOPIC_DATA.DATE_FORMAT.ISO)
+                          this._handleOnDateTimeFormatChanged(
+                            constants.SETTINGS_VALUES.TOPIC_DATA.DATE_TIME_FORMAT.ISO
+                          )
                         }>
                         Show ISO timestamp
                       </Dropdown.Item>
@@ -965,7 +969,10 @@ class TopicData extends Root {
                     colName: 'Date',
                     type: 'text',
                     cell: (obj, col) => {
-                      return <DateTime isoDateTimeString={obj[col.accessor]} dateTimeFormat={this.state.dateFormat} />;
+                      return <DateTime 
+                        isoDateTimeString={obj[col.accessor]} 
+                        dateTimeFormat={this.state.dateTimeFormat} 
+                      />;
                     }
                   },
                   {

--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -69,7 +69,7 @@ class TopicData extends Root {
     percent: 0,
     loading: true,
     canDownload: false,
-    dateFormat: 'RELATIVE'
+    dateFormat: constants.SETTINGS_VALUES.TOPIC_DATA.DATE_FORMAT.RELATIVE
   };
 
   searchFilterTypes = [
@@ -115,7 +115,7 @@ class TopicData extends Root {
           offsets: (query.get('offset'))? this._getOffsetsByOffset(query.get('partition'), query.get('offset')) :
               ((query.get('after'))? this._getOffsetsByAfterString(query.get('after')): this.state.offsets),
           dateFormat: (uiOptions && uiOptions.topicData && uiOptions.topicData.dateFormat)?
-              uiOptions.topicData.dateFormat : 'RELATIVE'
+              uiOptions.topicData.dateFormat : constants.SETTINGS_VALUES.TOPIC_DATA.DATE_FORMAT.RELATIVE
         },
         () => {
             if(query.get('single') !== null) {
@@ -863,10 +863,14 @@ class TopicData extends Root {
                       <strong>Date Format</strong>
                     </Dropdown.Toggle>
                     <Dropdown.Menu>
-                      <Dropdown.Item onClick={() => this._handleOnDateFormatChanged('RELATIVE')}>
+                      <Dropdown.Item onClick={() => 
+                          this._handleOnDateFormatChanged(constants.SETTINGS_VALUES.TOPIC_DATA.DATE_FORMAT.RELATIVE)
+                        }>
                         Show relative time
                       </Dropdown.Item>
-                      <Dropdown.Item onClick={() => this._handleOnDateFormatChanged('ISO')}>
+                      <Dropdown.Item onClick={() => 
+                          this._handleOnDateFormatChanged(constants.SETTINGS_VALUES.TOPIC_DATA.DATE_FORMAT.ISO)
+                        }>
                         Show ISO timestamp
                       </Dropdown.Item>
                     </Dropdown.Menu>
@@ -950,8 +954,17 @@ class TopicData extends Root {
                       const isoDate = obj[col.accessor]
                       const TimeAgoComp = <TimeAgo date={Date.parse(isoDate)} title={''}/>
                       return (
-                          <Tooltip arrow title={this.state.dateFormat === 'ISO' ? TimeAgoComp : isoDate} interactive>
-                            <span>{this.state.dateFormat === 'ISO' ?  isoDate : TimeAgoComp}</span>
+                          <Tooltip arrow title={
+                                this.state.dateFormat === constants.SETTINGS_VALUES.TOPIC_DATA.DATE_FORMAT.ISO ?
+                                  TimeAgoComp : 
+                                  isoDate
+                              } interactive>
+                            <span>{
+                                this.state.dateFormat === constants.SETTINGS_VALUES.TOPIC_DATA.DATE_FORMAT.ISO ?  
+                                  isoDate : 
+                                  TimeAgoComp
+                              }
+                            </span>
                           </Tooltip>
                       );
                     }

--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -844,10 +844,10 @@ class TopicData extends Root {
                       <strong>Date Format</strong>
                     </Dropdown.Toggle>
                     <Dropdown.Menu>
-                      <Dropdown.Item onClick={() => this.setState({showTimeAgo: true})}>
+                      <Dropdown.Item onClick={() => this.setState({showRelativeTimes: true})}>
                         Show relative time
                       </Dropdown.Item>
-                      <Dropdown.Item onClick={() => this.setState({showTimeAgo: false})}>
+                      <Dropdown.Item onClick={() => this.setState({showRelativeTimes: false})}>
                         Show ISO timestamp
                       </Dropdown.Item>
                     </Dropdown.Menu>

--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -26,13 +26,11 @@ import 'ace-builds/src-noconflict/theme-dracula';
 import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import Root from '../../../../components/Root';
+import DateTime from '../../../../components/DateTime';
 import { capitalizeTxt, getClusterUIOptions } from '../../../../utils/functions';
 import { setProduceToTopicValues, setUIOptions} from '../../../../utils/localstorage';
 import Select from '../../../../components/Form/Select';
-import TimeAgo from 'react-timeago'
 import JSONbig from 'json-bigint';
-
-import {Tooltip} from '@material-ui/core';
 
 class TopicData extends Root {
   state = {
@@ -876,7 +874,7 @@ class TopicData extends Root {
                 <li>
                   <Dropdown>
                     <Dropdown.Toggle className="nav-link dropdown-toggle">
-                      <strong>Date Format</strong>
+                      <strong>Date Format:</strong> ({this.state.dateFormat})
                     </Dropdown.Toggle>
                     <Dropdown.Menu>
                       <Dropdown.Item onClick={() =>
@@ -967,22 +965,7 @@ class TopicData extends Root {
                     colName: 'Date',
                     type: 'text',
                     cell: (obj, col) => {
-                      const isoDate = obj[col.accessor]
-                      const TimeAgoComp = <TimeAgo date={Date.parse(isoDate)} title={''}/>
-                      return (
-                          <Tooltip arrow title={
-                                this.state.dateFormat === constants.SETTINGS_VALUES.TOPIC_DATA.DATE_FORMAT.ISO ?
-                                  TimeAgoComp :
-                                  isoDate
-                              } interactive>
-                            <span>{
-                                this.state.dateFormat === constants.SETTINGS_VALUES.TOPIC_DATA.DATE_FORMAT.ISO ?
-                                  isoDate :
-                                  TimeAgoComp
-                              }
-                            </span>
-                          </Tooltip>
-                      );
+                      return <DateTime isoDateTimeString={obj[col.accessor]} dateTimeFormat={this.state.dateFormat} />;
                     }
                   },
                   {

--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -31,6 +31,8 @@ import Select from '../../../../components/Form/Select';
 import TimeAgo from 'react-timeago'
 import JSONbig from 'json-bigint';
 
+import {Tooltip} from '@material-ui/core';
+
 class TopicData extends Root {
   state = {
     sortBy: 'Oldest',
@@ -65,7 +67,8 @@ class TopicData extends Root {
     canDeleteRecords: false,
     percent: 0,
     loading: true,
-    canDownload: false
+    canDownload: false,
+    showRelativeTimes: true
   };
 
   searchFilterTypes = [
@@ -835,6 +838,21 @@ class TopicData extends Root {
                     )}
                   </Dropdown>
                 </li>
+                <li>
+                  <Dropdown>
+                    <Dropdown.Toggle className="nav-link dropdown-toggle">
+                      <strong>Date Format</strong>
+                    </Dropdown.Toggle>
+                    <Dropdown.Menu>
+                      <Dropdown.Item onClick={() => this.setState({showTimeAgo: true})}>
+                        Show relative time
+                      </Dropdown.Item>
+                      <Dropdown.Item onClick={() => this.setState({showTimeAgo: false})}>
+                        Show ISO timestamp
+                      </Dropdown.Item>
+                    </Dropdown.Menu>
+                  </Dropdown>
+                </li>
               </ul>
             </div>
           </nav>
@@ -910,7 +928,13 @@ class TopicData extends Root {
                     colName: 'Date',
                     type: 'text',
                     cell: (obj, col) => {
-                      return (<TimeAgo date={Date.parse(obj[col.accessor])} title={obj[col.accessor]}/>);
+                      const isoDate = obj[col.accessor]
+                      const TimeAgoComp = <TimeAgo date={Date.parse(isoDate)} title={""}/>
+                      return (
+                          <Tooltip arrow title={!this.state.showRelativeTimes ? TimeAgoComp : isoDate} interactive>
+                            <span>{this.state.showRelativeTimes ? TimeAgoComp : isoDate}</span>
+                          </Tooltip>
+                      );
                     }
                   },
                   {

--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -100,8 +100,8 @@ class TopicData extends Root {
     const query =  new URLSearchParams(this.props.location.search);
     const uiOptions = await getClusterUIOptions(clusterId);
 
-    this.setState(
-        {
+    this.setState((prevState) =>
+        ({
           selectedCluster: clusterId,
           selectedTopic: topicId,
           sortBy: (query.get('sort'))? query.get('sort') : (uiOptions && uiOptions.topicData && uiOptions.topicData.sort)?
@@ -113,8 +113,8 @@ class TopicData extends Root {
           offsets: (query.get('offset'))? this._getOffsetsByOffset(query.get('partition'), query.get('offset')) :
               ((query.get('after'))? this._getOffsetsByAfterString(query.get('after')): this.state.offsets),
           dateTimeFormat: (uiOptions && uiOptions.topicData && uiOptions.topicData.dateTimeFormat)?
-              uiOptions.topicData.dateTimeFormat : constants.SETTINGS_VALUES.TOPIC_DATA.DATE_TIME_FORMAT.RELATIVE
-        },
+              uiOptions.topicData.dateTimeFormat : prevState.dateTimeFormat
+        }),
         () => {
             if(query.get('single') !== null) {
               this._getSingleMessage(query.get('partition'), query.get('offset'));

--- a/client/src/containers/Topic/TopicList/TopicList.jsx
+++ b/client/src/containers/Topic/TopicList/TopicList.jsx
@@ -13,9 +13,9 @@ import {toast} from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import {Collapse} from 'react-bootstrap';
 import Root from '../../../components/Root';
+import DateTime from '../../../components/DateTime';
 import {getClusterUIOptions} from '../../../utils/functions';
 import {handlePageChange, getPageNumber} from './../../../utils/pagination';
-import TimeAgo from 'react-timeago';
 
 class TopicList extends Root {
   state = {
@@ -47,7 +47,6 @@ class TopicList extends Root {
   };
 
   componentDidMount() {
-
    this._initializeVars(() => {
      this.getTopics();
      this.props.history.replace({
@@ -90,7 +89,13 @@ class TopicList extends Root {
       pageNumber = (query.get('page'))? parseInt(query.get('page')) : parseInt(pageNumber)
     }
 
-    this.setState({selectedCluster: clusterId, searchData: searchDataTmp, keepSearch: keepSearchTmp, uiOptions: (uiOptions)? uiOptions.topic : {}, pageNumber: pageNumber}, callBackFunction);
+    this.setState({
+      selectedCluster: clusterId, 
+      searchData: searchDataTmp,
+      keepSearch: keepSearchTmp,
+      uiOptions: uiOptions ?? {},
+      pageNumber: pageNumber
+    }, callBackFunction);
   }
 
   showDeleteModal = deleteMessage => {
@@ -173,6 +178,7 @@ class TopicList extends Root {
     const collapseConsumerGroups = {};
 
     const { selectedCluster, uiOptions } = this.state;
+    const uiOptionsTopic = uiOptions.topic ?? {};
 
     const setState = () =>  {
       this.setState({ topics: Object.values(tableTopics) });
@@ -191,14 +197,14 @@ class TopicList extends Root {
         groupComponent: undefined,
         internal: topic.internal
       }
-      collapseConsumerGroups[topic.name] = (uiOptions.showAllConsumerGroups)  ? true : false;
+      collapseConsumerGroups[topic.name] = (uiOptionsTopic.showAllConsumerGroups)  ? true : false;
     });
     this.setState({collapseConsumerGroups});
     setState()
 
     const topicsName = topics.map(topic => topic.name).join(",");
 
-    if(!uiOptions.skipConsumerGroups) {
+    if(!uiOptionsTopic.skipConsumerGroups) {
       this.getApi(uriConsumerGroupByTopics(selectedCluster, encodeURIComponent(topicsName)))
           .then(value => {
             topics.forEach(topic => {
@@ -210,7 +216,7 @@ class TopicList extends Root {
           });
     }
 
-    if(!uiOptions.skipLastRecord) {
+    if(!uiOptionsTopic.skipLastRecord) {
       this.getApi(uriTopicLastRecord(selectedCluster, encodeURIComponent(topicsName)))
           .then(value => {
             topics.forEach((topic) => {
@@ -274,8 +280,13 @@ class TopicList extends Root {
 
   render() {
     const { topics, selectedCluster, searchData, pageNumber, totalPageNumber, loading, collapseConsumerGroups, keepSearch, uiOptions } = this.state;
+    const uiOptionsTopic = uiOptions.topic ?? {};
+    const dateFormat = uiOptions.topicData ? 
+      uiOptions.topicData.dateFormat : 
+      constants.SETTINGS_VALUES.TOPIC_DATA.DATE_FORMAT.RELATIVE;
     const roles = this.state.roles || {};
     const { clusterId } = this.props.match.params;
+    
 
     const topicCols =
         [
@@ -302,14 +313,14 @@ class TopicList extends Root {
           }
         ];
 
-    if(!uiOptions.skipLastRecord) {
+    if(!uiOptionsTopic.skipLastRecord) {
         topicCols.push({
           id: 'lastWrite',
           accessor: 'lastWrite',
           colName: 'Last Record',
           type: 'text',
           cell: (obj, col) => {
-            return <TimeAgo date={Date.parse(obj[col.accessor])} title={obj[col.accessor]}/>;
+            return <DateTime isoDateTimeString={obj[col.accessor]} dateTimeFormat={dateFormat} />;
           }
         });
     }
@@ -388,7 +399,7 @@ class TopicList extends Root {
       {colName: 'Replications', colSpan: replicationCols.length}
     ];
 
-    if(!uiOptions.skipConsumerGroups) {
+    if(!uiOptionsTopic.skipConsumerGroups) {
       firstColumns.push({colName: 'Consumer Groups', colSpan: 1});
     }
 
@@ -441,7 +452,7 @@ class TopicList extends Root {
           history={this.props.history}
           has2Headers
           firstHeader={firstColumns}
-          columns={topicCols.concat(partitionCols, replicationCols, (uiOptions.skipConsumerGroups)?[]: consumerGprCols)}
+          columns={topicCols.concat(partitionCols, replicationCols, (uiOptionsTopic.skipConsumerGroups)?[]: consumerGprCols)}
           data={topics}
           updateData={data => {
             this.setState({ topics: data });

--- a/client/src/containers/Topic/TopicList/TopicList.jsx
+++ b/client/src/containers/Topic/TopicList/TopicList.jsx
@@ -13,9 +13,9 @@ import {toast} from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import {Collapse} from 'react-bootstrap';
 import Root from '../../../components/Root';
-import {getClusterUIOptions} from "../../../utils/functions";
-import {handlePageChange, getPageNumber} from "./../../../utils/pagination"
-import TimeAgo from "react-timeago";
+import {getClusterUIOptions} from '../../../utils/functions';
+import {handlePageChange, getPageNumber} from './../../../utils/pagination';
+import TimeAgo from 'react-timeago';
 
 class TopicList extends Root {
   state = {
@@ -29,7 +29,7 @@ class TopicList extends Root {
     totalPageNumber: 1,
     searchData: {
       search: '',
-      topicListView: 'HIDE_INTERNAL'
+      topicListView: constants.SETTINGS_VALUES.TOPIC.TOPIC_DEFAULT_VIEW.HIDE_INTERNAL
     },
     keepSearch: false,
     createTopicFormData: {

--- a/client/src/containers/Topic/TopicList/TopicList.jsx
+++ b/client/src/containers/Topic/TopicList/TopicList.jsx
@@ -281,9 +281,9 @@ class TopicList extends Root {
   render() {
     const { topics, selectedCluster, searchData, pageNumber, totalPageNumber, loading, collapseConsumerGroups, keepSearch, uiOptions } = this.state;
     const uiOptionsTopic = uiOptions.topic ?? {};
-    const dateFormat = uiOptions.topicData ? 
-      uiOptions.topicData.dateFormat : 
-      constants.SETTINGS_VALUES.TOPIC_DATA.DATE_FORMAT.RELATIVE;
+    const dateTimeFormat = uiOptions.topicData ?
+      uiOptions.topicData.dateTimeFormat :
+      constants.SETTINGS_VALUES.TOPIC_DATA.DATE_TIME_FORMAT.RELATIVE;
     const roles = this.state.roles || {};
     const { clusterId } = this.props.match.params;
     
@@ -320,7 +320,9 @@ class TopicList extends Root {
           colName: 'Last Record',
           type: 'text',
           cell: (obj, col) => {
-            return <DateTime isoDateTimeString={obj[col.accessor]} dateTimeFormat={dateFormat} />;
+            return obj[col.accessor] ?
+              <DateTime isoDateTimeString={obj[col.accessor]} dateTimeFormat={dateTimeFormat} /> :
+              '';
           }
         });
     }

--- a/client/src/containers/Topic/TopicList/TopicList.jsx
+++ b/client/src/containers/Topic/TopicList/TopicList.jsx
@@ -281,7 +281,7 @@ class TopicList extends Root {
   render() {
     const { topics, selectedCluster, searchData, pageNumber, totalPageNumber, loading, collapseConsumerGroups, keepSearch, uiOptions } = this.state;
     const uiOptionsTopic = uiOptions.topic ?? {};
-    const dateTimeFormat = uiOptions.topicData ?
+    const dateTimeFormat = uiOptions.topicData && uiOptions.topicData.dateTimeFormat ?
       uiOptions.topicData.dateTimeFormat :
       constants.SETTINGS_VALUES.TOPIC_DATA.DATE_TIME_FORMAT.RELATIVE;
     const roles = this.state.roles || {};

--- a/client/src/utils/constants.js
+++ b/client/src/utils/constants.js
@@ -53,7 +53,7 @@ export const SETTINGS_VALUES = {
       OLDEST: 'OLDEST',
       NEWEST: 'NEWEST',
     },
-    DATE_FORMAT: {
+    DATE_TIME_FORMAT: {
       RELATIVE: 'RELATIVE',
       ISO: 'ISO',
     }

--- a/client/src/utils/constants.js
+++ b/client/src/utils/constants.js
@@ -36,12 +36,28 @@ export const ACLS = 'acls';
 export const SCHEMA = 'schema';
 export const CONNECT = 'connect';
 export const SETTINGS = 'settings';
-export const TOPICS = {
-  ALL: 'ALL',
-  HIDE_INTERNAL: 'HIDE_INTERNAL',
-  HIDE_INTERNAL_STREAM: 'HIDE_INTERNAL_STREAM',
-  HIDE_STREAM: 'HIDE_STREAM'
-};
+
+// Configurable settings
+export const SETTINGS_VALUES = {
+  TOPIC: {
+    TOPIC_DEFAULT_VIEW: {
+      ALL: 'ALL',
+      HIDE_INTERNAL: 'HIDE_INTERNAL',
+      HIDE_INTERNAL_STREAM: 'HIDE_INTERNAL_STREAM',
+      HIDE_STREAM: 'HIDE_STREAM'
+    }
+  },
+  TOPIC_DATA: {
+    SORT: {
+      OLDEST: 'OLDEST',
+      NEWEST: 'NEWEST',
+    },
+    DATE_FORMAT: {
+      RELATIVE: 'RELATIVE',
+      ISO: 'ISO',
+    }
+  }
+}
 
 export const TYPES = {
   STRING: 'STRING',
@@ -71,7 +87,6 @@ export default {
   NODE,
   TOPIC,
   TAIL,
-  TOPICS,
   GROUP,
   ACLS,
   SCHEMA,
@@ -79,7 +94,8 @@ export default {
   TYPES,
   ROLE_TYPE,
   VERSION,
-  SETTINGS
+  SETTINGS,
+  SETTINGS_VALUES
 };
 
 export const sortBy = (field, reverse, primer) => {

--- a/src/main/java/org/akhq/configs/Connection.java
+++ b/src/main/java/org/akhq/configs/Connection.java
@@ -79,7 +79,8 @@ public class Connection extends AbstractProperties {
         );
 
         options.topicData = new UiOptionsTopicData(
-            StringUtils.isNotEmpty(this.uiOptions.topicData.getSort()) ? this.uiOptions.topicData.getSort() : defaultOptions.getTopicData().getSort()
+            StringUtils.isNotEmpty(this.uiOptions.topicData.getSort()) ? this.uiOptions.topicData.getSort() : defaultOptions.getTopicData().getSort(),
+            this.uiOptions.topicData.getDateFormat()
         );
 
         return options;

--- a/src/main/java/org/akhq/configs/Connection.java
+++ b/src/main/java/org/akhq/configs/Connection.java
@@ -80,7 +80,7 @@ public class Connection extends AbstractProperties {
 
         options.topicData = new UiOptionsTopicData(
             StringUtils.isNotEmpty(this.uiOptions.topicData.getSort()) ? this.uiOptions.topicData.getSort() : defaultOptions.getTopicData().getSort(),
-            this.uiOptions.topicData.getDateFormat()
+            this.uiOptions.topicData.getDateTimeFormat()
         );
 
         return options;

--- a/src/main/java/org/akhq/configs/DateFormat.java
+++ b/src/main/java/org/akhq/configs/DateFormat.java
@@ -1,0 +1,7 @@
+package org.akhq.configs;
+
+public enum DateFormat {
+
+    RELATIVE, ISO
+
+}

--- a/src/main/java/org/akhq/configs/DateTimeFormat.java
+++ b/src/main/java/org/akhq/configs/DateTimeFormat.java
@@ -1,6 +1,6 @@
 package org.akhq.configs;
 
-public enum DateFormat {
+public enum DateTimeFormat {
 
     RELATIVE, ISO
 

--- a/src/main/java/org/akhq/configs/UiOptionsTopicData.java
+++ b/src/main/java/org/akhq/configs/UiOptionsTopicData.java
@@ -4,12 +4,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import static org.akhq.configs.DateFormat.RELATIVE;
+import static org.akhq.configs.DateTimeFormat.RELATIVE;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class UiOptionsTopicData {
     private String sort;
-    private DateFormat dateFormat = RELATIVE;
+    private DateTimeFormat dateTimeFormat = RELATIVE;
 }

--- a/src/main/java/org/akhq/configs/UiOptionsTopicData.java
+++ b/src/main/java/org/akhq/configs/UiOptionsTopicData.java
@@ -4,9 +4,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import static org.akhq.configs.DateFormat.RELATIVE;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class UiOptionsTopicData {
     private String sort;
+    private DateFormat dateFormat = RELATIVE;
 }


### PR DESCRIPTION
Fixes the current behavior of not being able to select the ISO date displayed in the tooltips of the TopicData table (see comment below). 

Also added a dropdown to switch between displaying relative times via `react-timeago` or plain ISO dates. The tooltip remains, but switches to either option.

fixes #938 