### PR TITLE
feat: Produce to topic from existing message

### DIFF
--- a/client/src/components/Table/Table.jsx
+++ b/client/src/components/Table/Table.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import * as constants from '../../utils/constants';
 import './styles.scss';
 import Spinner from '../Spinner';
-import {Link} from "react-router-dom";
+import {Link} from 'react-router-dom';
 
 class Table extends Component {
   state = {
@@ -288,7 +288,7 @@ class Table extends Component {
   }
 
   renderActions(row) {
-    const { actions, onAdd, onDetails, onConfig, onDelete, onEdit, onRestart, onShare, onDownload, idCol } = this.props;
+    const { actions, onAdd, onDetails, onConfig, onDelete, onEdit, onRestart, onShare, onDownload, onCopy, idCol } = this.props;
 
     let idColVal = idCol ? row[this.props.idCol] : row.id;
 
@@ -361,6 +361,18 @@ class Table extends Component {
               <i className="fa fa-refresh" />
             </span>
           </td>
+        )}
+        {actions.find(el => el === constants.TABLE_COPY) && (
+            <td className="khq-row-action khq-row-action-main action-hover">
+            <span title="Copy"
+                  id="copy"
+                  onClick={() => {
+                    onCopy && onCopy(row);
+                  }}
+            >
+              <i className="fa fa-clone" />
+            </span>
+            </td>
         )}
         {actions.find(el => el === constants.TABLE_SHARE) && (
             <td className="khq-row-action khq-row-action-main action-hover">
@@ -488,9 +500,17 @@ Table.propTypes = {
     })
   ),
   actions: PropTypes.array,
+
+  onAdd: PropTypes.func,
   onDetails: PropTypes.func,
   onConfig: PropTypes.func,
   onDelete: PropTypes.func,
+  onEdit: PropTypes.func,
+  onRestart: PropTypes.func,
+  onShare: PropTypes.func,
+  onDownload: PropTypes.func,
+  onCopy: PropTypes.func,
+
   idCol: PropTypes.string,
   toPresent: PropTypes.array,
   noContent: PropTypes.any,

--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -17,6 +17,7 @@ import moment from 'moment';
 import DatePicker from '../../../../components/DatePicker';
 import _ from 'lodash';
 import constants from '../../../../utils/constants';
+import { setProduceToTopicValues } from '../../../../utils/localstorage';
 import AceEditor from 'react-ace';
 import ConfirmModal from '../../../../components/Modal/ConfirmModal';
 
@@ -26,7 +27,7 @@ import 'ace-builds/src-noconflict/theme-dracula';
 import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import Root from '../../../../components/Root';
-import {capitalizeTxt, getClusterUIOptions} from '../../../../utils/functions';
+import { capitalizeTxt, getClusterUIOptions } from '../../../../utils/functions';
 import Select from '../../../../components/Form/Select';
 import TimeAgo from 'react-timeago'
 import JSONbig from 'json-bigint';
@@ -365,6 +366,21 @@ class TopicData extends Root {
     a.remove();
   }
 
+  _handleCopy(row) {
+    const data =  {
+      partition: row.partition,
+      key: row.key,
+      header: row.headers,
+      keySchemaId: row.schema.key,
+      valueSchemaId: row.schema.value,
+      value: row.value,
+    }
+    setProduceToTopicValues(data)
+
+    const { clusterId, topicId } = this.props.match.params;
+    this.props.history.push(`/ui/${clusterId}/topic/${topicId}/produce`)
+  }
+
   _showDeleteModal = deleteMessage => {
     this.setState({ showDeleteModal: true, deleteMessage });
   };
@@ -664,7 +680,8 @@ class TopicData extends Root {
       loading
     } = this.state;
 
-    let actions = canDeleteRecords ? [constants.TABLE_DELETE, constants.TABLE_SHARE] : [constants.TABLE_SHARE]
+    let actions = [constants.TABLE_SHARE, constants.TABLE_COPY]
+    if (canDeleteRecords) actions.push(constants.TABLE_DELETE)
     if (canDownload) actions.push(constants.TABLE_DOWNLOAD)
 
     let date = moment(datetime);
@@ -989,6 +1006,9 @@ class TopicData extends Root {
                 }}
                 onDownload={row => {
                   this._handleDownload(row);
+                }}
+                onCopy={row => {
+                  this._handleCopy(row)
                 }}
                 actions={actions}
                 onExpand={obj => {

--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -413,10 +413,10 @@ class TopicData extends Root {
     let tableMessages = append ? this.state.messages : [];
     messages.forEach(message => {
       let messageToPush = {
-        key: message.key || 'null',
+        key: message.key || '',
         value: message.truncated
-          ? message.value + '...\nToo large message. Full body in share button.'  || 'null'
-          : message.value || 'null',
+          ? message.value + '...\nToo large message. Full body in share button.'  || ''
+          : message.value || '',
         timestamp: message.timestamp,
         partition: JSON.stringify(message.partition) || '',
         offset: JSON.stringify(message.offset) || '',
@@ -896,7 +896,7 @@ class TopicData extends Root {
                               mode="json"
                               id={'value' + index}
                               theme="merbivore_soft"
-                              value={value}
+                              value={value || 'null'}
                               readOnly
                               name="UNIQUE_ID_OF_DIV"
                               editorProps={{ $blockScrolling: true }}
@@ -915,7 +915,7 @@ class TopicData extends Root {
                                 </div>
                             )}
                             <pre className="mb-0 khq-data-highlight">
-                              <code>{obj.value}</code>
+                              <code>{obj.value || 'null'}</code>
                             </pre>
                           </div>
                       );

--- a/client/src/utils/constants.js
+++ b/client/src/utils/constants.js
@@ -24,7 +24,8 @@ export const TABLE_DETAILS = 'details';
 export const TABLE_CONFIG = 'config';
 export const TABLE_RESTART = 'restart';
 export const TABLE_SHARE = 'share';
-export const TABLE_DOWNLOAD = 'download'
+export const TABLE_DOWNLOAD = 'download';
+export const TABLE_COPY = 'copy';
 
 // Tab names/route names
 export const CLUSTER = 'cluster';
@@ -66,6 +67,7 @@ export default {
   TABLE_CONFIG,
   TABLE_RESTART,
   TABLE_SHARE,
+  TABLE_COPY,
   TABLE_DOWNLOAD,
   CLUSTER,
   NODE,

--- a/client/src/utils/localstorage.d.ts
+++ b/client/src/utils/localstorage.d.ts
@@ -1,0 +1,16 @@
+type TopicEventHeaders = {
+    [key: string]: string
+}
+
+interface TopicEvent {
+    partition: number,
+    key: string,
+    header: TopicEventHeaders,
+    keySchemaId: string,
+    valueSchemaId: string,
+    value: object
+}
+
+
+declare const popProduceToTopicValues: () => TopicEvent | {};
+declare const setProduceToTopicValues: (event: TopicEvent) => void;

--- a/client/src/utils/localstorage.js
+++ b/client/src/utils/localstorage.js
@@ -1,25 +1,34 @@
-
 export const getUIOptions = (cluster) => {
-    const uiOptions = localStorage.getItem('uiOptions');
-    if(uiOptions !== null) {
-        const objParsed = JSON.parse(uiOptions);
-        return objParsed[cluster];
-    } else {
-        return null;
-    }
+  const uiOptions = localStorage.getItem('uiOptions');
+  if (uiOptions !== null) {
+    const objParsed = JSON.parse(uiOptions);
+    return objParsed[cluster];
+  } else {
+    return null;
+  }
 }
 
 export const setUIOptions = (cluster, newUIOptions) => {
 
-    const uiOptions = localStorage.getItem('uiOptions');
-    if(uiOptions !== null) {
-        const objParsed = JSON.parse(uiOptions);
-        objParsed[cluster] = newUIOptions;
-        localStorage.setItem('uiOptions', JSON.stringify(objParsed));
-    } else {
-        localStorage.setItem('uiOptions', JSON.stringify({ [cluster] : newUIOptions}));
-    }
+  const uiOptions = localStorage.getItem('uiOptions');
+  if (uiOptions !== null) {
+    const objParsed = JSON.parse(uiOptions);
+    objParsed[cluster] = newUIOptions;
+    localStorage.setItem('uiOptions', JSON.stringify(objParsed));
+  } else {
+    localStorage.setItem('uiOptions', JSON.stringify({[cluster]: newUIOptions}));
+  }
 
+}
+
+export const popProduceToTopicValues = () => {
+  const produceToTopicValues = localStorage.getItem('produceToTopicValues');
+  localStorage.removeItem('produceToTopicValues');
+  return produceToTopicValues !== null ? JSON.parse(produceToTopicValues) : {};
+}
+
+export const setProduceToTopicValues = (newProduceToTopicValues) => {
+  localStorage.setItem('produceToTopicValues', JSON.stringify(newProduceToTopicValues));
 }
 
 


### PR DESCRIPTION
Adds copy button to kafka message in TopicData view, which allows to reproduce the message to the same or any other topic of the cluster.

Does implement the initial ask of #579 .
Does not implement the enhancement as suggested by @AtulKhanduri.