### PR TITLE
feat: Delete all offsets of a consumer group from a topic

### DIFF
--- a/client/src/containers/ConsumerGroup/ConsumerGroupDetail/ConsumerGroup.jsx
+++ b/client/src/containers/ConsumerGroup/ConsumerGroupDetail/ConsumerGroup.jsx
@@ -123,14 +123,26 @@ class ConsumerGroup extends Component {
           </div>
         </div>
 
-        {roles.group && roles.group['group/offsets/update'] && (
+        {roles.group && (roles.group['group/offsets/delete'] || roles.group['group/offsets/update']) && (
           <aside>
-            <Link
-              to={`/ui/${clusterId}/group/${consumerGroupId}/offsets`}
-              className="btn btn-primary"
-            >
-              Update Offsets
-            </Link>
+            <li className="aside-button">
+              {roles.group['group/offsets/delete'] && (
+                <Link
+                  to={`/ui/${clusterId}/group/${consumerGroupId}/offsetsdelete`}
+                  className="btn btn-secondary mr-2"
+                >
+                  Delete Offsets
+                </Link>
+              )}
+              {roles.group['group/offsets/update'] && (
+                <Link
+                  to={`/ui/${clusterId}/group/${consumerGroupId}/offsets`}
+                  className="btn btn-primary"
+                >
+                  Update Offsets
+                </Link>
+              )}
+            </li>
           </aside>
         )}
       </div>

--- a/client/src/containers/ConsumerGroup/ConsumerGroupDetail/ConsumerGroupOffsetDelete/ConsumerGroupOffsetDelete.jsx
+++ b/client/src/containers/ConsumerGroup/ConsumerGroupDetail/ConsumerGroupOffsetDelete/ConsumerGroupOffsetDelete.jsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import Header from '../../../Header/Header';
+import {
+  uriConsumerGroup, uriDeleteGroupOffsets,
+} from '../../../../utils/endpoints';
+import 'react-toastify/dist/ReactToastify.css';
+import Root from "../../../../components/Root";
+import Table from "../../../../components/Table";
+import constants from "../../../../utils/constants";
+import ConfirmModal from "../../../../components/Modal/ConfirmModal";
+import {toast} from "react-toastify";
+
+class ConsumerGroupOffsetDelete extends Root {
+  state = {
+    clusterId: '',
+    consumerGroupId: '',
+    topicIds: [],
+    deleteAllOffsetsForTopic: '',
+    showDeleteModal: false,
+    deleteMessage: '',
+  };
+
+  componentDidMount() {
+    const {clusterId, consumerGroupId} = this.props.match.params;
+
+    this.setState({clusterId, consumerGroupId}, () => {
+      this.getTopics();
+    });
+  }
+
+  async getTopics() {
+    const { clusterId, consumerGroupId } = this.state;
+
+    let data;
+    data = await this.getApi(uriConsumerGroup(clusterId, consumerGroupId));
+    data = data.data;
+
+    if (data && data.topics) {
+      this.setState({ topicIds: data.topics.map(topic => ({ topic })) });
+    } else {
+      this.setState({ topicIds: [] });
+    }
+  }
+
+  showDeleteModal = deleteMessage => {
+    this.setState({ showDeleteModal: true, deleteMessage });
+  };
+
+  closeDeleteModal = () => {
+    this.setState({ showDeleteModal: false, deleteMessage: '', deleteAllOffsetsForTopic: '' });
+  };
+
+  deleteOffsets = () => {
+    const { clusterId, consumerGroupId, deleteAllOffsetsForTopic } = this.state;
+    this.removeApi(uriDeleteGroupOffsets(clusterId, consumerGroupId, deleteAllOffsetsForTopic))
+      .then(() => {
+        toast.success(`Offsets for topic '${deleteAllOffsetsForTopic}' and consumer group '${consumerGroupId}' are deleted`);
+        this.setState({ showDeleteModal: false, deleteMessage: '', deleteAllOffsetsForTopic: '' }, () => {
+          this.getTopics();
+        });
+      })
+      .catch(() => {
+        this.setState({ showDeleteModal: false, deleteMessage: '', deleteAllOffsetsForTopic: '' });
+      });
+  }
+
+  handleOnDelete(topicId) {
+    this.setState({ deleteAllOffsetsForTopic: topicId }, () => {
+      this.showDeleteModal(
+        <React.Fragment>
+          Do you want to delete all offsets of topic: {<code>{topicId}</code>} ?
+        </React.Fragment>
+      );
+    });
+  }
+
+  render() {
+    const {consumerGroupId} = this.state;
+
+    return (
+      <div>
+        <div>
+          <Header title={`Delete offsets: ${consumerGroupId}`}
+                  history={this.props.history}/>
+        </div>
+        <div>
+          <Table
+            history={this.props.history}
+            columns={[
+              {
+                id: 'topic',
+                accessor: 'topic',
+                colName: 'Topic',
+                type: 'text',
+                sortable: true
+              },
+            ]}
+            data={this.state.topicIds}
+            noContent={
+              <tr>
+                <td colSpan={3}>
+                  <div className="alert alert-warning mb-0" role="alert">
+                    No offsets found.
+                  </div>
+                </td>
+              </tr>
+            }
+            onDelete={(row) => {
+              this.handleOnDelete(row.topic)
+            }}
+            actions={
+              [constants.TABLE_DELETE]
+            }
+          />
+        </div>
+        <ConfirmModal
+          show={this.state.showDeleteModal}
+          handleCancel={this.closeDeleteModal}
+          handleConfirm={this.deleteOffsets}
+          message={this.state.deleteMessage}
+        />
+      </div>
+    );
+  }
+}
+
+export default ConsumerGroupOffsetDelete;

--- a/client/src/containers/ConsumerGroup/ConsumerGroupDetail/ConsumerGroupOffsetDelete/index.js
+++ b/client/src/containers/ConsumerGroup/ConsumerGroupDetail/ConsumerGroupOffsetDelete/index.js
@@ -1,0 +1,3 @@
+import ConsumerGroupOffsetDelete from './ConsumerGroupOffsetDelete';
+
+export default ConsumerGroupOffsetDelete;

--- a/client/src/utils/Routes.js
+++ b/client/src/utils/Routes.js
@@ -21,6 +21,7 @@ import Schema from '../containers/Schema/SchemaDetail/Schema';
 import SchemaList from '../containers/Schema/SchemaList/SchemaList';
 import SchemaCreate from '../containers/Schema/SchemaCreate/SchemaCreate';
 import ConsumerGroupUpdate from '../containers/ConsumerGroup/ConsumerGroupDetail/ConsumerGroupUpdate';
+import ConsumerGroupOffsetDelete from '../containers/ConsumerGroup/ConsumerGroupDetail/ConsumerGroupOffsetDelete';
 import AclDetails from '../containers/Acl/AclDetail';
 import Login from '../containers/Login';
 import Settings from '../containers/Settings/Settings';
@@ -183,6 +184,14 @@ class Routes extends Root {
 
               {roles && roles.group && roles.group['group/read'] && (
                 <Route exact path="/ui/:clusterId/group" component={ConsumerGroupList} />
+              )}
+
+              {roles && roles.group && roles.group['group/offsets/delete'] && (
+                  <Route
+                      exact
+                      path="/ui/:clusterId/group/:consumerGroupId/offsetsdelete"
+                      component={ConsumerGroupOffsetDelete}
+                  />
               )}
 
               {roles && roles.group && roles.group['group/offsets/update'] && (

--- a/client/src/utils/endpoints.js
+++ b/client/src/utils/endpoints.js
@@ -256,6 +256,10 @@ export const uriConsumerGroupUpdate = (clusterId, groupId) => {
   return `${apiUrl}/${clusterId}/group/${groupId}/offsets`;
 };
 
+export const uriDeleteGroupOffsets = (clusterId, groupId, topicName) => {
+  return `${apiUrl}/${clusterId}/group/${groupId}/topic/${topicName}`;
+};
+
 export const uriAclsList = (clusterId, search) => {
   let url = `${apiUrl}/${clusterId}/acls`;
   return search ? `${url}?search=${search}` : url;
@@ -343,5 +347,6 @@ export default {
   uriAclsByPrincipal,
   uriLiveTail,
   uriTopicDataSearch,
-  uriTopicDataDelete
+  uriTopicDataDelete,
+  uriDeleteGroupOffsets
 };

--- a/src/main/java/org/akhq/configs/Role.java
+++ b/src/main/java/org/akhq/configs/Role.java
@@ -16,6 +16,7 @@ public class Role {
     public static final String ROLE_GROUP_READ = "group/read";
     public static final String ROLE_GROUP_DELETE = "group/delete";
     public static final String ROLE_GROUP_OFFSETS_UPDATE = "group/offsets/update";
+    public static final String ROLE_GROUP_OFFSETS_DELETE = "group/offsets/delete";
 
     public static final String ROLE_ACLS_READ = "acls/read";
 

--- a/src/main/java/org/akhq/controllers/GroupController.java
+++ b/src/main/java/org/akhq/controllers/GroupController.java
@@ -155,6 +155,14 @@ public class GroupController extends AbstractController {
         return HttpResponse.noContent();
     }
 
+    @Secured(Role.ROLE_GROUP_OFFSETS_DELETE)
+    @Delete("{groupName}/topic/{topicName}")
+    @Operation(tags = {"consumer group"}, summary = "Delete group offsets of given topic")
+    public HttpResponse<?> deleteConsumerGroupOffsets(String cluster, String groupName, String topicName) throws ExecutionException {
+        this.kafkaWrapper.deleteConsumerGroupOffsets(cluster, groupName, topicName);
+        return HttpResponse.noContent();
+    }
+
     @NoArgsConstructor
     @AllArgsConstructor
     @Getter

--- a/src/main/java/org/akhq/modules/AbstractKafkaWrapper.java
+++ b/src/main/java/org/akhq/modules/AbstractKafkaWrapper.java
@@ -368,4 +368,23 @@ abstract public class AbstractKafkaWrapper {
 
         return describeAcls.get(clusterId).get(filter);
     }
+
+    public void deleteConsumerGroupOffsets(String clusterId, String groupName, String topicName)
+        throws ExecutionException {
+        final Map<String, TopicDescription> topics = describeTopics(clusterId, List.of(topicName));
+        if (topics.containsKey(topicName)) {
+            final TopicDescription topic = topics.get(topicName);
+            final Set<TopicPartition> topicPartitions = topic.partitions().stream()
+                .map(p -> new TopicPartition(topicName, p.partition()))
+                .collect(toSet());
+
+            Logger.call(kafkaModule
+                    .getAdminClient(clusterId)
+                    .deleteConsumerGroupOffsets(groupName, topicPartitions)
+                    .all(),
+                "Delete consumer group offsets from topic {}",
+                List.of(groupName, topicName)
+            );
+        }
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -145,6 +145,7 @@ akhq:
         - group/read
         - group/delete
         - group/offsets/update
+        - group/offsets/delete
         - registry/read
         - registry/insert
         - registry/update


### PR DESCRIPTION
Adds a 'Delete offsets' button to the 'ConsumerGroup' view which brings you to a new 'ConsumerGroupOffsetDelete' view that lists all topics of the consumer group in a table with a 'Delete' action button per row.

Adds a new endpoint to the backend to delete all offsets of one consumer group from one topic by using `deleteConsumerGroupOffsets(String groupId, Set<TopicPartition> partitions)` of the Kafka `AdminClient`.

Implements #790 