### PR TITLE
feat(ui): Format offset lag with toLocaleString

### DIFF
--- a/client/src/containers/ConsumerGroup/ConsumerGroupDetail/ConsumerGroupTopics/ConsumerGroupTopics.jsx
+++ b/client/src/containers/ConsumerGroup/ConsumerGroupDetail/ConsumerGroupTopics/ConsumerGroupTopics.jsx
@@ -39,7 +39,7 @@ class ConsumerGroupTopics extends Root {
   }
 
   handleOptional(optional) {
-    if (optional !== undefined && optional !== '') {
+    if (optional !== undefined && optional !== '' && optional !== 'NaN') {
       return <label>{optional}</label>;
     } else {
       return <label>-</label>;
@@ -115,7 +115,7 @@ class ConsumerGroupTopics extends Root {
               colName: 'Lag',
               type: 'text',
               cell: obj => {
-                return this.handleOptional(obj.lag);
+                return this.handleOptional(Number(obj.lag).toLocaleString());
               }
             }
           ]}

--- a/client/src/containers/ConsumerGroup/ConsumerGroupList/ConsumerGroupList.jsx
+++ b/client/src/containers/ConsumerGroup/ConsumerGroupList/ConsumerGroupList.jsx
@@ -127,7 +127,7 @@ class ConsumerGroupList extends Root {
         >
           {topicId + ' '}
 
-          <div className="badge badge-secondary">Lag: {offsetLag}</div>
+          <div className="badge badge-secondary">Lag: {Number(offsetLag).toLocaleString()}</div>
         </Link>
       );
     });

--- a/client/src/containers/Node/NodeDetail/NodeLogs/NodeLogs.jsx
+++ b/client/src/containers/Node/NodeDetail/NodeLogs/NodeLogs.jsx
@@ -36,7 +36,7 @@ class NodeLogs extends Root {
         topic: log.topic,
         partition: log.partition,
         size: showBytes(log.size),
-        offsetLag: log.offsetLag
+        offsetLag: Number(log.offsetLag).toLocaleString()
       };
     });
     this.setState({ data: tableNodes, loading: false });

--- a/client/src/containers/Topic/Topic/TopicGroups/TopicGroups.jsx
+++ b/client/src/containers/Topic/Topic/TopicGroups/TopicGroups.jsx
@@ -76,7 +76,7 @@ class TopicGroups extends Root {
           onClick={noPropagation}
         >
           {topic}
-          <div className="badge badge-secondary">Lag: {topics[topic]}</div>
+          <div className="badge badge-secondary">Lag: {Number(topics[topic]).toLocaleString()}</div>
         </Link>
       );
     });

--- a/client/src/containers/Topic/Topic/TopicLogs/TopicLogs.jsx
+++ b/client/src/containers/Topic/Topic/TopicLogs/TopicLogs.jsx
@@ -30,7 +30,7 @@ class TopicLogs extends Root {
         topic: log.topic,
         partition: log.partition,
         size: log.size,
-        offsetLag: log.offsetLag
+        offsetLag: Number(log.offsetLag).toLocaleString()
       };
     });
     this.setState({ data: tableLogs, loading: false });

--- a/client/src/containers/Topic/TopicList/TopicList.jsx
+++ b/client/src/containers/Topic/TopicList/TopicList.jsx
@@ -243,7 +243,7 @@ class TopicList extends Root {
               className={className}
               onClick={noPropagation}
             >
-              {consumerGroup.id} <div className="badge badge-secondary"> Lag: {offsetLag}</div>
+              {consumerGroup.id} <div className="badge badge-secondary"> Lag: {Number(offsetLag).toLocaleString()}</div>
             </Link>
           );
       });


### PR DESCRIPTION
When displaying the lag of a topic for a consumer group, the lag is formatted using `toLocateString()`
Especially when a high lag is present, it is easier to determine whether it is i.e. 10,000 or rather 1,000,000.

Documentation:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString

Example:
![image](https://user-images.githubusercontent.com/7568775/159141811-687d729b-58bd-47e0-82e2-c6c2f608dd2c.png)

Closes #911 
