### PR TITLE
Close consumer when returning null after calculating offset for newes…

### DIFF
--- a/src/main/java/org/akhq/repositories/RecordRepository.java
+++ b/src/main/java/org/akhq/repositories/RecordRepository.java
@@ -396,6 +396,7 @@ public class RecordRepository extends AbstractRepository {
                 }
 
                 if (last == partition.getFirstOffset() || last < 0) {
+                    consumer.close();
                     return null;
                 } else if (!(last - pollSizePerPartition < first)) {
                     first = last - pollSizePerPartition;


### PR DESCRIPTION
…t sort

Closes consumer when returning null for getOffsetForSortNewest method.

There are chances of too many open files exception if a significant number of partitions are empty