### PR TITLE
Upload Connector Config

### DIFF
--- a/client/src/containers/Connect/ConnectCreate/ConnectCreate.jsx
+++ b/client/src/containers/Connect/ConnectCreate/ConnectCreate.jsx
@@ -438,6 +438,25 @@ class ConnectCreate extends Root {
     reader.readAsText(value.target.files[0]);
   };
 
+  handleDownload = value => {
+    const { formData } = this.state;
+    let filename = formData['subject'] + ".json";
+    let filtered = {};
+    for (let d in formData){ if (formData[d] != '' && formData[d] != null) { filtered[d] = formData[d] }}
+    let text = JSON.stringify({
+      "name": formData['subject'],
+      "config": filtered
+    })
+
+    var element = document.createElement('a');
+    element.setAttribute('href', 'data:application/json;charset=utf-8,' + encodeURIComponent(text));
+    element.setAttribute('download', filename);
+    element.style.display = 'none';
+    document.body.appendChild(element);
+    element.click();
+    document.body.removeChild(element);
+  }
+
   render() {
     const { formData, selectedType } = this.state;
     const { history } = this.props;
@@ -501,6 +520,7 @@ class ConnectCreate extends Root {
             <aside>
               <input type="file" id="fileElem" onChange={value => {this.onFileUpload(value)}} accept=".json" style={{display:'none'}}></input>
               <button type="button" id="uploadButton" onClick={this.handleFileUpload} className='btn btn-warning'>Upload</button>
+              <button type="button" id="downloadButton" onClick={this.handleDownload} className='btn btn-danger'>Download</button>
               <button type={'submit'} className="btn btn-primary" disabled={this.validate()}>
                 Create
               </button>

--- a/client/src/containers/Connect/ConnectCreate/ConnectCreate.jsx
+++ b/client/src/containers/Connect/ConnectCreate/ConnectCreate.jsx
@@ -58,7 +58,7 @@ class ConnectCreate extends Root {
     let formData = {};
     formData.type = this.state.selectedType;
     this.schema['type'] = Joi.string().required();
-    formData.subject = '';
+    // formData.subject = '';
     this.schema['subject'] = Joi.string().required();
     definitions.forEach(definition => {
       let config = this.handleDefinition(definition);
@@ -414,6 +414,28 @@ class ConnectCreate extends Root {
       });
   }
 
+  handleFileUpload(){
+    let fileElem = document.getElementById("fileElem");
+    if (fileElem) {
+      fileElem.click();
+    }
+  }
+
+  onFileUpload = value => {
+    const reader = new FileReader();
+    const self = this;
+    reader.onload = function(evt) {
+      let connector = JSON.parse(evt.target.result.replaceAll('\r\n', ''));
+      connector.config.subject = connector.name;
+      connector.config.type = connector.config['connector.class'];
+      window.connector = connector;
+      self.setState({ selectedType: connector.config['connector.class'], formData: connector.config }, () => {
+        self.renderForm();
+      });  
+    };
+    reader.readAsText(value.target.files[0]);
+  };
+
   render() {
     const { formData, selectedType } = this.state;
     const { history } = this.props;
@@ -479,6 +501,8 @@ class ConnectCreate extends Root {
             </React.Fragment>
           )}
         </form>
+        <input type="file" id="fileElem" onChange={value => {this.onFileUpload(value)}} accept=".json" style={{display:'none'}}></input>
+        <button type="button" id="uploadButton" onClick={this.handleFileUpload} className='btn btn-warning'>Upload</button>
       </div>
     );
   }

--- a/client/src/containers/Connect/ConnectCreate/styles.scss
+++ b/client/src/containers/Connect/ConnectCreate/styles.scss
@@ -14,6 +14,7 @@
   margin-left: 1%;
 }
 
-#uploadButton {
+#uploadButton, #downloadButton {
   margin-right: 10px;
 }
+

--- a/client/src/containers/Connect/ConnectCreate/styles.scss
+++ b/client/src/containers/Connect/ConnectCreate/styles.scss
@@ -13,3 +13,7 @@
 .fa.fa-info.text-warning{
   margin-left: 1%;
 }
+
+#uploadButton {
+  margin-right: 10px;
+}

--- a/client/src/containers/Connect/ConnectDetail/ConnectConfigs/ConnectConfigs.jsx
+++ b/client/src/containers/Connect/ConnectDetail/ConnectConfigs/ConnectConfigs.jsx
@@ -369,6 +369,25 @@ class ConnectConfigs extends Form {
     toast.success(`${`Definition '${formData.name}' is updated`}`);
   }
 
+  handleDownload = value => {
+    const { formData } = this.state;
+    let filename = formData['name'] + ".json";
+    let filtered = {};
+    for (let d in formData){ if (formData[d] != '' && formData[d] != null) { filtered[d] = formData[d] }}
+    let text = JSON.stringify({
+      "name": formData['name'],
+      "config": filtered
+    })
+
+    var element = document.createElement('a');
+    element.setAttribute('href', 'data:application/json;charset=utf-8,' + encodeURIComponent(text));
+    element.setAttribute('download', filename);
+    element.style.display = 'none';
+    document.body.appendChild(element);
+    element.click();
+    document.body.removeChild(element);
+  }
+
   render() {
     const { plugin, display } = this.state;
     const { name } = this.state.formData;
@@ -416,6 +435,14 @@ class ConnectConfigs extends Form {
               </div>
               {roles.connect && roles.connect['connect/update'] && (
                 <div style={{ left: 0, width: '100%' }} className="khq-submit">
+                  <button
+                    type="button"
+                    className="btn btn-danger"
+                    style={{ marginRight: '10px' }}
+                    onClick={this.handleDownload}
+                  >
+                    Download
+                  </button>
                   <button
                     type={'submit'}
                     className="btn btn-primary"


### PR DESCRIPTION
Adds button and file input to the Connect Create page so that a user can optionally upload a connector file (from JSON) and have the form data auto populate.

Changes made:
- Added [hidden] file input (outside of form) on ConnectCreate page
- Added "Upload" button (outside of form) with function `handleFileUpload` to click the file input
- Added function for handling file selection `onFileUpload`, which reads/parses a JSON file and sets state based on the contents.
- Removed line that was automatically resetting the subject name.