### PR TITLE
feat(helm): added jwt secret auto gen (#1062)

### DIFF
--- a/helm/akhq/templates/deployment.yaml
+++ b/helm/akhq/templates/deployment.yaml
@@ -64,6 +64,22 @@ spec:
             {{ toYaml .Values.containerSecurityContext | nindent 12 }}
           {{- end }}
           env:
+            {{- /* check for user defined settings of the Micronaut JWT generator secret environment variable */}}
+            {{- $jwtSecretEnvExists := "" -}}
+            {{- range $env := .Values.extraEnv }}
+              {{- if eq $env.name "MICRONAUT_SECURITY_TOKEN_JWT_SIGNATURES_SECRET_GENERATOR_SECRET" }}
+            {{- $jwtSecretEnvExists = "yes" -}}
+              {{- end }}
+            {{- end }}
+            {{- /* only add auto generated JWT secret if no explicit user settings has been defined */}}
+            {{- if not $jwtSecretEnvExists }}
+            - name: MICRONAUT_SECURITY_TOKEN_JWT_SIGNATURES_SECRET_GENERATOR_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "akhq.fullname" . }}-secrets
+                  key: jwtSignatureGeneratorSecret
+                  optional: false
+            {{- end }}
             {{- if .Values.extraEnv }}{{ toYaml .Values.extraEnv | trim | nindent 12 }}{{ end }}
             {{- if or (.Values.existingSecrets) (.Values.secrets) }}
             - name: MICRONAUT_ENVIRONMENTS

--- a/helm/akhq/templates/secret.yaml
+++ b/helm/akhq/templates/secret.yaml
@@ -1,8 +1,9 @@
-{{- if and ( not .Values.existingSecrets) (.Values.secrets) }}
+{{- $secretName:= print (include "akhq.fullname" .) "-secrets" -}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "akhq.fullname" . }}-secrets
+  name: {{ $secretName | toString }}
   labels:
     app.kubernetes.io/name: {{ include "akhq.name" . }}
     helm.sh/chart: {{ include "akhq.chart" . }}
@@ -10,10 +11,16 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
+{{- if and ( not .Values.existingSecrets) (.Values.secrets) }}
   application-secrets.yml: {{ toYaml .Values.secrets | b64enc | quote }}
   {{- if .Values.kafkaSecrets }}
   {{- range $key, $value := .Values.kafkaSecrets }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
   {{- end }}
-  {{- end }}
+{{- end }}
+{{- if (($secret.data).generatorSecret) }}
+  jwtSignatureGeneratorSecret: {{ $secret.data.generatorSecret }}
+{{- else }}
+  jwtSignatureGeneratorSecret: {{ randAlphaNum 64 | b64enc }}
+{{- end }}


### PR DESCRIPTION
> Introduced a new auto generated secret key that will only be
> generated on first install called "jwtSignatureGeneratorSecret".
> The value of this secret key is added via an environment variable
> setting to the depoyment only if no user defined variable with
> the same name is found. This should avoid duplicate env var names
> that can cause trouble with subsequent changes to the deployment
> object.

I would like to get some feedback on the implementation design. I tried to introduce the new feature without breaking existing behavior.

Summary of changes:
- the `release-name-akhq-secrets` is now created always and the previous conditional is moved closer to the `application-secrets.yml` key
- a Helm lookup is used to only generate the secret once on first install and reuse it's value on subsequent upgrades. This should make it possible to slowly shift traffic between pods on e.g. upgrades as all instances use the same signature generator secret
- the deployment `env` section now incorporates a bunch of logic to check if a user as explicitly set the `MICRONAUT_SECURITY_TOKEN_JWT_SIGNATURES_SECRET_GENERATOR_SECRET` env var. In this case the auto generated value will not be used (however it will still be generated and written to the secret).

One point of uncertainty at this point is the question if we should include a general switch to completely disable this new feature. However with the default setting being active as the goal of #1062 is to make the chart secure per default.