### PR TITLE
Fix topic display error for MSK Serverless

### DIFF
--- a/src/main/java/org/akhq/modules/AbstractKafkaWrapper.java
+++ b/src/main/java/org/akhq/modules/AbstractKafkaWrapper.java
@@ -16,6 +16,7 @@ import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.SecurityDisabledException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
 
 import java.util.*;
 import java.util.concurrent.ExecutionException;
@@ -254,7 +255,7 @@ abstract public class AbstractKafkaWrapper {
                             .allDescriptions()
                             .get();
                     } catch (ExecutionException e) {
-                        if (e.getCause() instanceof ClusterAuthorizationException || e.getCause() instanceof TopicAuthorizationException) {
+                        if (e.getCause() instanceof ClusterAuthorizationException || e.getCause() instanceof TopicAuthorizationException || e.getCause() instanceof UnsupportedVersionException) {
                             return new HashMap<>();
                         }
 


### PR DESCRIPTION

The API support status of MSK Serverless can be checked as follows

```
$ ./kafka-broker-api-versions.sh --bootstrap-server $BS --command-config client.properties
*************.amazonaws.com:9098 (id: 153 rack: null) -> (
        Produce(0): 7 to 9 [usable: 9],
        Fetch(1): 10 to 12 [usable: 12],
        ListOffsets(2): 5 to 6 [usable: 6],
        Metadata(3): 7 to 11 [usable: 11],
        LeaderAndIsr(4): UNSUPPORTED,
        StopReplica(5): UNSUPPORTED,
        UpdateMetadata(6): UNSUPPORTED,
        ControlledShutdown(7): UNSUPPORTED,
        OffsetCommit(8): 6 to 8 [usable: 8],
        OffsetFetch(9): 5 to 7 [usable: 7],
        FindCoordinator(10): 2 to 3 [usable: 3],
        JoinGroup(11): 4 to 7 [usable: 7],
        Heartbeat(12): 2 to 4 [usable: 4],
        LeaveGroup(13): 2 to 4 [usable: 4],
        SyncGroup(14): 2 to 5 [usable: 5],
        DescribeGroups(15): 2 to 5 [usable: 5],
        ListGroups(16): 2 to 4 [usable: 4],
        SaslHandshake(17): 1 [usable: 1],
        ApiVersions(18): 2 to 3 [usable: 3],
        CreateTopics(19): 3 to 7 [usable: 7],
        DeleteTopics(20): 3 to 6 [usable: 6],
        DeleteRecords(21): UNSUPPORTED,
        InitProducerId(22): 1 to 4 [usable: 4],
        OffsetForLeaderEpoch(23): 2 to 4 [usable: 4],
        AddPartitionsToTxn(24): 1 to 3 [usable: 3],
        AddOffsetsToTxn(25): 1 to 3 [usable: 3],
        EndTxn(26): 1 to 3 [usable: 3],
        WriteTxnMarkers(27): 0 to 1 [usable: 1],
        TxnOffsetCommit(28): 2 to 3 [usable: 3],
        DescribeAcls(29): UNSUPPORTED,
        CreateAcls(30): UNSUPPORTED,
        DeleteAcls(31): UNSUPPORTED,
        DescribeConfigs(32): 2 to 4 [usable: 4],
        AlterConfigs(33): 1 to 2 [usable: 2],
        AlterReplicaLogDirs(34): UNSUPPORTED,
        DescribeLogDirs(35): UNSUPPORTED,
        SaslAuthenticate(36): 1 to 2 [usable: 2],
        CreatePartitions(37): 1 to 3 [usable: 3],
        CreateDelegationToken(38): UNSUPPORTED,
        RenewDelegationToken(39): UNSUPPORTED,
        ExpireDelegationToken(40): UNSUPPORTED,
        DescribeDelegationToken(41): UNSUPPORTED,
        DeleteGroups(42): 1 to 2 [usable: 2],
        ElectLeaders(43): UNSUPPORTED,
        IncrementalAlterConfigs(44): 0 to 1 [usable: 1],
        AlterPartitionReassignments(45): UNSUPPORTED,
        ListPartitionReassignments(46): 0 [usable: 0],
        OffsetDelete(47): 0 [usable: 0],
        DescribeClientQuotas(48): UNSUPPORTED,
        AlterClientQuotas(49): UNSUPPORTED,
        DescribeUserScramCredentials(50): UNSUPPORTED,
        AlterUserScramCredentials(51): UNSUPPORTED,
        AlterIsr(56): UNSUPPORTED,
        UpdateFeatures(57): UNSUPPORTED,
        DescribeCluster(60): 0 [usable: 0],
        DescribeProducers(61): UNSUPPORTED
)
```

DescribeLogDirs(35): UNSUPPORTED but
Topic display is not required to be interrupted, so empty data is returned when UnsupportedVersionException is raised

That will allow Topic display.


![image](https://user-images.githubusercontent.com/79543/172104132-d453aebd-30d1-4169-9f4a-400508d5e404.png)




Implements #1112 
