### PR TITLE
Adding serializer for protobuf schema registry

### DIFF
--- a/src/main/java/org/akhq/modules/schemaregistry/ProtobufSerializer.java
+++ b/src/main/java/org/akhq/modules/schemaregistry/ProtobufSerializer.java
@@ -1,0 +1,72 @@
+package org.akhq.modules.schemaregistry;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+import org.akhq.configs.SchemaRegistryType;
+
+import com.google.protobuf.util.JsonFormat;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+@Singleton
+@Slf4j
+public class ProtobufSerializer implements SchemaSerializer {
+    private static final int idSize = 4;
+    private final int schemaId;
+    private final ProtobufSchema protobufSchema;
+    private final SchemaRegistryType schemaRegistryType;
+
+    public static boolean supports(ParsedSchema parsedSchema) {
+        return Objects.equals(ProtobufSchema.TYPE, parsedSchema.schemaType());
+    }
+
+    public static ProtobufSerializer newInstance(int schemaId, ParsedSchema parsedSchema, SchemaRegistryType schemaRegistryType) {
+        if (supports(parsedSchema)) {
+            return new ProtobufSerializer(schemaId, (ProtobufSchema) parsedSchema, schemaRegistryType);
+        } else {
+            String errorMsg = String
+                .format("Schema %s has not supported schema type expected %s but found %s", parsedSchema.name(), ProtobufSchema.TYPE,
+                    parsedSchema.schemaType());
+            throw new IllegalArgumentException(errorMsg);
+        }
+    }
+
+    @Override
+    public byte[] serialize(String json) {
+        try {
+            return this.fromJsonToProtobuf(json.trim(), protobufSchema, schemaId);
+        } catch (IOException e) {
+            log.error("Cannot serialize value", e);
+            throw new RuntimeException("Cannot serialize value", e);
+        }
+    }
+
+    private byte[] fromJsonToProtobuf(String json, ProtobufSchema schema, int schemaId) throws IOException {
+        log.trace("encoding message {} with schema {} and id {}", json, schema, schemaId);
+        final com.google.protobuf.DynamicMessage.Builder messageBuilder = schema.newMessageBuilder();
+        JsonFormat.parser().merge(json, messageBuilder);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        outputStream.write(schemaRegistryType.getMagicByte());
+        outputStream.write(ByteBuffer.allocate(idSize).putInt(schemaId).array());
+        // zero index https://stackoverflow.com/questions/64820256/kafka-protobuf-console-consumer-serialization-exception
+        outputStream.write((byte) 0x0);
+        outputStream.write(messageBuilder.build().toByteArray());
+        outputStream.flush();
+        outputStream.close();
+
+        return outputStream.toByteArray();
+    }
+
+    private ProtobufSerializer(int schemaId, ProtobufSchema protobufSchema, SchemaRegistryType schemaRegistryType) {
+        this.schemaId = schemaId;
+        this.protobufSchema = protobufSchema;
+        this.schemaRegistryType = schemaRegistryType;
+    }
+}

--- a/src/main/java/org/akhq/modules/schemaregistry/RecordWithSchemaSerializerFactory.java
+++ b/src/main/java/org/akhq/modules/schemaregistry/RecordWithSchemaSerializerFactory.java
@@ -1,16 +1,17 @@
 package org.akhq.modules.schemaregistry;
 
-import io.confluent.kafka.schemaregistry.ParsedSchema;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.io.IOException;
+
 import org.akhq.configs.Connection;
 import org.akhq.configs.SchemaRegistryType;
 import org.akhq.modules.KafkaModule;
 
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import jakarta.inject.Singleton;
-import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Singleton
 @RequiredArgsConstructor
@@ -29,6 +30,8 @@ public class RecordWithSchemaSerializerFactory {
             return JsonSchemaSerializer.newInstance(schemaId, parsedSchema, schemaRegistryType);
         } if (AvroSerializer.supports(parsedSchema)) {
             return AvroSerializer.newInstance(schemaId, parsedSchema, schemaRegistryType);
+        } if (ProtobufSerializer.supports(parsedSchema)) {
+            return ProtobufSerializer.newInstance(schemaId, parsedSchema, schemaRegistryType);
         } else {
             String errorMsg = String.format("Schema with id %d has unsupported schema type %s", schemaId, parsedSchema.schemaType());
             throw new IllegalStateException(errorMsg);


### PR DESCRIPTION
Adding a Serializer for Protobuf Schema Registry, so it's possible to edit and send messages via UI.

The Serializer has been tested on Confluent Kafka 7:
  confluentinc/cp-zookeeper:7.0.0
  confluentinc/cp-enterprise-kafka:7.0.0
  confluentinc/cp-schema-registry:7.0.0

and Java Spring Boot application as Consumer. 

After sending the sent message is immediately and correctly rendered in UI with correct schemaId

