### PR TITLE
Allow integer/long to be serialized as float/double when using AVRO schema.

### DIFF
--- a/src/main/java/org/akhq/utils/AvroSerializer.java
+++ b/src/main/java/org/akhq/utils/AvroSerializer.java
@@ -123,13 +123,23 @@ public class AvroSerializer {
                 case INT:
                     return value;
                 case LONG:
-                    if (value != null && value instanceof Integer) {
+                   if (value instanceof Integer) {
                         return ((Integer) value).longValue();
                     }
                     return value;
                 case FLOAT:
+                    if (value instanceof Integer) {
+                        return ((Integer) value).floatValue();
+                    } else if (value instanceof Long) {
+                        return ((Long) value).floatValue();
+                    }
                     return value;
                 case DOUBLE:
+                    if (value instanceof Integer) {
+                        return ((Integer) value).doubleValue();
+                    } else if (value instanceof Long) {
+                        return ((Long) value).doubleValue();
+                    }
                     return value;
                 case BOOLEAN:
                     return value;


### PR DESCRIPTION
fixes https://github.com/tchiotludo/akhq/issues/1122