### PR TITLE
issue #1115 adding  Pattern Type to ACLs Panel Information

### DIFF
--- a/client/src/containers/Acl/AclDetail/AclClusters/AclClusters.jsx
+++ b/client/src/containers/Acl/AclDetail/AclClusters/AclClusters.jsx
@@ -30,7 +30,8 @@ class AclClusters extends Root {
   handleAcls = data => {
     const tableData = data.acls.map(acl => {
       return {
-        topic: acl.resource.name,
+        cluster: acl.resource.name,
+        patterntype: acl.resource.patternType,
         host: acl.host,
         permission: acl.operation
       };
@@ -56,9 +57,16 @@ class AclClusters extends Root {
         history={this.props.history}
         columns={[
           {
-            id: 'topic',
-            accessor: 'topic',
-            colName: 'Topic',
+            id: 'cluster',
+            accessor: 'cluster',
+            colName: 'Cluster',
+            type: 'text',
+            sortable: true
+          },
+          {
+            id: 'pattern-type',
+            accessor: 'patterntype',
+            colName: 'Pattern Type',
             type: 'text',
             sortable: true
           },

--- a/client/src/containers/Acl/AclDetail/AclGroups/AclGroups.jsx
+++ b/client/src/containers/Acl/AclDetail/AclGroups/AclGroups.jsx
@@ -31,6 +31,7 @@ class AclGroups extends Root {
     const tableData = data.acls.map(acl => {
       return {
         group: acl.resource.name,
+        patterntype: acl.resource.patternType,
         host: acl.host,
         permission: acl.operation
       };
@@ -59,6 +60,13 @@ class AclGroups extends Root {
             id: 'group',
             accessor: 'group',
             colName: 'Group',
+            type: 'text',
+            sortable: true
+          },
+          {
+            id: 'pattern-type',
+            accessor: 'patterntype',
+            colName: 'Pattern Type',
             type: 'text',
             sortable: true
           },

--- a/client/src/containers/Acl/AclDetail/AclTopics/AclTopics.jsx
+++ b/client/src/containers/Acl/AclDetail/AclTopics/AclTopics.jsx
@@ -31,6 +31,7 @@ class AclTopics extends Root {
     const tableData = data.acls.map(acl => {
       return {
         topic: acl.resource.name,
+        patterntype: acl.resource.patternType,
         host: acl.host,
         permission: acl.operation
       };
@@ -59,6 +60,13 @@ class AclTopics extends Root {
             id: 'topic',
             accessor: 'topic',
             colName: 'Topic',
+            type: 'text',
+            sortable: true
+          },
+          {
+            id: 'pattern-type',
+            accessor: 'patterntype',
+            colName: 'Pattern Type',
             type: 'text',
             sortable: true
           },

--- a/client/src/containers/Acl/AclDetail/AclTransactionalIds/AclTransactionalIds.jsx
+++ b/client/src/containers/Acl/AclDetail/AclTransactionalIds/AclTransactionalIds.jsx
@@ -30,7 +30,8 @@ class AclTransactionalIds extends Root {
   handleAcls = data => {
     const tableData = data.acls.map(acl => {
       return {
-        topic: acl.resource.name,
+        transactionalId: acl.resource.name,
+        patterntype: acl.resource.patternType,
         host: acl.host,
         permission: acl.operation
       };
@@ -56,9 +57,16 @@ class AclTransactionalIds extends Root {
         history={this.props.history}
         columns={[
           {
-            id: 'topic',
-            accessor: 'topic',
-            colName: 'Topic',
+            id: 'transactionalId',
+            accessor: 'transactionalId',
+            colName: 'Transactional Id',
+            type: 'text',
+            sortable: true
+          },
+          {
+            id: 'pattern-type',
+            accessor: 'patterntype',
+            colName: 'Pattern Type',
             type: 'text',
             sortable: true
           },


### PR DESCRIPTION
@tchiotludo

The Pattern Types are show on ACLs Panel Information for: Topics, Groups, Clusters and Transactional IDs. Please see the attached screenshot. 

![acl-pt](https://user-images.githubusercontent.com/102477169/174877435-203c5c94-cc62-4620-8270-6533b5bfc251.png)
