### PR TITLE
fix(docker): Run upgrade in order to reduce CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM openjdk:11-jre-slim
 RUN apt-get update && \
     apt-get install -y \
       curl && \
+    apt-get upgrade -y &&\ 
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 


### PR DESCRIPTION
Add apt-get upgrade to Dockerfile, fix CVEs for : 

libssl1.1
dpkg
libldap-common

close #1132 