### PR TITLE
Added encoding and decoding to solve the UI crash when slash characters are used in consumer group names

### DIFF
--- a/client/src/containers/ConsumerGroup/ConsumerGroupDetail/ConsumerGroup.jsx
+++ b/client/src/containers/ConsumerGroup/ConsumerGroupDetail/ConsumerGroup.jsx
@@ -88,7 +88,7 @@ class ConsumerGroup extends Component {
     const roles = this.state.roles || {};
     return (
       <div>
-        <Header title={`Consumer Group: ${consumerGroupId}`} history={this.props.history} />
+        <Header title={`Consumer Group: ${decodeURIComponent(consumerGroupId)}`} history={this.props.history} />
         <div className="tabs-container">
           <ul className="nav nav-tabs" role="tablist">
             <li className="nav-item">

--- a/client/src/containers/ConsumerGroup/ConsumerGroupList/ConsumerGroupList.jsx
+++ b/client/src/containers/ConsumerGroup/ConsumerGroupList/ConsumerGroupList.jsx
@@ -154,7 +154,7 @@ class ConsumerGroupList extends Root {
   deleteConsumerGroup = () => {
     const { selectedCluster, groupToDelete } = this.state;
 
-    this.removeApi(uriConsumerGroupDelete(selectedCluster, groupToDelete.id))
+    this.removeApi(uriConsumerGroupDelete(selectedCluster, encodeURIComponent(groupToDelete.id)))
       .then(() => {
         toast.success(`Consumer Group '${groupToDelete.id}' is deleted`);
         this.setState({ showDeleteModal: false, groupToDelete: {} }, () => this.getConsumerGroup());
@@ -243,7 +243,7 @@ class ConsumerGroupList extends Root {
           onDelete={group => {
             this.handleOnDelete(group);
           }}
-          onDetails={id => `/ui/${selectedCluster}/group/${id}`}
+          onDetails={id => `/ui/${selectedCluster}/group/${encodeURIComponent(id)}`}
           actions={
             roles.group && roles.group['group/delete']
               ? [constants.TABLE_DELETE, constants.TABLE_DETAILS]

--- a/client/src/containers/Topic/TopicList/TopicList.jsx
+++ b/client/src/containers/Topic/TopicList/TopicList.jsx
@@ -261,7 +261,7 @@ class TopicList extends Root {
           return (
             <Link
               key={consumerGroup.id}
-              to={`/ui/${this.state.selectedCluster}/group/${consumerGroup.id}`}
+              to={`/ui/${this.state.selectedCluster}/group/${encodeURIComponent(consumerGroup.id)}`}
               className={className}
               onClick={noPropagation}
             >


### PR DESCRIPTION
Hello! Here is a solution that targets issue [#1101 ](https://github.com/tchiotludo/akhq/issues/1101)

- Adds URI encoding and decoding in the UI to solve the UI crash when slash characters are used in consumer group names.

Let me know if you got any questions or suggestions to improve my solution.