### PR TITLE
fix: Adding namespace to kubectl port-forward Helm Chart NOTES

### DIFF
--- a/helm/akhq/templates/NOTES.txt
+++ b/helm/akhq/templates/NOTES.txt
@@ -17,5 +17,5 @@
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "akhq.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:{{ .Values.service.port }}
+  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:{{ .Values.service.port }}
 {{- end }}


### PR DESCRIPTION
Helm Chart Template NOTES output is not informing the needed to pass the namespace while port forwarding.
![image](https://user-images.githubusercontent.com/17765109/184596615-983846a8-8a86-4f0a-a9ae-207590a25ec3.png)

If we do not pass the namespace it will trigger an error:
![image](https://user-images.githubusercontent.com/17765109/184596428-1051b68d-a7b6-4ab9-9513-66f26d13c710.png)
