### PR TITLE
fix(helm): correct port for port-forward is 8080

### DIFF
--- a/helm/akhq/templates/NOTES.txt
+++ b/helm/akhq/templates/NOTES.txt
@@ -17,5 +17,5 @@
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "akhq.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:{{ .Values.service.port }}
+  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:8080
 {{- end }}


### PR DESCRIPTION
Fix port displayed at the end of the helm release.

It displays `{{ .Values.service.port }}` which is `80` per default, it should be `8080`.