### PR TITLE
chore(docker): change upstream image from openjdk to eclipse-temurin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:11-jre
 
 # install curl
 RUN apt-get update && \
     apt-get install -y \
       curl && \
-    apt-get upgrade -y &&\ 
+    apt-get upgrade -y &&\
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 

--- a/docker/app/akhq
+++ b/docker/app/akhq
@@ -7,4 +7,4 @@ do
   JAVA_OPTS="${JAVA_OPTS} ${JVM_OPT}"
 done
 
-/usr/local/openjdk-11/bin/java ${JAVA_OPTS} -cp /app/akhq.jar:${CLASSPATH} org.akhq.App
+/opt/java/openjdk/bin/java ${JAVA_OPTS} -cp /app/akhq.jar:${CLASSPATH} org.akhq.App

--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -28,7 +28,7 @@ extraEnv: []
 #             properties:
 #               bootstrap.servers: "kafka:9092"
 # - name: JAVA_OPTS
-#   value: "-Djavax.net.ssl.trustStore=/usr/local/openjdk-11/lib/security/cacerts -Djavax.net.ssl.trustStorePassword=password"
+#   value: "-Djavax.net.ssl.trustStore=/opt/java/openjdk/lib/security/cacerts -Djavax.net.ssl.trustStorePassword=password"
 # - name: CLASSPATH
 #   value: "/any/additional/jars/desired.jar:/go/here.jar"
 
@@ -79,7 +79,7 @@ serviceAccount:
 # Add your own init container or uncomment and modify the example.
 initContainers: {}
 #   create-keystore:
-#     image: "openjdk:11-slim"
+#     image: "eclipse-temurin:11-jre"
 #     command: ['sh', '-c', 'keytool']
 #     volumeMounts:
 #      - mountPath: /tmp


### PR DESCRIPTION
Changes the upstream image from the used-to-be official OpenJDK image, which is now [deprecated](https://hub.docker.com/_/openjdk), to the Official Image for OpenJDK binaries built by Eclipse Temurin. Since this image is based on Ubuntu Jammy (most recent LTS version of Ubuntu), I would expect this to fix most of the OS vulns in the current image.

This is my first contribution to AKHQ, and I did not find docs for building the image locally. But I think I have done the required modifications and trust the CI to catch any leftovers.

Closes https://github.com/tchiotludo/akhq/issues/1157

I think this change should be highlighted in the next release notes. Changing both the Linux base image AND OpenJDK build might cause problems for some users - especially for those using custom PKI/certs settings. Note: openssl is also upgraded to version 3.x in Ubuntu Jammy.