### PR TITLE
UI - Faster topic-data search & sorting

### DIFF
--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -147,7 +147,7 @@ class TopicData extends Root {
     const percentUpdateDelta = 0.5;
 
     let self = this;
-    this.setState({ sortBy: 'Oldest', messages: [], pageNumber: 1, percent: 0, isSearching: true, recordCount: 0 }, () => {
+    this.setState({ messages: [], pageNumber: 1, percent: 0, isSearching: true, recordCount: 0 }, () => {
       const filters = this._buildFilters();
       if (changePage) {
         this._setUrlHistory(filters + '&after=' + nextPage );
@@ -170,7 +170,8 @@ class TopicData extends Root {
         }
 
         if(records.length) {
-          self._handleMessages(records, true);
+          const tableMessages = self._handleMessages(records, true, self.state.sortBy === "Oldest");
+          self.setState({messages: tableMessages});
         }
       });
 
@@ -440,8 +441,8 @@ class TopicData extends Root {
         });
   };
 
-  _handleMessages = (messages, append = false) => {
-    let tableMessages = append ? this.state.messages : [];
+  _handleMessages = (messages, append = false, insertAtEnd = true) => {
+    let tableMessages = append ? [...this.state.messages] : [];
     messages.forEach(message => {
       let messageToPush = {
         key: message.key || '',
@@ -455,7 +456,12 @@ class TopicData extends Root {
         schema: { key: message.keySchemaId, value: message.valueSchemaId },
         exceptions: message.exceptions || []
       };
-      tableMessages.push(messageToPush);
+
+      if (insertAtEnd) {
+        tableMessages.push(messageToPush);
+      } else {
+        tableMessages.unshift(messageToPush);
+      }
     });
     return tableMessages;
   };
@@ -1052,6 +1058,9 @@ class TopicData extends Root {
                 extraRow
                 noStripes
                 data={messages}
+                rowId={data => {
+                  return data.partition + '-' + data.offset;
+                }}
                 updateData={data => {
                   this.setState({ messages: data });
                 }}


### PR DESCRIPTION
This PR fixes a few UI issues in the topic-data view:
1. searching in large topics no longer freezes the entire tab
2. sorting by "Newest" works again (removed in #473)
3. correctly updating the table-row react state

---
Using the search on topics with many rows (e.g. one of our topics has ~5M entries @ 7GB) completely freezes the UI.
The search itself it really fast, however the HTTP result streams "percent" values with the current progress, this happens around once per ms.
The UI then tries to update in real-time and freezes, ironically also rendering the  "Stop" Button unusable.
With this PR it will only update in 0.5% increments.
While i didn't change the backend, it might be a good idea to check if it's possible to reduce the progress events to avoid unnecessary traffic.

---

Sorting by newest now works by assuming that sorting by oldest works, and inserting the data in the front instead.
The search itself will still scan the data from oldest to newest, but the data view will be sorted correctly.
To make this work, rows now have a custom ID instead of using the index.
This also fixes an unrelated issue where expanded messages will auto-expand messages with the same index when switching to the next page. 

---

The last issue was a small fix in the model update, which modified the state directly, now it's creating copies to do proper state updates.