### PR TITLE
Issue #1226 Fix NPE occurs when trying to view cluster information in MSK Serverless

### DIFF
--- a/client/src/containers/Node/NodeList/NodesList.jsx
+++ b/client/src/containers/Node/NodeList/NodesList.jsx
@@ -37,7 +37,7 @@ class NodesList extends Root {
         id: JSON.stringify(node.id) || '',
         host: `${node.host}:${node.port}` || '',
         rack: node.rack || '',
-        controller: nodes.controller.id === node.id ? 'True' : 'False' || '',
+        controller: nodes.controller && nodes.controller.id === node.id ? 'True' : 'False' || '',
         partition: undefined
       };
     });

--- a/src/main/java/org/akhq/models/Cluster.java
+++ b/src/main/java/org/akhq/models/Cluster.java
@@ -8,6 +8,7 @@ import org.apache.kafka.clients.admin.DescribeClusterResult;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 @ToString
@@ -25,6 +26,8 @@ public class Cluster {
             this.nodes.add(new Node(node));
         }
 
-        this.controller = new Node(result.controller().get());
+        Optional.ofNullable(result.controller().get()).ifPresentOrElse(
+            node -> this.controller = new Node(node),
+            () -> this.controller = new Node());
     }
 }

--- a/src/main/java/org/akhq/models/Cluster.java
+++ b/src/main/java/org/akhq/models/Cluster.java
@@ -26,8 +26,8 @@ public class Cluster {
             this.nodes.add(new Node(node));
         }
 
-        Optional.ofNullable(result.controller().get()).ifPresentOrElse(
-            node -> this.controller = new Node(node),
-            () -> this.controller = new Node());
+        if (result.controller().get() != null) {
+            this.controller = new Node(result.controller().get());
+        }
     }
 }


### PR DESCRIPTION
fix #1226 

When I try to display cluster information in MSK Serverless, I get a NullPointerException.
So, if I can't get the Node information, I used the default constructor of the Node class to work around the problem

