### PR TITLE
fix[#1006]: replaced 'json-bigint' parser with 'lossless-json'

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3471,11 +3471,6 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
-    "bignumber.js": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
-    },
     "binary-extensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
@@ -8769,14 +8764,6 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
-    "json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "requires": {
-        "bignumber.js": "^9.0.0"
-      }
-    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -9320,6 +9307,11 @@
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
+    },
+    "lossless-json": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-2.0.1.tgz",
+      "integrity": "sha512-KW/FSL426qblKVvf4ImeMVGr0Je6J9aXvAMUOIU8AzelDj06q47mn6QJ+56lBBd+A8kjrncrxdKQs6ZssAXTmw=="
     },
     "loud-rejection": {
       "version": "1.6.0",

--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,7 @@
     "css-loader": "^3.4.1",
     "font-awesome": "^4.7.0",
     "joi-validation": "^2.0.0",
-    "json-bigint": "^1.0.0",
+    "lossless-json": "^2.0.1",
     "lodash": "^4.17.21",
     "moment": "^2.24.0",
     "node-sass": "^4.14.1",

--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -30,7 +30,7 @@ import DateTime from '../../../../components/DateTime';
 import { capitalizeTxt, getClusterUIOptions } from '../../../../utils/functions';
 import { setProduceToTopicValues, setUIOptions} from '../../../../utils/localstorage';
 import Select from '../../../../components/Form/Select';
-import JSONbig from 'json-bigint';
+import * as LosslessJson from 'lossless-json'
 
 class TopicData extends Root {
   state = {
@@ -928,8 +928,8 @@ class TopicData extends Root {
                     extraRowContent: (obj, index) => {
                       let value = obj.value;
                       try {
-                        let json = JSONbig.parse(obj.value);
-                        value = JSONbig.stringify(json, null, 2);
+                        let json = LosslessJson.parse(obj.value);
+                        value = LosslessJson.stringify(json, undefined, " ");
                         // eslint-disable-next-line no-empty
                       } catch (e) {}
 

--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -929,7 +929,7 @@ class TopicData extends Root {
                       let value = obj.value;
                       try {
                         let json = LosslessJson.parse(obj.value);
-                        value = LosslessJson.stringify(json, undefined, " ");
+                        value = LosslessJson.stringify(json, undefined, "  ");
                         // eslint-disable-next-line no-empty
                       } catch (e) {}
 
@@ -969,9 +969,9 @@ class TopicData extends Root {
                     colName: 'Date',
                     type: 'text',
                     cell: (obj, col) => {
-                      return <DateTime 
-                        isoDateTimeString={obj[col.accessor]} 
-                        dateTimeFormat={this.state.dateTimeFormat} 
+                      return <DateTime
+                        isoDateTimeString={obj[col.accessor]}
+                        dateTimeFormat={this.state.dateTimeFormat}
                       />;
                     }
                   },


### PR DESCRIPTION
This replacement allows for pretty-printing the json data, but still keeping the original values especially for floating numbers and bigints.

After this change a message with content:

```
{ "someFloat": 1.00, "bigNumber": 123456789012345678901234567890 }
```

will be displayed without losing any information from the original message. But still be pretty-printed:

```
{
  "someFloat": 1.00, 
  "bigNumber": 123456789012345678901234567890
}
```

Prior to this change the message would have looked like this:

```
{
  "someFloat": 1,
  "bigNumber": 1.2345678901234567890123456789e+29
}
```