### PR TITLE
Deserialization error when produce with emtpy key or value

### DIFF
--- a/src/main/java/org/akhq/repositories/RecordRepository.java
+++ b/src/main/java/org/akhq/repositories/RecordRepository.java
@@ -39,6 +39,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import jakarta.inject.Inject;
@@ -606,7 +607,7 @@ public class RecordRepository extends AbstractRepository {
                 SchemaSerializer keySerializer = serializerFactory.createSerializer(clusterId, keySchemaId.get());
                 keyAsBytes = keySerializer.serialize(key.get());
             } else {
-                keyAsBytes = key.get().getBytes();
+                keyAsBytes = key.filter(Predicate.not(String::isEmpty)).map(String::getBytes).orElse(null);
             }
         } else {
             try {
@@ -622,7 +623,7 @@ public class RecordRepository extends AbstractRepository {
             SchemaSerializer valueSerializer = serializerFactory.createSerializer(clusterId, valueSchemaId.get());
             valueAsBytes = valueSerializer.serialize(value.get());
         } else {
-            valueAsBytes = value.map(String::getBytes).orElse(null);
+            valueAsBytes = value.filter(Predicate.not(String::isEmpty)).map(String::getBytes).orElse(null);
         }
 
         return produce(clusterId, topic, valueAsBytes, headers, keyAsBytes, partition, timestamp);


### PR DESCRIPTION
Hi, I am facing a deserialization error when producing to a topic with an empty Key or Value. I am consuming with a Spring Kafka app, and debugging I noticed that when producing an empty key or value with AKHQ, the key/value is not actually null, an array of bytes.

In this screenshot you can see that they are not null.
![produce_empty_key](https://user-images.githubusercontent.com/31214345/201339768-1b1bcce0-9233-4893-90bb-b62c9865759c.png)

And the error that is causing is 
```
java.lang.IllegalStateException: This error handler cannot process 'SerializationException's directly; please consider configuring an 'ErrorHandlingDeserializer' in the value and/or key deserializer
Caused by: java.nio.BufferUnderflowException: null
```

The provided solution is to check if the key/value is empty. If it is, produce sending a null.