### PR TITLE
Get all values from auth header in header auth

### DIFF
--- a/src/main/java/org/akhq/modules/HeaderAuthenticationFetcher.java
+++ b/src/main/java/org/akhq/modules/HeaderAuthenticationFetcher.java
@@ -19,6 +19,7 @@ import org.reactivestreams.Publisher;
 
 import java.net.InetSocketAddress;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -86,16 +87,18 @@ public class HeaderAuthenticationFetcher implements AuthenticationFetcher {
             log.debug("One or more of the IP patterns matched the host address [{}]. Continuing request processing.", hostAddress);
         }
 
-        Optional<String> groupHeaders = headerAuth.getGroupsHeader() != null ?
-            request.getHeaders().get(headerAuth.getGroupsHeader(), String.class) :
-            Optional.empty();
+        List<String> groupsHeader = headerAuth.getGroupsHeader() != null ?
+            request.getHeaders().getAll(headerAuth.getGroupsHeader()) :
+            Collections.emptyList();
 
         return Flowable
             .fromCallable(() -> {
-                List<String> groups = groupHeaders
+                List<String> groups = groupsHeader
                     .stream()
                     .flatMap(s -> Arrays.stream(s.split(headerAuth.getGroupsHeaderSeparator())))
                     .collect(Collectors.toList());
+
+                log.debug("Got groups [{}] from groupsHeader [{}] and separator [{}]", groups, groupsHeader, headerAuth.getGroupsHeaderSeparator());
 
                 ClaimRequest claim =
                     ClaimRequest.builder()


### PR DESCRIPTION
When setting up the header auth with [Traefik's OIDC Middleware](https://doc.traefik.io/traefik-enterprise/middlewares/oidc/), Micronauts already parsed the group's header into a list before AKHQ could.

Invoking `request.getHeaders().get[...]` only returned the group list's first entry and not the entire list.
Thus, one could not configure access for a user who's a member of multiple groups.

This change should be fully compatible with the group header being raw yet separated string and a pre-parsed list of strings.