### PR TITLE
enhancement: support for acls-filter-regexp

### DIFF
--- a/docs/docs/configuration/authentifications/groups.md
+++ b/docs/docs/configuration/authentifications/groups.md
@@ -12,9 +12,10 @@ Define groups with specific roles for your users
     * `attributes.topics-filter-regexp`: Regexp list to filter topics available for current group
     * `attributes.connects-filter-regexp`: Regexp list to filter Connect tasks available for current group
     * `attributes.consumer-groups-filter-regexp`: Regexp list to filter Consumer Groups available for current group
+    * `attributes.acls-filter-regexp`: Regexp list to filter acls available for current group
 
 ::: warning
-`topics-filter-regexp`, `connects-filter-regexp` and `consumer-groups-filter-regexp` are only used when listing resources.
+`topics-filter-regexp`, `connects-filter-regexp`, `consumer-groups-filter-regexp` and `acls-filter-regexp` are only used when listing resources.
 If you have `topics/create` or `connect/create` roles and you try to create a resource that doesn't follow the regexp, that resource **WILL** be created.
 :::
 

--- a/src/test/java/org/akhq/KafkaTestCluster.java
+++ b/src/test/java/org/akhq/KafkaTestCluster.java
@@ -326,6 +326,10 @@ public class KafkaTestCluster implements Runnable {
                 new AccessControlEntry("user:toto", "*", AclOperation.DESCRIBE, AclPermissionType.ALLOW))
         );
         bindings.add(new AclBinding(
+                new ResourcePattern(ResourceType.TOPIC, "anotherAclTestTopic", PatternType.LITERAL),
+                new AccessControlEntry("test:toto", "*", AclOperation.DESCRIBE, AclPermissionType.ALLOW))
+        );
+        bindings.add(new AclBinding(
                 new ResourcePattern(ResourceType.GROUP, "groupConsumer", PatternType.LITERAL),
                 new AccessControlEntry("user:toto", "*", AclOperation.DESCRIBE, AclPermissionType.ALLOW))
         );
@@ -336,6 +340,10 @@ public class KafkaTestCluster implements Runnable {
         bindings.add(new AclBinding(
                 new ResourcePattern(ResourceType.GROUP, "groupConsumer2", PatternType.LITERAL),
                 new AccessControlEntry("user:toto", "*", AclOperation.DESCRIBE, AclPermissionType.ALLOW))
+        );
+        bindings.add(new AclBinding(
+                new ResourcePattern(ResourceType.GROUP, "groupConsumer2", PatternType.LITERAL),
+                new AccessControlEntry("test:toto", "*", AclOperation.DESCRIBE, AclPermissionType.ALLOW))
         );
         testUtils.getAdminClient().createAcls(bindings).all().get();
         log.debug("bindings acls added");

--- a/src/test/java/org/akhq/repositories/AccessControlRepositoryTest.java
+++ b/src/test/java/org/akhq/repositories/AccessControlRepositoryTest.java
@@ -45,6 +45,19 @@ class AccessControlRepositoryTest extends AbstractTest {
     }
 
     @Test
+    void findAllBySecondUser() throws ExecutionException, InterruptedException {
+        var searchResult = aclRepository.findByPrincipal(KafkaTestCluster.CLUSTER_ID, AccessControl.encodePrincipal("test:toto"), Optional.empty());
+        assertEquals("test:toto", searchResult.getPrincipal());
+        assertEquals(2, searchResult.getAcls().size());
+        assertEquals(2, searchResult
+            .getAcls()
+            .stream()
+            .filter(acl -> acl.getOperation().getPermissionType() == AclPermissionType.ALLOW)
+            .count()
+        );
+    }
+
+    @Test
     void findHostByUser() throws ExecutionException, InterruptedException {
         var searchResult = aclRepository.findByPrincipal(KafkaTestCluster.CLUSTER_ID, AccessControl.encodePrincipal("user:tata"), Optional.empty());
         assertEquals("user:tata", searchResult.getPrincipal());

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -104,6 +104,9 @@ akhq:
           - connect/update
           - connect/delete
           - connect/state/update
+        attributes:
+          acls-filter-regexp:
+            - "user.*"
       limited:
         name: limited
         roles:
@@ -114,6 +117,8 @@ akhq:
         attributes:
           topics-filter-regexp:
             - "test.*"
+          acls-filter-regexp:
+            - "user.*"
       operator:
         name: operator
         roles:
@@ -131,6 +136,9 @@ akhq:
           - topic/insert
           - topic/delete
           - registry/version/delete
+        attributes:
+          acls-filter-regexp:
+            - "user.*"
     basic-auth:
       - username: user
         password: d74ff0ee8da3b9806b18c877dbf29bbde50b5bd8e4dad7a3a725000feb82e8f1


### PR DESCRIPTION
This PR contains changes to support Regex for filtering security groups based on principal names added to the acl bindings