### PR TITLE
fix(probes): opening management port on endpoint | connection refused

### DIFF
--- a/helm/akhq/templates/service.yaml
+++ b/helm/akhq/templates/service.yaml
@@ -22,6 +22,10 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: {{ .Values.service.managementPort }}
+      targetPort: management
+      protocol: TCP
+      name: management
       {{- if and (eq "NodePort" .Values.service.type) .Values.service.httpNodePort }}
       nodePort: {{ .Values.service.httpNodePort }}
       {{- end }}

--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -107,6 +107,7 @@ service:
   enabled: true
   type: ClusterIP
   port: 80
+  managementPort: 28081
   #httpNodePort: 32551
   labels: {}
   annotations:


### PR DESCRIPTION
This PR fixes the endpoint behind the Service which only had http port opened.

Related logs are

```plaintext
  Warning  Unhealthy  102s (x7 over 3m2s)   kubelet            Readiness probe failed: Get "http://10.80.6.231:28081/health": dial tcp 10.80.6.231:28081: connect: connection refused
  Warning  Unhealthy  102s (x6 over 3m2s)   kubelet            Liveness probe failed: Get "http://10.80.6.231:28081/health": dial tcp 10.80.6.231:28081: connect: connection refused
```