### PR TITLE
Uninstall unused dep

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13899,39 +13899,6 @@
         "prop-types": "^15.6.2"
       }
     },
-    "reactstrap": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-8.5.1.tgz",
-      "integrity": "sha512-igpdw8DiW48ZtwGOo2unwlsILFlF7deiqFUAqc3wrsX/0H0OkvmezJdkjJx2X9jaHfjGdPpm0vu5VN/kk7tv+A==",
-      "requires": {
-        "@babel/runtime": "^7.2.0",
-        "classnames": "^2.2.3",
-        "prop-types": "^15.5.8",
-        "react-popper": "^1.3.6",
-        "react-transition-group": "^2.3.1"
-      },
-      "dependencies": {
-        "dom-helpers": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-          "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-          "requires": {
-            "@babel/runtime": "^7.1.2"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
-          "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        }
-      }
-    },
     "read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -30,8 +30,7 @@
     "react-router-dom": "^5.1.2",
     "react-scripts": "^5.0.1",
     "react-timeago": "^6.2.1",
-    "react-toastify": "^6.0.6",
-    "reactstrap": "^8.4.0"
+    "react-toastify": "^6.0.6"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
I started looking into the react upgrade and stumbled upon this.

If you're ok with it, I want to open a pr to add a [nvmrc](https://github.com/nvm-sh/nvm) file to the client dir with the version of node we're using (`18.12.1`) 

It would help us using the same versions of node/npm. For example, I had to manually go back to node 14 to create this pull request with a small and "clean" diff. Using later versions would run into lockfileversion changes (it has already happened in the repo [here](https://github.com/tchiotludo/akhq/commit/71015d454fe796a924c6e2f4457481b7dcb6fd52) for example). 