### PR TITLE
Include worker override properties in Connect Configs tab

### DIFF
--- a/client/src/containers/Connect/ConnectDetail/ConnectConfigs/ConnectConfigs.jsx
+++ b/client/src/containers/Connect/ConnectDetail/ConnectConfigs/ConnectConfigs.jsx
@@ -8,7 +8,6 @@ import {
 } from '../../../../utils/endpoints';
 import constants from '../../../../utils/constants';
 import Form from '../../../../components/Form/Form';
-import AceEditor from 'react-ace';
 import filter from 'lodash/filter';
 import 'ace-builds/webpack-resolver';
 import 'ace-builds/src-noconflict/mode-json';
@@ -242,7 +241,6 @@ class ConnectConfigs extends Form {
   };
 
   handleGroup(group) {
-    let { formData } = this.state;
     let groupDisplay = [
       <tr key={0} className="bg-primary">
         <td colSpan="3">{group[0].group}</td>
@@ -251,9 +249,6 @@ class ConnectConfigs extends Form {
 
     group.forEach(element => {
       const rows = this.renderTableRows(element);
-      const errors = [];
-      const roles = this.state.roles || {};
-
       groupDisplay.push(<tr>{rows}</tr>);
     });
     return groupDisplay;

--- a/client/src/utils/endpoints.js
+++ b/client/src/utils/endpoints.js
@@ -129,6 +129,10 @@ export const uriConnectPlugin = (clusterId, connectId, pluginId) => {
   return `${apiUrl}/${clusterId}/connect/${connectId}/plugins/${pluginId}`;
 };
 
+export const uriValidatePluginConfigs = (clusterId, connectId, pluginId) => {
+  return `${apiUrl}/${clusterId}/connect/${connectId}/plugins/${pluginId}/validate`;
+};
+
 export const uriCreateConnect = (clusterId, connectId) => {
   return `${apiUrl}/${clusterId}/connect/${connectId}`;
 };

--- a/src/main/java/org/akhq/controllers/ConnectController.java
+++ b/src/main/java/org/akhq/controllers/ConnectController.java
@@ -8,6 +8,8 @@ import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Delete;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Put;
+
 import io.micronaut.security.annotation.Secured;
 import io.swagger.v3.oas.annotations.Operation;
 import org.akhq.configs.Role;
@@ -67,6 +69,12 @@ public class ConnectController extends AbstractController {
             .filter(connectPlugin -> connectPlugin.getClassName().equals(type))
             .findAny()
             .orElseThrow();
+    }
+
+    @Put("/plugins/{type}/validate")
+    @Operation(tags = {"connect"}, summary = "Validate plugin configs")
+    public ConnectPlugin validatePlugin(String cluster, String connectId, String type, Map<String, String> configs) {
+        return connectRepository.validatePlugin(cluster, connectId, type, configs).orElseThrow();
     }
 
     @Secured(Role.ROLE_CONNECT_INSERT)

--- a/src/test/java/org/akhq/controllers/ConnectControllerTest.java
+++ b/src/test/java/org/akhq/controllers/ConnectControllerTest.java
@@ -90,6 +90,26 @@ class ConnectControllerTest extends AbstractTest {
     }
 
     @Test
+    @Order(2)
+    void validatePluginApi() {
+        ConnectPlugin result = this.retrieve(HttpRequest.PUT(
+            BASE_URL + "/plugins/org.apache.kafka.connect.file.FileStreamSinkConnector/validate",
+            ImmutableMap.of(
+                "configs",              ImmutableMap.of(
+                    "connector.class", "org.apache.kafka.connect.file.FileStreamSinkConnector",
+                    "file", PATH2,
+                    "topics", KafkaTestCluster.TOPIC_CONNECT,
+                    "consumer.override.retry.backoff.ms","400"
+                )
+            )
+        ), ConnectPlugin.class);
+
+        assertEquals("sink", result.getType());
+        assertTrue(result.getDefinitions().size() > 0);
+        assertTrue(result.getDefinitions().stream().anyMatch(definition -> definition.getName().equals("consumer.override.retry.backoff.ms")));
+    }
+
+    @Test
     @Order(5)
     void updateApi() {
         ConnectDefinition result = this.retrieve(HttpRequest.POST(

--- a/src/test/java/org/akhq/repositories/ConnectRepositoryTest.java
+++ b/src/test/java/org/akhq/repositories/ConnectRepositoryTest.java
@@ -45,20 +45,6 @@ class ConnectRepositoryTest extends AbstractTest {
         assertEquals(2, all.size());
     }
 
-    @Test
-    void getPlugin() {
-        Optional<ConnectPlugin> plugin = repository.getPlugin(
-            KafkaTestCluster.CLUSTER_ID,
-            "connect-1",
-            "FileStreamSinkConnector"
-        );
-
-        assertTrue(plugin.isPresent());
-        assertEquals("FileStreamSinkConnector", plugin.get().getShortClassName());
-        assertEquals("sink", plugin.get().getType());
-        assertTrue(plugin.get().getDefinitions().stream().anyMatch(definition -> definition.getName().equals("file")));
-    }
-
     @AfterEach
     void cleanup() {
         try {


### PR DESCRIPTION
This resolves the issue #1336 

I've made a few changes. Instead of calling the Connect /validate endpoint with dummy values to retrieve the plugin configs, I send the request with all the configs that the connector has. That way, it returns the specification of all the required definitions and also the ones of the worker overridden properties(producer.override.* and consumer.override.*). Also the type of the values required for validation.

I also changed the transforms properties to follow the same behavior. Instead of having a raw json, there will be a row for each key/value, and now the validations returned from the connect will be applied to the values.
![override](https://user-images.githubusercontent.com/31214345/212097601-35a5ad1a-3345-4cdd-a9bf-bd5d5ed7d925.png)
![transforms](https://user-images.githubusercontent.com/31214345/212097892-71981c2f-e6ae-40c3-94cd-8d9794c953f8.png)

