### PR TITLE
Replace window pathname by component to fix context-path issues on frontend

### DIFF
--- a/client/src/components/Root/Root.jsx
+++ b/client/src/components/Root/Root.jsx
@@ -6,9 +6,10 @@ class Root extends Component {
   cancel = axios.CancelToken.source();
 
   componentWillUnmount() {
-    const pathname = window.location.pathname;
+    /* eslint-disable react/prop-types */
+    const pathname = this.props.location?.pathname;
 
-    if (pathname !== '/ui/login') {
+    if (pathname && pathname !== '/ui/login') {
       sessionStorage.setItem('returnTo', pathname + (window.location.search || ''));
     }
 


### PR DESCRIPTION
When using Micronaut context-path, the React router will use this context-path as base path for the frontend.
This leads to issues especially with login (see #907) because, for context-path = /linked, the returnTo will be set to /linked/ui/login/ (the if test doesn't work because of this basename) and will try to redirect the user to /linked/linked/ui/login. Because this path is unknown, user will view the login page twice.

Using the component pathname fixes the issue because we won't take the basename into account to set returnTo and let the React router add it