### PR TITLE
Remove basePath on next page URI to prevent no data available error

### DIFF
--- a/client/src/utils/endpoints.js
+++ b/client/src/utils/endpoints.js
@@ -60,12 +60,7 @@ export const uriDeleteTopics = (clusterId, topicId) => {
 };
 
 export const uriTopicData = (clusterId, topicId, filters, nextPage = '') => {
-  if (nextPage !== '') {
-    return basePath + nextPage;
-  }
-
-  let uri = `${apiUrl}/${clusterId}/topic/${topicId}/data?${filters}`;
-  return uri;
+  return nextPage !== '' ? nextPage : `${apiUrl}/${clusterId}/topic/${topicId}/data?${filters}`;
 };
 
 export const uriTopicDataSearch = (clusterId, topicId, filters, offsets) => {


### PR DESCRIPTION
GET /topic/{topicName}/data returns in the after variable the URI to call to get the next page of data. When using context-path in Micronaut, the context-path is added in the URI.
![image](https://user-images.githubusercontent.com/2262145/215795920-be59d409-20ee-429d-9efe-f75df6beb5d1.png)

The problem is that we add it another time in the uriTopicData endpoint.
![image](https://user-images.githubusercontent.com/2262145/215795732-2dc46244-8643-4297-b6f0-8914a22a9607.png)

This leads to a /linked/linked/api/... call which fails and show the issue mentionned in #1298.
![image](https://user-images.githubusercontent.com/2262145/215796140-3b6fda14-c687-4b29-baa4-7a630d760899.png)

If we keep only the after URI as it is and don't add the basePath, pagination works well with context-path