### PR TITLE
fix(docs): add missed keyword in avro-raw docs in yaml

### DIFF
--- a/docs/docs/configuration/avro.md
+++ b/docs/docs/configuration/avro.md
@@ -16,6 +16,7 @@ akhq:
     kafka:
       properties:
         # standard kafka properties
+      deserialization:
         avro-raw:
           schemas-folder: "/app/avro_schemas"
           topics-mapping:


### PR DESCRIPTION
Signed-off-by: Dmitrii Bocharov <dmitrii.bocharov@embedit.cz>