### PR TITLE
docs(oidc): Add precision on the token source for OIDC claims mapping

### DIFF
--- a/docs/docs/configuration/authentifications/oidc.md
+++ b/docs/docs/configuration/authentifications/oidc.md
@@ -46,7 +46,7 @@ akhq:
                 - topic-writer
 ```
 
-The username field can be any string field, the roles field has to be a JSON array.
+The username field can be any string field, the roles field has to be a JSON array. The mapping is performed on the OIDC _ID token_.
 
 ## Direct OIDC mapping
 


### PR DESCRIPTION
Signed-off-by: syalioune <sy_alioune@yahoo.fr>

Small precision that can maybe change countless hours of debugging. A colleague of mine and I wrongly assumed that the mapping was done on the access token.