### PR TITLE
fix(models): Use the partition leader from partition info

### DIFF
--- a/src/main/java/org/akhq/models/Partition.java
+++ b/src/main/java/org/akhq/models/Partition.java
@@ -29,19 +29,27 @@ public class Partition {
         this.lastOffset = offsets.getLastOffset();
         this.nodes = new ArrayList<>();
         for (org.apache.kafka.common.Node replica : partitionInfo.replicas()) {
-            nodes.add(new Node.Partition(
+            Node.Partition partition = new Node.Partition(
                 replica,
                 partitionInfo.leader().id() == replica.id(),
                 partitionInfo.isr().stream().anyMatch(node -> node.id() == replica.id())
-            ));
+            );
+            
+            this.nodes.add(partition);
+            if (partition.isLeader()) {
+                this.leader = partition;
+            }
         }
         
-        org.apache.kafka.common.Node leader = partitionInfo.leader();
-        this.leader = new Node.Partition(
-            leader,
-            true,
-            partitionInfo.isr().stream().anyMatch(node -> node.id() == leader.id())
-        );
+        if (this.leader == null)
+        {
+            org.apache.kafka.common.Node leader = partitionInfo.leader();
+            this.leader = new Node.Partition(
+                leader,
+                true,
+                partitionInfo.isr().stream().anyMatch(node -> node.id() == leader.id())
+            );
+        }
     }
 
     public Node.Partition getLeader() {

--- a/src/main/java/org/akhq/models/Partition.java
+++ b/src/main/java/org/akhq/models/Partition.java
@@ -34,15 +34,14 @@ public class Partition {
                 partitionInfo.leader().id() == replica.id(),
                 partitionInfo.isr().stream().anyMatch(node -> node.id() == replica.id())
             );
-            
+
             this.nodes.add(partition);
             if (partition.isLeader()) {
                 this.leader = partition;
             }
         }
-        
-        if (this.leader == null)
-        {
+
+        if (this.leader == null) {
             org.apache.kafka.common.Node leader = partitionInfo.leader();
             this.leader = new Node.Partition(
                 leader,

--- a/src/main/java/org/akhq/models/Partition.java
+++ b/src/main/java/org/akhq/models/Partition.java
@@ -58,7 +58,7 @@ public class Partition {
 
     public long getLogDirSize() {
         return this.getLogDir().stream()
-            .filter(logDir -> logDir.getBrokerId() == this.leader.getId())
+            .filter(logDir -> this.leader != null && logDir.getBrokerId() == this.leader.getId())
             .map(LogDir::getSize)
             .reduce(0L, Long::sum);
     }


### PR DESCRIPTION
This doesn't necessarily enable EventHubs completely, but this is attempting to address the first issue hit when attempting to connect to Azure Event Hubs which causes it to crash at startup.

The issue is that in `EventHubs` the replica set is empty and therefore there is no leader in the `this.nodes` list, which blows up when `getLeader()` is called.

This change will find the leader in the constructor instead of in the call to `getLeader()`, if there are no replicas (or replica leaders) it will call `partitionInfo.getLeader()` instead, which hopefully does not return null and hopefully will have the correct logic to identify the partition leader, but if it does then can easily be null checked in `getLogDirSize()` which will safely default to 0 in that case.

## Related To

- https://github.com/tchiotludo/akhq/issues/1364
- https://github.com/tchiotludo/akhq/issues/657