### PR TITLE
fix string header regex error

### DIFF
--- a/src/main/java/org/akhq/utils/ContentUtils.java
+++ b/src/main/java/org/akhq/utils/ContentUtils.java
@@ -15,19 +15,23 @@ public class ContentUtils {
      */
     private static boolean isValidUTF8(byte[] value) throws UnsupportedEncodingException
     {
-        Pattern p = Pattern.compile("\\A(\n" +
-            "  [\\x09\\x0A\\x0D\\x20-\\x7E]             # ASCII\\n" +
-            "| [\\xC2-\\xDF][\\x80-\\xBF]               # non-overlong 2-byte\n" +
-            "|  \\xE0[\\xA0-\\xBF][\\x80-\\xBF]         # excluding overlongs\n" +
-            "| [\\xE1-\\xEC\\xEE\\xEF][\\x80-\\xBF]{2}  # straight 3-byte\n" +
-            "|  \\xED[\\x80-\\x9F][\\x80-\\xBF]         # excluding surrogates\n" +
-            "|  \\xF0[\\x90-\\xBF][\\x80-\\xBF]{2}      # planes 1-3\n" +
-            "| [\\xF1-\\xF3][\\x80-\\xBF]{3}            # planes 4-15\n" +
-            "|  \\xF4[\\x80-\\x8F][\\x80-\\xBF]{2}      # plane 16\n" +
-            ")*\\z", Pattern.COMMENTS);
+        //If the array is too long, it throws a StackOverflowError due to the regex, so we assume it is a String.
+        if (value.length <= 1000) {
+            Pattern p = Pattern.compile("\\A(\n" +
+                "  [\\x09\\x0A\\x0D\\x20-\\x7E]             # ASCII\\n" +
+                "| [\\xC2-\\xDF][\\x80-\\xBF]               # non-overlong 2-byte\n" +
+                "|  \\xE0[\\xA0-\\xBF][\\x80-\\xBF]         # excluding overlongs\n" +
+                "| [\\xE1-\\xEC\\xEE\\xEF][\\x80-\\xBF]{2}  # straight 3-byte\n" +
+                "|  \\xED[\\x80-\\x9F][\\x80-\\xBF]         # excluding surrogates\n" +
+                "|  \\xF0[\\x90-\\xBF][\\x80-\\xBF]{2}      # planes 1-3\n" +
+                "| [\\xF1-\\xF3][\\x80-\\xBF]{3}            # planes 4-15\n" +
+                "|  \\xF4[\\x80-\\x8F][\\x80-\\xBF]{2}      # plane 16\n" +
+                ")*\\z", Pattern.COMMENTS);
 
-        String phonyString = new String(value, "ISO-8859-1");
-        return p.matcher(phonyString).matches();
+            String phonyString = new String(value, "ISO-8859-1");
+            return p.matcher(phonyString).matches();
+        }
+        return true;
     }
 
     /**

--- a/src/test/java/org/akhq/utils/ContentUtilsTest.java
+++ b/src/test/java/org/akhq/utils/ContentUtilsTest.java
@@ -1,6 +1,7 @@
 package org.akhq.utils;
 
 import org.akhq.models.Record;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.kafka.common.header.Header;
 import org.junit.jupiter.api.Test;
 
@@ -68,6 +69,13 @@ public class ContentUtilsTest {
         short testValue = 10;
 
         assertEquals(testValue, ContentUtils.convertToObject(toBytes(testValue)));
+    }
+
+    @Test
+    void testHeaderValueLongStringUTF8() {
+        String testValue = RandomStringUtils.random(10000, true, false);
+
+        assertEquals(testValue, ContentUtils.convertToObject(testValue.getBytes(StandardCharsets.UTF_8)));
     }
 
 }


### PR DESCRIPTION
Fix #1401  

I am assuming that if the header length is greater than 1000 it is a String, so we avoid the regex loop error.