### PR TITLE
Set Micronaut default log level

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -38,4 +38,5 @@
     </root>
 
     <logger name="org.apache" level="WARN" />
+    <logger name="io.micronaut" level="WARN"/>
 </configuration>


### PR DESCRIPTION
I suggest to set the Micronaut log level to WARN by default.
One day we changed the root log level to TRACE to do some troubleshooting on AKHQ. 

```yaml
loggers:
  levels:
    ROOT: TRACE
```
We realized that user credentials were added in the logs by Micronaut during login:

`TRACE pGroup-1-4 i.m.h.n.r.HandlerPublisher HandlerPublisher (state: BUFFERING) emitting next message: {
    "username": "MyUsername",
    "password": "MyPassword"
}`

To prevent this kind of behaviour, settings a log level for Micronaut would be preferable. Logs can be sent to some central tool (ELK, Splunk, etc.) so these credentials could eventually leak with the actual setup