### PR TITLE
fix sort contract error

### DIFF
--- a/src/main/java/org/akhq/models/ConnectPlugin.java
+++ b/src/main/java/org/akhq/models/ConnectPlugin.java
@@ -31,7 +31,8 @@ public class ConnectPlugin {
                 .map(config -> new Definition(config.getDefinition())),
             registryDefinition()
         )
-            .sorted(Comparator.comparing(Definition::getGroup, (s1, s2) -> s1.equals("Others") ? 1 : s1.compareTo(s2))
+            .sorted(Comparator.comparing(Definition::getGroup, Comparator.comparing((String s) -> s.equals("Others"))
+                    .thenComparing(Comparator.naturalOrder()))
                 .thenComparing(Definition::getOrder)
             )
             .collect(Collectors.toList());


### PR DESCRIPTION
Hi, I faced an error when trying to view the configs of a JDBC Sink Connector.

![Screenshot from 2023-03-22 16-57-07](https://user-images.githubusercontent.com/31214345/226964304-83e68915-bfb2-4b40-8137-223b71824673.png)

The error is thrown when sorting the groups and treating the group "Others" in https://github.com/tchiotludo/akhq/blob/dev/src/main/java/org/akhq/models/ConnectPlugin.java#L34 . It fails with certain combinations of overridden properties (group Others) and transforms (group Transforms). It seems that the sorting breaks the contract and there is some inconsistency. If I remove that conditional, everything works OK, but I guess that the intention of that code is that the group Others is shown at the end of the form and not alphabetically. 

So I fixed that line to keep the same behavior.
