### PR TITLE
First topic record not shown on partitions with 1 record on newest sort

### DIFF
--- a/src/main/java/org/akhq/repositories/RecordRepository.java
+++ b/src/main/java/org/akhq/repositories/RecordRepository.java
@@ -408,7 +408,7 @@ public class RecordRepository extends AbstractRepository {
                     last = options.after.get(partition.getId()) - 1;
                 }
 
-                if (last == partition.getFirstOffset() || last < 0) {
+                if (last < 0) {
                     consumer.close();
                     return null;
                 } else if (!(last - pollSizePerPartition < first)) {


### PR DESCRIPTION
When fixing the newest sort I forgot one specific case that we experienced recently.
On a new topic, if we have only one record in one or several partition, AKHQ shows No data available. This is due to a wrong test that closes the consumer and doesn't return anything