### PR TITLE
Fix after parameter on topic data pagination

### DIFF
--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -183,7 +183,6 @@ class TopicData extends Root {
         this.eventSource.addEventListener('searchBody', function (e) {
           const res = JSON.parse(e.data);
           const records = res.records || [];
-          const nextPage = res.after ? res.after : self.state.nextPage;
 
           const percentDiff = res.percent - lastPercentVal;
 
@@ -191,7 +190,6 @@ class TopicData extends Root {
           if (percentDiff >= percentUpdateDelta) {
             lastPercentVal = res.percent;
             self.setState({
-              nextPage,
               recordCount: self.state.recordCount + records.length,
               percent: res.percent.toFixed(2)
             });
@@ -207,9 +205,12 @@ class TopicData extends Root {
           }
         });
 
-        this.eventSource.addEventListener('searchEnd', function () {
+        this.eventSource.addEventListener('searchEnd', function (e) {
+          const res = JSON.parse(e.data);
+          const nextPage = res.after ? res.after : self.state.nextPage;
+          self.setState({ percent: 100, nextPage, isSearching: false, loading: false });
+
           self.eventSource.close();
-          self.setState({ percent: 100, isSearching: false, loading: false });
         });
       }
     );

--- a/src/main/java/org/akhq/repositories/RecordRepository.java
+++ b/src/main/java/org/akhq/repositories/RecordRepository.java
@@ -683,8 +683,7 @@ public class RecordRepository extends AbstractRepository {
 
             // end
             if (searchEvent == null || searchEvent.emptyPoll == 666) {
-
-                emitter.onNext(new SearchEvent(topic).end());
+                emitter.onNext(new SearchEvent(topic).end(searchEvent != null ? searchEvent.after: null));
                 emitter.onComplete();
                 consumer.close();
 
@@ -725,7 +724,7 @@ public class RecordRepository extends AbstractRepository {
 
             if (currentEvent.emptyPoll >= 1) {
                 currentEvent.emptyPoll = 666;
-                emitter.onNext(currentEvent.end());
+                emitter.onNext(currentEvent.end(searchEvent.getAfter()));
             } else if (matchesCount.get() >= options.getSize()) {
                 currentEvent.emptyPoll = 666;
                 emitter.onNext(currentEvent.progress(options));
@@ -860,8 +859,9 @@ public class RecordRepository extends AbstractRepository {
                 });
         }
 
-        public Event<SearchEvent> end() {
+        public Event<SearchEvent> end(String after) {
             this.percent = 100;
+            this.after = after;
 
             return Event.of(this).name("searchEnd");
         }


### PR DESCRIPTION
When the topic data search gets enough results in less than the defined 0.5% topic data increment (merged in #1209), the after variable given by the backend response won't be used (never set in nextPage state). 

Then pagination won't work because it will use an old value of the nextPage variable (the one we get after the 1st topic data request when you open the topic data screen).

Ex: I perform a search by the key and the first page is returned after looking into the first 0.46% of topic data.
![image](https://user-images.githubusercontent.com/2262145/234567900-d9dbfc22-9513-4c25-86a8-1a2012374468.png)

When I try to navigate to the next page, AKHQ will display No data available. This is because the URL requested is wrong:

`/ui/myCluster/topic/myTopic/data?sort=OLDEST&partition=All&searchByKey=XXX_C&after=/api/myCluster/topic/myTopic/data?after=0-50&partition=All&sort=OLDEST`

instead of
`/ui/myCluster/topic/myTopic/data?sort=OLDEST&partition=All&searchByKey=XXX_C&after=0-122_1-0_2-0`

This fix will always add the after parameter in searchEnd and set the nextPage variable with this value
![image](https://user-images.githubusercontent.com/2262145/234583108-a7ff659b-addd-46bd-b2be-70ea0568b77e.png)
 