### PR TITLE
add missing / to search string in replace

### DIFF
--- a/src/main/java/org/akhq/controllers/StaticFilter.java
+++ b/src/main/java/org/akhq/controllers/StaticFilter.java
@@ -72,7 +72,7 @@ public class StaticFilter implements HttpServerFilter {
     private String replace(String line) {
         line = line.replace("./ui", (basePath == null ? "" : basePath) + "/ui");
 
-        line = line.replace("<meta name=\"html-head\" content=\"replace\">", this.htmlHead == null ? "" : this.htmlHead);
+        line = line.replace("<meta name=\"html-head\" content=\"replace\" />", this.htmlHead == null ? "" : this.htmlHead);
 
         return line;
     }


### PR DESCRIPTION
Hello!

I've added the missing space and the missing `/` to the replace function to match. Since I do not have an idea to build the jar file locally, I create this PR. It should fix #1451 .

@AlexisSouquiere Thanks for pointing into the right direction.