### PR TITLE
List topics even if a broker is unable to serve log information

### DIFF
--- a/src/main/java/org/akhq/modules/AbstractKafkaWrapper.java
+++ b/src/main/java/org/akhq/modules/AbstractKafkaWrapper.java
@@ -15,6 +15,7 @@ import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.SecurityDisabledException;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 
@@ -262,7 +263,8 @@ abstract public class AbstractKafkaWrapper {
                             .allDescriptions()
                             .get();
                     } catch (ExecutionException e) {
-                        if (e.getCause() instanceof ClusterAuthorizationException || e.getCause() instanceof TopicAuthorizationException || e.getCause() instanceof UnsupportedVersionException) {
+                        if (e.getCause() instanceof ClusterAuthorizationException || e.getCause() instanceof TopicAuthorizationException || e.getCause() instanceof UnsupportedVersionException ||
+                            e.getCause() instanceof TimeoutException) {
                             return new HashMap<>();
                         }
 


### PR DESCRIPTION
There is a time during a broker's startup when the broker is registered in the Kafka cluster but not yet ready to serve requests. During that time, describeCluster will return the broker but describeLogDirs will run into a timeout trying to get information about log directories from that broker.

To list topics during a broker restart, the TimeoutException from the describeLogDirs call needs to be caught. That way, topics are still returned to the frontend. (The Size column stays empty, though.) Per default, the timeout for the AdminClient is 60s. However, this timeout can be decreased with the default.api.timeout.ms property.

The AdminClient logs a warning for each unsuccessful attempt to connect to the broker:
`Connection to node 0 (<url>:<port>) could not be established. Broker may not be available.`

In that broker state, the AdminClient runs into the same timeout when trying to fetch consumer groups. For consumer groups, however, the exception is already caught and passed on to the frontend. 

Before:
![before](https://github.com/tchiotludo/akhq/assets/60183196/74fc66c0-2aae-49d0-815a-8cd651c09dd5)

After:
![after](https://github.com/tchiotludo/akhq/assets/60183196/fac2308c-cc7d-4e82-8372-faf3d43dd107)
