### PR TITLE
feat(registry): regexp filter on schema registry subjects

### DIFF
--- a/application.example.yml
+++ b/application.example.yml
@@ -225,6 +225,9 @@ akhq:
           # Regexp list to filter consumer groups visible for group
           consumer-groups-filter-regexp:
             - "consumer.*"
+          # Regexp list to filter schemas visible for group
+          subjects-filter-regexp:
+            - "subject.*"
       topic-reader: # unique key
         name: topic-reader # Other group
         roles:

--- a/docs/docs/configuration/authentifications/groups.md
+++ b/docs/docs/configuration/authentifications/groups.md
@@ -13,9 +13,10 @@ Define groups with specific roles for your users
     * `attributes.connects-filter-regexp`: Regexp list to filter Connect tasks available for current group
     * `attributes.consumer-groups-filter-regexp`: Regexp list to filter Consumer Groups available for current group
     * `attributes.acls-filter-regexp`: Regexp list to filter acls available for current group
+    * `attributes.subjects-filter-regexp`: Regexp list to filter schema registry subjects available for current group
 
 ::: warning
-`topics-filter-regexp`, `connects-filter-regexp`, `consumer-groups-filter-regexp` and `acls-filter-regexp` are only used when listing resources.
+`topics-filter-regexp`, `connects-filter-regexp`, `consumer-groups-filter-regexp`, `acls-filter-regexp` and `subjects-filter-regexp` are only used when listing resources.
 If you have `topics/create` or `connect/create` roles and you try to create a resource that doesn't follow the regexp, that resource **WILL** be created.
 :::
 


### PR DESCRIPTION
Following this issue: https://github.com/tchiotludo/akhq/issues/853

As suggested [here](https://github.com/tchiotludo/akhq/issues/853#issuecomment-942586096), implementation is inspired from consumer groups regexp