### PR TITLE
Fix regression on search filters when changing sort

### DIFF
--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -234,7 +234,9 @@ class TopicData extends Root {
           key: { text: '', type: 'C' },
           value: { text: '', type: 'C' },
           headerKey: { text: '', type: 'C' },
-          headerValue: { text: '', type: 'C' }
+          headerValue: { text: '', type: 'C' },
+          keySubject: { text: '', type: 'C' },
+          valueSubject: { text: '', type: 'C' }
         }
       },
       () => {


### PR DESCRIPTION
#1430 is causing a regression when changing the sort filter (blank screen).
This is because the key/value subject reset was missing on the clearSearch function called when changing the sort
