### PR TITLE
Fix permission issue on topic data search with session token

### DIFF
--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -34,6 +34,7 @@ import { setProduceToTopicValues, setUIOptions } from '../../../../utils/localst
 import Select from '../../../../components/Form/Select';
 import * as LosslessJson from 'lossless-json';
 import { Buffer } from 'buffer';
+import { EventSourcePolyfill } from 'event-source-polyfill';
 
 class TopicData extends Root {
   state = {
@@ -175,13 +176,20 @@ class TopicData extends Root {
         } else {
           this._setUrlHistory(filters);
         }
-        this.eventSource = new EventSource(
+        this.eventSource = new EventSourcePolyfill(
           uriTopicDataSearch(
             selectedCluster,
             selectedTopic,
             filters,
             changePage ? nextPage : undefined
-          )
+          ),
+          sessionStorage.getItem('jwtToken')
+            ? {
+                headers: {
+                  Authorization: 'Bearer ' + sessionStorage.getItem('jwtToken')
+                }
+              }
+            : {}
         );
 
         this.eventSource.addEventListener('searchBody', function (e) {


### PR DESCRIPTION
With `token: bearer` we get a HTTP 401 on topic data search because the bearer token is not sent in the Authorization header in the EventSource. I already fixed it on the tail feature but forgot this one
This PR fixes the issue to make it works with bearer and still with cookie