### PR TITLE
Fix and enhance search

### DIFF
--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -712,6 +712,14 @@ class TopicData extends Root {
         {this._renderSearchFilter('keySubject', 'Key Subject')}
         {this._renderSearchFilter('valueSubject', 'Value Subject')}
 
+        <p style={{ fontStyle: 'italic' }}>
+          * Whitespaces in search string are considered as separators for search patterns unless
+          enclosed with double quotes
+          <br />
+          In case of multiple patterns, OR operator is applied for Contains / Equals. AND is applied
+          for Not contains
+        </p>
+
         <div style={{ display: 'flex' }}>
           <button
             className="btn btn-primary inline-block search"


### PR DESCRIPTION
Fix #1532 

This PR keeps the current behaviour that splits the search string by whitespace to build multiple search patterns. But the way it was supposed to works was confusing. For instance, by giving the following search string `value to search` with Contains option, the result could return records that contain only `to` whereas users were expecting records that contain `value to search`.

- [x] Allow giving a single pattern that contains whitespaces by enclosing it with double quotes (ex: "value to search")
- [x] Support complex patterns like searching for JSON key/value where we need to escape double quotes
- [x] Add details on the way the search works. Especially on the whitespace split + AND/OR operator in case of multiple patterns

On the following example, we are looking for records where the value contains `P1` OR `"field 1":"v1"`

![image](https://github.com/tchiotludo/akhq/assets/2262145/a54748bc-2088-4fbd-a88c-bd87098e73e5)