### PR TITLE
Redirect on login page when token expires

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,15 +1,32 @@
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { basePath } from './utils/endpoints';
+import { basePath, uriLogin } from './utils/endpoints';
 import Routes from './utils/Routes';
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import MomentUtils from '@date-io/moment';
 import { ToastContainer } from 'react-toastify';
 import { loadProgressBar } from 'axios-progress-bar';
+import axios from 'axios';
 
 class App extends React.Component {
   componentDidMount() {
     loadProgressBar();
+
+    axios.interceptors.response.use(null, error => {
+      try {
+        // Used for token expiration by redirecting on login page
+        if (error.response.status === 401) {
+          window.location = uriLogin();
+        }
+
+        return error;
+      } catch (e) {
+        // Propagate cancel
+        if (axios.isCancel(error)) {
+          throw new axios.Cancel('Operation canceled by the user.');
+        }
+      }
+    });
   }
 
   render() {

--- a/client/src/components/Root/Root.jsx
+++ b/client/src/components/Root/Root.jsx
@@ -1,7 +1,6 @@
 import { Component } from 'react';
 import axios from 'axios';
 import { get, put, post, remove } from '../../utils/api';
-import { uriLogin } from '../../utils/endpoints';
 
 class Root extends Component {
   cancel = axios.CancelToken.source();
@@ -15,19 +14,6 @@ class Root extends Component {
     }
 
     this.cancelAxiosRequests();
-
-    axios.interceptors.response.use(
-      response => {
-        return response;
-      },
-      error => {
-        // Used for token expiration by redirecting on login page
-        if (error.response.status === 401) {
-          window.location = uriLogin();
-        }
-        return error;
-      }
-    );
   }
 
   cancelAxiosRequests() {

--- a/client/src/components/Root/Root.jsx
+++ b/client/src/components/Root/Root.jsx
@@ -1,6 +1,7 @@
 import { Component } from 'react';
 import axios from 'axios';
 import { get, put, post, remove } from '../../utils/api';
+import { uriLogin } from '../../utils/endpoints';
 
 class Root extends Component {
   cancel = axios.CancelToken.source();
@@ -14,6 +15,19 @@ class Root extends Component {
     }
 
     this.cancelAxiosRequests();
+
+    axios.interceptors.response.use(
+      response => {
+        return response;
+      },
+      error => {
+        // Used for token expiration by redirecting on login page
+        if (error.response.status === 401) {
+          window.location = uriLogin();
+        }
+        return error;
+      }
+    );
   }
 
   cancelAxiosRequests() {


### PR DESCRIPTION
Fix #801

With the new permissions management, we have now an "Unauthorized" message on the screen when the token is expired
![image](https://github.com/tchiotludo/akhq/assets/2262145/1010f560-7241-4a96-a2ed-00e22c19b5e9)

I added an interceptor that redirects to the login page

