### PR TITLE
Cancel previous requests on search schema

### DIFF
--- a/client/src/containers/Schema/SchemaList/SchemaList.jsx
+++ b/client/src/containers/Schema/SchemaList/SchemaList.jsx
@@ -60,6 +60,11 @@ class SchemaList extends Root {
 
   handleSearch = data => {
     const { searchData } = data;
+
+    // Cancel previous requests is there are some to prevent UI issues
+    this.cancelAxiosRequests();
+    this.renewCancelToken();
+
     this.setState({ pageNumber: 1, searchData }, () => {
       this.getSchemaRegistry();
     });


### PR DESCRIPTION
With a large amount of schemas in the registry, the 1st request on the schema list can be slow before displaying results.
User can be tempted to search for schemas before the end of the pending request, creating a new request in //
We experienced that this behaviour causes inconsistency in the result table, mixing results from the 2 requests.
Cancelling pending requests if there are some when user search for a schema will prevent this behaviour