### PR TITLE
feat(helm): added ingress pathType

### DIFF
--- a/helm/akhq/templates/ingress.yaml
+++ b/helm/akhq/templates/ingress.yaml
@@ -36,7 +36,7 @@ spec:
 	{{- range $ingressPaths }}
           - path: {{ . }}
             {{- if eq (include "akhq.ingress.apiVersion" $) "networking.k8s.io/v1" }}
-            pathType: "ImplementationSpecific"
+            pathType: {{ $.Values.ingress.pathType | default "ImplementationSpecific" }}
             {{- end }}
             backend:
               {{- if eq (include "akhq.ingress.apiVersion" $) "networking.k8s.io/v1" }}

--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -121,6 +121,7 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   paths:
     - /
+  pathType: "ImplementationSpecific"
   hosts:
     - akhq.demo.com
   tls: []


### PR DESCRIPTION
As mentioned in #1534 the ingress `pathType ` was hardcoded to `ImplementationSpecific`, which is not optimal in every environment. I tried to make it possible to change the `pathType` in the values file. What do you think?

I'm using the default template function here as to not break existing setups.