### PR TITLE
Fix unhandled BufferUnderflowException on header deserialization

### DIFF
--- a/src/main/java/org/akhq/utils/ContentUtils.java
+++ b/src/main/java/org/akhq/utils/ContentUtils.java
@@ -2,9 +2,11 @@ package org.akhq.utils;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 
 public class ContentUtils {
+    private static final byte[] HEX_ARRAY = "0123456789ABCDEF".getBytes(StandardCharsets.US_ASCII);
 
     /**
      * Detects if bytes contain a UTF-8 string or something else
@@ -87,11 +89,22 @@ public class ContentUtils {
                         }
                     }
                 }
-            } catch(UnsupportedEncodingException ex) {
-                    valueAsObject = "[encoding error]";
+            } catch(Exception ex) {
+                // Show the header as hexadecimal string
+                valueAsObject = bytesToHex(value);
             }
         }
         return valueAsObject;
     }
 
+    // https://stackoverflow.com/questions/9655181/java-convert-a-byte-array-to-a-hex-string
+    public static String bytesToHex(byte[] bytes) {
+        byte[] hexChars = new byte[bytes.length * 2];
+        for (int j = 0; j < bytes.length; j++) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = HEX_ARRAY[v >>> 4];
+            hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
+        }
+        return new String(hexChars, StandardCharsets.UTF_8);
+    }
 }


### PR DESCRIPTION
When deserializing headers a BufferUnderflowException can be thrown after unsuccessful string, long, int and short deserialization. This exception is never catched. I propose to catch it and return the value of the byte[] header in an hex string