### PR TITLE
feat(core): allow to delete topic config (GH-362)

### DIFF
--- a/src/main/java/org/akhq/models/Config.java
+++ b/src/main/java/org/akhq/models/Config.java
@@ -46,6 +46,10 @@ public class Config {
         }
     }
 
+    public boolean shouldResetToDefault() {
+        return this.getValue().isBlank();
+    }
+
     private String findDescription(String name) {
         String docName = name.toUpperCase().replace(".", "_") + "_DOC";
 


### PR DESCRIPTION
When a config is deleted, it is reset to the default value.

No changes to the ui are necessary.

Resolves #362 