### PR TITLE
Check only cluster permissions on search for acl and schema

### DIFF
--- a/src/main/java/org/akhq/controllers/AclsController.java
+++ b/src/main/java/org/akhq/controllers/AclsController.java
@@ -29,10 +29,7 @@ public class AclsController extends AbstractController {
     @Operation(tags = {"acls"}, summary = "List all acls")
     @Get
     public List<AccessControl> list(HttpRequest<?> request, String cluster, Optional<String> search) throws ExecutionException, InterruptedException {
-        if (search.isPresent())
-            checkIfClusterAndResourceAllowed(cluster, search.get());
-        else
-            checkIfClusterAllowed(cluster);
+        checkIfClusterAllowed(cluster);
 
         return aclRepository.findAll(cluster, search, buildUserBasedResourceFilters(cluster));
     }

--- a/src/main/java/org/akhq/controllers/SchemaController.java
+++ b/src/main/java/org/akhq/controllers/SchemaController.java
@@ -64,10 +64,7 @@ public class SchemaController extends AbstractController {
         Optional<String> search,
         Optional<Integer> page
     ) throws IOException, RestClientException, ExecutionException, InterruptedException {
-        if (search.isPresent())
-            checkIfClusterAndResourceAllowed(cluster, search.get());
-        else
-            checkIfClusterAllowed(cluster);
+        checkIfClusterAllowed(cluster);
 
         URIBuilder uri = URIBuilder.fromURI(request.getUri());
         Pagination pagination = new Pagination(pageSize, uri, page.orElse(1));


### PR DESCRIPTION
During the ACL rewrite I did a mistake on the acl and schema search endpoint when user tries to search for a acl/schema if there are patterns set for his group. I should not not check the resource based on the patterns (but just the cluster) and let the `buildUserBasedResourceFilters` function to use patterns and filter results.
