### PR TITLE
feat(auth): customizable github SSO url (#1606)

### DIFF
--- a/src/main/java/org/akhq/security/authentication/GithubApiClient.java
+++ b/src/main/java/org/akhq/security/authentication/GithubApiClient.java
@@ -8,7 +8,7 @@ import org.reactivestreams.Publisher;
 
 @Header(name = "User-Agent", value = "Micronaut")
 @Header(name = "Accept", value = "application/vnd.github.v3+json, application/json")
-@Client("https://api.github.com")
+@Client("${github.api.url}")
 public interface GithubApiClient {
 
     @Get("/user")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,6 +66,9 @@ micronaut:
     kafka-wrapper:
       record-stats: true
       expire-after-write: 0s
+  http:
+    client:
+      github.api.url: https://api.github.com
 
 jackson:
   serialization:


### PR DESCRIPTION
The GitHub URL is customizable.
Default value 'https://api.github.com' setup in properties.yml

The сustom value can be set in environment variables
`export github.api.url=https://github.example.com`