### PR TITLE
Adding end timestamp filter

### DIFF
--- a/client/src/components/DatePicker/DatePicker.jsx
+++ b/client/src/components/DatePicker/DatePicker.jsx
@@ -43,11 +43,19 @@ class DatePicker extends Component {
 
   render = () => {
     const { value } = this.state;
-    const { showDateTimeInput, showTimeInput, showTimeSelect, onClear } = this.props;
+    const { showDateTimeInput, showTimeInput, showTimeSelect, onClear, label } = this.props;
     return (
       <div style={{ display: 'block', padding: 10 }}>
         {showDateTimeInput && (
-          <div style={{ marginBottom: 10, display: 'flex', flexDirection: 'row' }}>
+          <div
+            style={{
+              marginBottom: 10,
+              display: 'flex',
+              flexDirection: 'row',
+              alignItems: 'center'
+            }}
+          >
+            {label && <div style={{ marginRight: 10 }}>{label}</div>}
             <input
               value={this.getDisplayValue(value)}
               className="form-control"
@@ -91,6 +99,7 @@ class DatePicker extends Component {
 }
 
 DatePicker.propTypes = {
+  label: PropTypes.string,
   value: PropTypes.string,
   onChange: PropTypes.func,
   showDateTimeInput: PropTypes.bool,

--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -69,6 +69,7 @@ class TopicData extends Root {
     selectedTopic: this.props.topicId,
     cleanupPolicy: '',
     datetime: '',
+    endDatetime: '',
     roles: JSON.parse(sessionStorage.getItem('roles')),
     canDeleteRecords: false,
     percent: 0,

--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -45,6 +45,7 @@ class TopicData extends Root {
     partitionOptions: [],
     offsetsOptions: [],
     timestamp: '',
+    endTimestamp: '',
     search: {
       key: { text: '', type: 'C' },
       value: { text: '', type: 'C' },
@@ -123,6 +124,9 @@ class TopicData extends Root {
           : this.state.sortBy,
         partition: query.get('partition') ? query.get('partition') : this.state.partition,
         datetime: query.get('timestamp') ? new Date(query.get('timestamp')) : this.state.datetime,
+        endDatetime: query.get('endTimestamp')
+          ? new Date(query.get('endTimestamp'))
+          : this.state.endDatetime,
         offsetsSearch: query.get('after') ? query.get('after') : this.state.offsetsSearch,
         search: this._buildSearchFromQueryString(query),
         offsets: query.get('offset')
@@ -259,7 +263,7 @@ class TopicData extends Root {
   }
 
   _buildFilters() {
-    const { sortBy, partition, datetime, offsetsSearch, search } = this.state;
+    const { sortBy, partition, datetime, endDatetime, offsetsSearch, search } = this.state;
 
     const filters = [];
 
@@ -268,21 +272,11 @@ class TopicData extends Root {
     if (partition) filters.push(`partition=${partition}`);
 
     if (datetime) {
-      let timestamp = datetime.toString().length > 0 ? moment(datetime) : '';
-      timestamp =
-        formatDateTime(
-          {
-            year: timestamp.year(),
-            monthValue: timestamp.month(),
-            dayOfMonth: timestamp.date(),
-            hour: timestamp.hour(),
-            minute: timestamp.minute(),
-            second: timestamp.second(),
-            milli: timestamp.millisecond()
-          },
-          'YYYY-MM-DDTHH:mm:ss.SSS'
-        ) + 'Z';
-      filters.push(`timestamp=${timestamp}`);
+      filters.push(`timestamp=${this._buildTimestampFilter(datetime)}`);
+    }
+
+    if (endDatetime) {
+      filters.push(`endTimestamp=${this._buildTimestampFilter(endDatetime)}`);
     }
 
     Object.keys(search)
@@ -295,6 +289,24 @@ class TopicData extends Root {
         );
       });
     return filters.join('&');
+  }
+
+  _buildTimestampFilter(datetime) {
+    let timestamp = datetime.toString().length > 0 ? moment(datetime) : '';
+    return (
+      formatDateTime(
+        {
+          year: timestamp.year(),
+          monthValue: timestamp.month(),
+          dayOfMonth: timestamp.date(),
+          hour: timestamp.hour(),
+          minute: timestamp.minute(),
+          second: timestamp.second(),
+          milli: timestamp.millisecond()
+        },
+        'YYYY-MM-DDTHH:mm:ss.SSS'
+      ) + 'Z'
+    );
   }
 
   _searchMessages(changePage = false) {
@@ -769,6 +781,7 @@ class TopicData extends Root {
       recordCount,
       showFilters,
       datetime,
+      endDatetime,
       isSearching,
       canDeleteRecords,
       canDownload,
@@ -783,6 +796,7 @@ class TopicData extends Root {
     if (canDownload) actions.push(constants.TABLE_DOWNLOAD);
 
     let date = moment(datetime);
+    let endDate = moment(endDatetime);
     const { history } = this.props;
     const firstColumns = [
       { colName: 'Key', colSpan: 1 },
@@ -868,7 +882,7 @@ class TopicData extends Root {
                   <Dropdown.Toggle className="nav-link dropdown-toggle">
                     <strong>Timestamp UTC:</strong>
                     {datetime !== '' &&
-                      ' ' +
+                      ' From ' +
                         formatDateTime(
                           {
                             year: date.year(),
@@ -880,23 +894,59 @@ class TopicData extends Root {
                           },
                           'DD-MM-YYYY HH:mm'
                         )}
+                    {endDatetime !== '' &&
+                      ' To ' +
+                        formatDateTime(
+                          {
+                            year: endDate.year(),
+                            monthValue: endDate.month(),
+                            dayOfMonth: endDate.date(),
+                            hour: endDate.hour(),
+                            minute: endDate.minute(),
+                            second: endDate.second()
+                          },
+                          'DD-MM-YYYY HH:mm'
+                        )}
                   </Dropdown.Toggle>
                   {!loading && (
                     <Dropdown.Menu>
-                      <div className="input-group">
-                        <DatePicker
-                          onClear={() => {
-                            this.setState({ datetime: '' });
-                          }}
-                          showDateTimeInput
-                          showTimeSelect
-                          value={datetime}
-                          onChange={value => {
-                            this.setState({ datetime: value }, () => {
-                              this._searchMessages();
-                            });
-                          }}
-                        />
+                      <div style={{ display: 'flex' }}>
+                        <div>
+                          <DatePicker
+                            label="Start"
+                            onClear={() => {
+                              this.setState({ datetime: '' }, () => {
+                                this._searchMessages();
+                              });
+                            }}
+                            showDateTimeInput
+                            showTimeSelect
+                            value={datetime}
+                            onChange={value => {
+                              this.setState({ datetime: value }, () => {
+                                this._searchMessages();
+                              });
+                            }}
+                          />
+                        </div>
+                        <div>
+                          <DatePicker
+                            label="End"
+                            onClear={() => {
+                              this.setState({ endDatetime: '' }, () => {
+                                this._searchMessages();
+                              });
+                            }}
+                            showDateTimeInput
+                            showTimeSelect
+                            value={endDatetime}
+                            onChange={value => {
+                              this.setState({ endDatetime: value }, () => {
+                                this._searchMessages();
+                              });
+                            }}
+                          />
+                        </div>
                       </div>
                     </Dropdown.Menu>
                   )}

--- a/src/main/java/org/akhq/controllers/TopicController.java
+++ b/src/main/java/org/akhq/controllers/TopicController.java
@@ -203,6 +203,7 @@ public class TopicController extends AbstractController {
         Optional<Integer> partition,
         Optional<RecordRepository.Options.Sort> sort,
         Optional<String> timestamp,
+        Optional<String> endTimestamp,
         Optional<String> searchByKey,
         Optional<String> searchByValue,
         Optional<String> searchByHeaderKey,
@@ -220,6 +221,7 @@ public class TopicController extends AbstractController {
                         partition,
                         sort,
                         timestamp,
+                        endTimestamp,
                         searchByKey,
                         searchByValue,
                         searchByHeaderKey,
@@ -389,6 +391,7 @@ public class TopicController extends AbstractController {
         Optional<Integer> partition,
         Optional<RecordRepository.Options.Sort> sort,
         Optional<String> timestamp,
+        Optional<String> endTimestamp,
         Optional<String> searchByKey,
         Optional<String> searchByValue,
         Optional<String> searchByHeaderKey,
@@ -405,6 +408,7 @@ public class TopicController extends AbstractController {
             partition,
             sort,
             timestamp,
+            endTimestamp,
             searchByKey,
             searchByValue,
             searchByHeaderKey,
@@ -453,6 +457,7 @@ public class TopicController extends AbstractController {
             topicName,
             offset - 1 < 0 ? Optional.empty() : Optional.of(String.join("-", String.valueOf(partition), String.valueOf(offset - 1))),
             Optional.of(partition),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
@@ -538,6 +543,7 @@ public class TopicController extends AbstractController {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty()
         );
 
@@ -558,6 +564,7 @@ public class TopicController extends AbstractController {
         Optional<Integer> partition,
         Optional<RecordRepository.Options.Sort> sort,
         Optional<String> timestamp,
+        Optional<String> endTimestamp,
         Optional<String> searchByKey,
         Optional<String> searchByValue,
         Optional<String> searchByHeaderKey,
@@ -571,6 +578,7 @@ public class TopicController extends AbstractController {
         partition.ifPresent(options::setPartition);
         sort.ifPresent(options::setSort);
         timestamp.map(r -> Instant.parse(r).toEpochMilli()).ifPresent(options::setTimestamp);
+        endTimestamp.map(r -> Instant.parse(r).toEpochMilli()).ifPresent(options::setEndTimestamp);
         after.ifPresent(options::setAfter);
         searchByKey.ifPresent(options::setSearchByKey);
         searchByValue.ifPresent(options::setSearchByValue);

--- a/src/main/java/org/akhq/repositories/RecordRepository.java
+++ b/src/main/java/org/akhq/repositories/RecordRepository.java
@@ -784,6 +784,19 @@ public class RecordRepository extends AbstractRepository {
         return true;
     }
 
+    private boolean matchFilters(Options options, Record record) {
+        if (!matchFilters((BaseOptions) options, record)) {
+            return false;
+        }
+
+        if (options.getEndTimestamp() != null) {
+            return record.getTimestamp().toInstant().toEpochMilli() <= options.getEndTimestamp();
+        }
+
+        return true;
+    }
+
+
     private boolean matchFilter(Search searchFilter, Collection<String> stringsToSearch) {
         switch (searchFilter.searchMatchType) {
             case EQUALS:
@@ -1250,6 +1263,7 @@ public class RecordRepository extends AbstractRepository {
         private Sort sort;
         private Integer partition;
         private Long timestamp;
+        private Long endTimestamp;
 
         public Options(Environment environment, String clusterId, String topic) {
             this.sort = Sort.OLDEST;


### PR DESCRIPTION
When testing/qualifying a Kafka producer, we would like to see messages created during 2 timestamps (and also download them for later analysis - related to #1628).

I propose to add an end timestamp filter next to the current one and update the DatePicker component to add an optional label (showing Start / End here).

Result looks like this:
![image](https://github.com/tchiotludo/akhq/assets/2262145/594998dd-047e-46fd-ad7e-43556bb9f8b0)
