### PR TITLE
Adding JWT payload compression

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,6 +153,8 @@ dependencies {
     implementation group: 'software.amazon.msk', name: 'aws-msk-iam-auth', version: '2.0.0'
 
     implementation group: 'io.projectreactor', name: 'reactor-core', version: '3.5.11'
+
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 }
 
 /**********************************************************************************************************************\

--- a/src/main/java/org/akhq/controllers/AbstractController.java
+++ b/src/main/java/org/akhq/controllers/AbstractController.java
@@ -11,14 +11,12 @@ import jakarta.inject.Inject;
 import org.akhq.configs.security.Group;
 import org.akhq.configs.security.SecurityProperties;
 import org.akhq.security.annotation.AKHQSecured;
+import org.akhq.security.rule.AKHQSecurityRule;
 
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -52,8 +50,7 @@ abstract public class AbstractController {
             return List.of();
         }
 
-        List<Group> groupBindings = ((Map<String, List<?>>) authentication.get().getAttributes().get("groups"))
-            .values()
+        List<Group> groupBindings = AKHQSecurityRule.decompressGroups(authentication.get()).values()
             .stream()
             .flatMap(Collection::stream)
             .map(gb -> new ObjectMapper().convertValue(gb, Group.class))
@@ -155,7 +152,7 @@ abstract public class AbstractController {
         try {
             AKHQSecured annotation = getCallingAKHQSecuredAnnotation();
 
-            isAllowed = ((Map<String, List<?>>)authentication.get().getAttributes().get("groups")).values().stream()
+            isAllowed = AKHQSecurityRule.decompressGroups(authentication.get()).values().stream()
                 .flatMap(Collection::stream)
                 .map(gb -> new ObjectMapper().convertValue(gb, Group.class))
                 // Get only group with role matching the method annotation resource and action

--- a/src/main/java/org/akhq/security/claim/CustomClaimsGenerator.java
+++ b/src/main/java/org/akhq/security/claim/CustomClaimsGenerator.java
@@ -1,0 +1,45 @@
+package org.akhq.security.claim;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jwt.JWTClaimsSet;
+import io.jsonwebtoken.impl.compression.GzipCompressionAlgorithm;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.runtime.ApplicationConfiguration;
+import io.micronaut.security.authentication.Authentication;
+import io.micronaut.security.token.claims.ClaimsAudienceProvider;
+import io.micronaut.security.token.claims.JtiGenerator;
+import io.micronaut.security.token.config.TokenConfiguration;
+import io.micronaut.security.token.jwt.generator.claims.JWTClaimsSetGenerator;
+import jakarta.inject.Singleton;
+
+import java.util.Base64;
+
+@Singleton
+@Replaces(JWTClaimsSetGenerator.class)
+public class CustomClaimsGenerator extends JWTClaimsSetGenerator {
+    private final GzipCompressionAlgorithm gzip = new GzipCompressionAlgorithm();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    /**
+     * @param tokenConfiguration       Token Configuration
+     * @param jwtIdGenerator           Generator which creates unique JWT ID
+     * @param claimsAudienceProvider   Provider which identifies the recipients that the JWT is intended for.
+     * @param applicationConfiguration The application configuration
+     */
+    public CustomClaimsGenerator(TokenConfiguration tokenConfiguration, @Nullable JtiGenerator jwtIdGenerator, @Nullable ClaimsAudienceProvider claimsAudienceProvider, @Nullable ApplicationConfiguration applicationConfiguration) {
+        super(tokenConfiguration, jwtIdGenerator, claimsAudienceProvider, applicationConfiguration);
+    }
+
+    protected void populateWithAuthentication(JWTClaimsSet.Builder builder, Authentication authentication) {
+        super.populateWithAuthentication(builder, authentication);
+
+        try {
+            String plainGroups = mapper.writeValueAsString(builder.getClaims().get("groups"));
+            builder.claim("groups", Base64.getEncoder().encodeToString(gzip.compress(plainGroups.getBytes())));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Unable to build the JWT token, groups format is incorrect");
+        }
+    }
+}


### PR DESCRIPTION
Fix #1621
Fix #1585

After rewriting the authorization feature, the JWT token contains now more information than before (clusters regex for instance).

The 4Kb cookie constraint is invariant unless we change the `micronaut.security.authentication.cookie` to `bearer` to store the JWT token in the browser storage and send in in the `Authorization` header.

Some users raised that AKHQ doesn't work with bearer auth and OIDC providers like Keycloak. So no way exists to help them managing complex user permissions.

I propose to setup a JWT payload GZIP compression to reduce the JWT token size and hopefully, solve issues raised previously. Tests that I did with a real use case that we had in my company (that forced us to use bearer auth) are promising. It's compatible with all the authentication mechanisms (basic, ldap, oidc, etc.) because the compression is done by extending the `JWTClaimsSetGenerator` that creates the JWT token

Even if the JWT payload compression isn't standard for signed JWT, it's used by libraries like [JJWT](https://github.com/jwtk/jjwt?tab=readme-ov-file#compression)