### PR TITLE
Fixes tchiotludo/akhq#1632

### DIFF
--- a/src/test/java/org/akhq/repositories/SchemaRegistryRepositoryTest.java
+++ b/src/test/java/org/akhq/repositories/SchemaRegistryRepositoryTest.java
@@ -170,4 +170,13 @@ public class SchemaRegistryRepositoryTest extends AbstractTest {
     void getDefaultConfig() throws IOException, RestClientException {
         assertEquals(Schema.Config.CompatibilityLevelConfig.BACKWARD, repository.getDefaultConfig(KafkaTestCluster.CLUSTER_ID).getCompatibilityLevel());
     }
+
+    @Test
+    void getById() throws IOException, RestClientException, ExecutionException, InterruptedException {
+        Schema registeredSchema = repository.register(KafkaTestCluster.CLUSTER_ID, SUBJECT_1, SCHEMA_1_V1.toString(), Collections.emptyList());
+
+        Optional<Schema> schemaById = repository.getById(KafkaTestCluster.CLUSTER_ID, registeredSchema.getId());
+        assertFalse(schemaById.isEmpty());
+        assertEquals(schemaById.get().getId(), registeredSchema.getId());
+    }
 }


### PR DESCRIPTION
These changes supposed to fix the problem presented. But there might be a compatibility issue due to use of a relatively new Schema Registry REST method https://docs.confluent.io/platform/current/schema-registry/develop/api.html#get--schemas-ids-int-%20id-versions