### PR TITLE
Fix NPE for tombstone values in contains search

### DIFF
--- a/src/main/java/org/akhq/repositories/RecordRepository.java
+++ b/src/main/java/org/akhq/repositories/RecordRepository.java
@@ -811,6 +811,7 @@ public class RecordRepository extends AbstractRepository {
         }
 
         return in.parallelStream()
+    		.filter(Objects::nonNull)
             .anyMatch(s -> extractSearchPatterns(search)
                 .stream()
                 .anyMatch(s.toLowerCase()::contains));


### PR DESCRIPTION
Currently, search by value (contains) crashes with NPE while applying lowercase to record's value (=null), if one of topic's records is a tombstone:
![image](https://github.com/tchiotludo/akhq/assets/51787541/12d6e528-f3ae-4a51-bdc6-0245c371ec4b)

 I guess the `filter(Objects::nonNull)` was simply missed here, so adding it. Okay for you @AlexisSouquiere or am I missing something?