### PR TITLE
Fix body serialization error for config updates

### DIFF
--- a/src/main/java/org/akhq/controllers/NodeController.java
+++ b/src/main/java/org/akhq/controllers/NodeController.java
@@ -130,7 +130,7 @@ public class NodeController extends AbstractController {
     @AKHQSecured(resource = Role.Resource.NODE, action = Role.Action.ALTER_CONFIG)
     @Post("api/{cluster}/node/{nodeId}/configs")
     @Operation(tags = {"node"}, summary = "Update configs for a node")
-    public List<Config> nodeConfigUpdate(String cluster, Integer nodeId, @Body Map<String, String> configs) throws ExecutionException, InterruptedException {
+    public List<Config> nodeConfigUpdate(String cluster, Integer nodeId, @Body("configs") Map<String, String> configs) throws ExecutionException, InterruptedException {
         checkIfClusterAndResourceAllowed(cluster, nodeId.toString());
 
         List<Config> updated = ConfigRepository.updatedConfigs(configs, this.configRepository.findByBroker(cluster, nodeId), false);

--- a/src/main/java/org/akhq/controllers/TopicController.java
+++ b/src/main/java/org/akhq/controllers/TopicController.java
@@ -306,7 +306,7 @@ public class TopicController extends AbstractController {
     @AKHQSecured(resource = Role.Resource.TOPIC, action = Role.Action.ALTER_CONFIG)
     @Post(value = "api/{cluster}/topic/{topicName}/configs")
     @Operation(tags = {"topic"}, summary = "Update configs from a topic")
-    public List<Config> updateConfig(String cluster, String topicName, @Body Map<String, String> configs) throws ExecutionException, InterruptedException {
+    public List<Config> updateConfig(String cluster, String topicName, @Body("configs") Map<String, String> configs) throws ExecutionException, InterruptedException {
         checkIfClusterAndResourceAllowed(cluster, topicName);
 
         List<Config> updated = ConfigRepository.updatedConfigs(configs, this.configRepository.findByTopic(cluster, topicName), false);

--- a/src/test/java/org/akhq/controllers/NodeControllerTest.java
+++ b/src/test/java/org/akhq/controllers/NodeControllerTest.java
@@ -53,7 +53,7 @@ class NodeControllerTest extends AbstractTest {
         List<Config> result = this.retrieveList(
             HttpRequest.POST(
                 "/api/" +  KafkaTestCluster.CLUSTER_ID + "/node/0/configs",
-                ImmutableMap.of("max.connections.per.ip", s)
+                ImmutableMap.of("configs", ImmutableMap.of("max.connections.per.ip", s))
             ),
             Config.class
         );

--- a/src/test/java/org/akhq/controllers/TopicControllerTest.java
+++ b/src/test/java/org/akhq/controllers/TopicControllerTest.java
@@ -106,7 +106,7 @@ class TopicControllerTest extends AbstractTest {
         List<Config> result = this.retrieveList(
             HttpRequest.POST(
                 TOPIC_URL + "/configs",
-                ImmutableMap.of("message.timestamp.difference.max.ms", s)
+                ImmutableMap.of("configs", ImmutableMap.of("message.timestamp.difference.max.ms", s))
             ),
             Config.class
         );


### PR DESCRIPTION
Fix regression in #1615 after adding the `@Body` annotation on the config parameter in the controller endpoints.
On 2 config updates endpoints (topic configuration and node configuration), the endpoints takes a `Map<String, Integer> config` parameter sent in the body in a nested config attribute.

![image](https://github.com/tchiotludo/akhq/assets/2262145/d4ecc360-2c6a-4b42-b9ff-a7f490055109)

By adding the `@Body` annotation, the backend is not able anymore to deserialize the body. It produces this error

![image](https://github.com/tchiotludo/akhq/assets/2262145/b52f8688-ac4b-4c99-afc3-fb3e64b29386)

Solved by using the value attribute of the annotation to reference the nested `configs` field.
