### PR TITLE
fix(helm): can not specify NodePort for http port 80

### DIFF
--- a/helm/akhq/templates/service.yaml
+++ b/helm/akhq/templates/service.yaml
@@ -22,12 +22,15 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      {{- if and (eq "NodePort" .Values.service.type) .Values.service.httpNodePort }}
+      nodePort: {{ .Values.service.httpNodePort }}
+      {{- end }}
     - port: {{ .Values.service.managementPort }}
       targetPort: management
       protocol: TCP
       name: management
-      {{- if and (eq "NodePort" .Values.service.type) .Values.service.httpNodePort }}
-      nodePort: {{ .Values.service.httpNodePort }}
+      {{- if and (eq "NodePort" .Values.service.type) .Values.service.managementNodePort }}
+      nodePort: {{ .Values.service.managementNodePort }}
       {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "akhq.name" . }}

--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -109,6 +109,7 @@ service:
   port: 80
   managementPort: 28081
   #httpNodePort: 32551
+  #managementNodePort: 32552
   labels: {}
   annotations:
     # cloud.google.com/load-balancer-type: "Internal"


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/tchiotludo/akhq/pull/1285.

I added new value for setting `management` node port called: `managementNodePort`.