### PR TITLE
Add support for GLUE schema registry (only deserialization)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,10 @@ dependencies {
     //AWS MSK IAM Auth
     implementation group: 'software.amazon.msk', name: 'aws-msk-iam-auth', version: '2.0.0'
 
+    // AWS Glue serde
+    implementation ("software.amazon.glue:schema-registry-serde:1.1.15")
+
+
     implementation group: 'io.projectreactor', name: 'reactor-core', version: '3.5.11'
 
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'

--- a/src/main/java/org/akhq/configs/Connection.java
+++ b/src/main/java/org/akhq/configs/Connection.java
@@ -33,7 +33,8 @@ public class Connection extends AbstractProperties {
         String basicAuthUsername;
         String basicAuthPassword;
         SchemaRegistryType type = SchemaRegistryType.CONFLUENT;
-
+        String glueSchemaRegistryName;
+        String awsRegion;
         @MapFormat(transformation = MapFormat.MapTransformation.FLAT)
         Map<String, String> properties;
     }

--- a/src/main/java/org/akhq/configs/SchemaRegistryType.java
+++ b/src/main/java/org/akhq/configs/SchemaRegistryType.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 @Getter
 public enum SchemaRegistryType {
     CONFLUENT((byte) 0x0),
-    TIBCO((byte) 0x80);
+    TIBCO((byte) 0x80),
+    GLUE((byte) 0x0);
 
     private byte magicByte;
 

--- a/src/main/java/org/akhq/controllers/TopicController.java
+++ b/src/main/java/org/akhq/controllers/TopicController.java
@@ -188,7 +188,7 @@ public class TopicController extends AbstractController {
                             key.map(String::getBytes).orElse(null),
                             value.map(String::getBytes).orElse(null),
                             headers,
-                            targetTopic))
+                            targetTopic, null))
                     .collect(Collectors.toList());
     }
 
@@ -365,7 +365,8 @@ public class TopicController extends AbstractController {
             Base64.getDecoder().decode(key),
             null,
             new ArrayList<>(),
-            topicRepository.findByName(cluster, topicName)
+            topicRepository.findByName(cluster, topicName),
+            null
         );
     }
 

--- a/src/main/java/org/akhq/models/Record.java
+++ b/src/main/java/org/akhq/models/Record.java
@@ -83,10 +83,10 @@ public class Record {
     private byte MAGIC_BYTE;
 
     private Boolean truncated;
-    private Deserializer awsKafkaDeserializer;
+    private Deserializer awsGlueKafkaDeserializer;
 
 
-    public Record(RecordMetadata record, SchemaRegistryType schemaRegistryType, byte[] bytesKey, byte[] bytesValue, List<KeyValue<String, String>> headers, Topic topic, Deserializer awsKafkaDeserializer) {
+    public Record(RecordMetadata record, SchemaRegistryType schemaRegistryType, byte[] bytesKey, byte[] bytesValue, List<KeyValue<String, String>> headers, Topic topic, Deserializer awsGlueKafkaDeserializer) {
         this.MAGIC_BYTE = schemaRegistryType.getMagicByte();
         this.topic = topic;
         this.partition = record.partition();
@@ -100,12 +100,12 @@ public class Record {
         this.valueSubject = getAvroSchemaSubject(this.valueSchemaId);
         this.headers = headers;
         this.truncated = false;
-        this.awsKafkaDeserializer = awsKafkaDeserializer;
+        this.awsGlueKafkaDeserializer = awsGlueKafkaDeserializer;
     }
 
     public Record(SchemaRegistryClient client, ConsumerRecord<byte[], byte[]> record, SchemaRegistryType schemaRegistryType, Deserializer kafkaAvroDeserializer,
                   Deserializer kafkaJsonDeserializer, Deserializer kafkaProtoDeserializer, AvroToJsonSerializer avroToJsonSerializer,
-                  ProtobufToJsonDeserializer protobufToJsonDeserializer, AvroToJsonDeserializer avroToJsonDeserializer, byte[] bytesValue, Topic topic, Deserializer awsKafkaDeserializer) {
+                  ProtobufToJsonDeserializer protobufToJsonDeserializer, AvroToJsonDeserializer avroToJsonDeserializer, byte[] bytesValue, Topic topic, Deserializer awsGlueKafkaDeserializer) {
         if (schemaRegistryType == SchemaRegistryType.TIBCO) {
             this.MAGIC_BYTE = (byte) 0x80;
         } else {
@@ -135,7 +135,7 @@ public class Record {
         this.avroToJsonSerializer = avroToJsonSerializer;
         this.kafkaJsonDeserializer = kafkaJsonDeserializer;
         this.truncated = false;
-        this.awsKafkaDeserializer = awsKafkaDeserializer;
+        this.awsGlueKafkaDeserializer = awsGlueKafkaDeserializer;
     }
 
     public String getKey() {
@@ -179,8 +179,8 @@ public class Record {
         if (payload == null) {
             return null;
         }
-        else if (this.awsKafkaDeserializer != null) {
-            return this.awsKafkaDeserializer.deserialize(this.topic.getName(), payload).toString();
+        else if (this.awsGlueKafkaDeserializer != null) {
+            return this.awsGlueKafkaDeserializer.deserialize(this.topic.getName(), payload).toString();
 
         } else if (schemaId != null) {
             try {

--- a/src/main/java/org/akhq/repositories/RecordRepository.java
+++ b/src/main/java/org/akhq/repositories/RecordRepository.java
@@ -472,7 +472,7 @@ public class RecordRepository extends AbstractRepository {
             avroWireFormatConverter.convertValueToWireFormat(record, client,
                     this.schemaRegistryRepository.getSchemaRegistryType(clusterId)),
             topic,
-            schemaRegistryType == SchemaRegistryType.GLUE ? schemaRegistryRepository.getAwsKafkaDeserializer(clusterId): null
+            schemaRegistryType == SchemaRegistryType.GLUE ? schemaRegistryRepository.getAwsGlueKafkaDeserializer(clusterId): null
         ));
     }
 
@@ -492,7 +492,7 @@ public class RecordRepository extends AbstractRepository {
             avroWireFormatConverter.convertValueToWireFormat(record, client,
                     this.schemaRegistryRepository.getSchemaRegistryType(options.clusterId)),
             topic,
-            schemaRegistryType == SchemaRegistryType.GLUE ? schemaRegistryRepository.getAwsKafkaDeserializer(options.getClusterId()): null
+            schemaRegistryType == SchemaRegistryType.GLUE ? schemaRegistryRepository.getAwsGlueKafkaDeserializer(options.getClusterId()): null
         ));
     }
 

--- a/src/main/java/org/akhq/repositories/RecordRepository.java
+++ b/src/main/java/org/akhq/repositories/RecordRepository.java
@@ -471,7 +471,8 @@ public class RecordRepository extends AbstractRepository {
             this.customDeserializerRepository.getAvroToJsonDeserializer(clusterId),
             avroWireFormatConverter.convertValueToWireFormat(record, client,
                     this.schemaRegistryRepository.getSchemaRegistryType(clusterId)),
-            topic
+            topic,
+            schemaRegistryType == SchemaRegistryType.GLUE ? schemaRegistryRepository.getAwsKafkaDeserializer(clusterId): null
         ));
     }
 
@@ -490,7 +491,8 @@ public class RecordRepository extends AbstractRepository {
             this.customDeserializerRepository.getAvroToJsonDeserializer(options.clusterId),
             avroWireFormatConverter.convertValueToWireFormat(record, client,
                     this.schemaRegistryRepository.getSchemaRegistryType(options.clusterId)),
-            topic
+            topic,
+            schemaRegistryType == SchemaRegistryType.GLUE ? schemaRegistryRepository.getAwsKafkaDeserializer(options.getClusterId()): null
         ));
     }
 

--- a/src/main/java/org/akhq/repositories/SchemaRegistryRepository.java
+++ b/src/main/java/org/akhq/repositories/SchemaRegistryRepository.java
@@ -326,7 +326,7 @@ public class SchemaRegistryRepository extends AbstractRepository {
             params.put(AWSSchemaRegistryConstants.AWS_REGION,"eu-west-2" );
             params.put(AWSSchemaRegistryConstants.AVRO_RECORD_TYPE, AvroRecordType.GENERIC_RECORD.getName());
             params.put(AWSSchemaRegistryConstants.SECONDARY_DESERIALIZER, StringDeserializer.class.getName());
-            Map<String, String> otherProps = kafkaModule.getConnection(clusterId).getProperties();
+            Map<String, String> otherProps = kafkaModule.getConnection(clusterId).getSchemaRegistry().getProperties();
             if (otherProps != null) {
                 params.putAll(otherProps);
             }

--- a/src/main/java/org/akhq/repositories/SchemaRegistryRepository.java
+++ b/src/main/java/org/akhq/repositories/SchemaRegistryRepository.java
@@ -1,6 +1,6 @@
 package org.akhq.repositories;
 
-import com.amazonaws.services.schemaregistry.deserializers.avro.AWSKafkaAvroDeserializer;
+import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryKafkaDeserializer;
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
 import com.amazonaws.services.schemaregistry.utils.AvroRecordType;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -44,7 +44,7 @@ public class SchemaRegistryRepository extends AbstractRepository {
     private final Map<String, Deserializer> kafkaAvroDeserializers = new HashMap<>();
     private final Map<String, Deserializer> kafkaJsonDeserializers = new HashMap<>();
     private final Map<String, Deserializer> kafkaProtoDeserializers = new HashMap<>();
-    private final Map<String, Deserializer> awsKafkaDeserializers = new HashMap<>();
+    private final Map<String, Deserializer> awsGlueKafkaDeserializers = new HashMap<>();
 
 
     public PagedList<Schema> list(String clusterId, Pagination pagination, Optional<String> search, List<String> filters) throws IOException, RestClientException, ExecutionException, InterruptedException {
@@ -318,9 +318,9 @@ public class SchemaRegistryRepository extends AbstractRepository {
         }
         return schemaRegistryType;
     }
-    public Deserializer getAwsKafkaDeserializer(String clusterId) {
+    public Deserializer getAwsGlueKafkaDeserializer(String clusterId) {
 
-        if (!this.awsKafkaDeserializers.containsKey(clusterId)){
+        if (!this.awsGlueKafkaDeserializers.containsKey(clusterId)){
             Connection.SchemaRegistry schemaRegistry = kafkaModule.getConnection(clusterId).getSchemaRegistry();
             Map<String, Object> params = new HashMap<>();
             params.put(AWSSchemaRegistryConstants.REGISTRY_NAME, schemaRegistry.getGlueSchemaRegistryName());
@@ -333,9 +333,9 @@ public class SchemaRegistryRepository extends AbstractRepository {
             if (otherParams != null) {
                 params.putAll(otherParams);
             }
-            this.awsKafkaDeserializers.put(clusterId, new AWSKafkaAvroDeserializer(DefaultCredentialsProvider.builder().build(), params));
+            this.awsGlueKafkaDeserializers.put(clusterId, new GlueSchemaRegistryKafkaDeserializer(DefaultCredentialsProvider.builder().build(), params));
         }
-        return this.awsKafkaDeserializers.get(clusterId);
+        return this.awsGlueKafkaDeserializers.get(clusterId);
     }
 
     static {


### PR DESCRIPTION
My team at booking.com use Glue as the Schema registry and since AKHQ doesn't  support Glue, we have a hard time visualising avro/json serialised messages in the AKHQ ui.
This PR adds support for deserializing glue . I have tested with json and avro serialized messages and deserialisation worked fine.

Connection configuration looks like this :
     ` schema-registry:
           type: "glue"
           glueSchemaRegistryName: name_of_your_schema_registry
            awsRegion: aws_region_of_your_schema_registry`

Authentication is done using aws default credential provider chain!
 
