### PR TITLE
fix(topicdata): Hide 'Empty Topic' button when user doesn't have DELETE permission

### DIFF
--- a/client/src/containers/Topic/Topic/Topic.jsx
+++ b/client/src/containers/Topic/Topic/Topic.jsx
@@ -322,22 +322,27 @@ class Topic extends Root {
                   </Dropdown>
                 </div>
               )}
-              {this.canEmptyTopic() && roles.TOPIC_DATA && roles.TOPIC_DATA.includes('CREATE') ? (
-                <div
-                  onClick={() => {
-                    this.handleOnEmpty();
-                  }}
-                  className="btn btn-secondary mr-2"
-                >
-                  <i className="fa fa-fw fa-eraser" aria-hidden={true} /> Empty Topic
-                </div>
+
+              {roles.TOPIC_DATA && roles.TOPIC_DATA.includes('DELETE') ? (
+                this.canEmptyTopic() ? (
+                  <div
+                    onClick={() => {
+                      this.handleOnEmpty();
+                    }}
+                    className="btn btn-secondary mr-2"
+                  >
+                    <i className="fa fa-fw fa-eraser" aria-hidden={true} /> Empty Topic
+                  </div>
+                ) : (
+                  <div
+                    title="Only enabled for topics with Delete Cleanup Policy"
+                    className="btn disabled-black-button mr-2"
+                  >
+                    <i className="fa fa-fw fa-eraser" aria-hidden={true} /> Empty Topic
+                  </div>
+                )
               ) : (
-                <div
-                  title="Only enabled for topics with Delete Cleanup Policy"
-                  className="btn disabled-black-button mr-2"
-                >
-                  <i className="fa fa-fw fa-eraser" aria-hidden={true} /> Empty Topic
-                </div>
+                <></>
               )}
 
               {roles.TOPIC_DATA && roles.TOPIC_DATA.includes('CREATE') && (


### PR DESCRIPTION
Currently "Empty Topic" button is displayed for all users with:

- `topic/data/insert` role in 0.24.0
- `TOPIC_DATA` / `CREATE` action permission in dev

but deletion actually requires `topic/data/delete` (`TOPIC_DATA` / `DELETE`).

This PR changes display condition for "Empty Topic" to check for the same permission as `TopicController`.