### PR TITLE
Adding JsonIgnore on awsGlueKafkaDeserializer

### DIFF
--- a/src/main/java/org/akhq/models/Record.java
+++ b/src/main/java/org/akhq/models/Record.java
@@ -87,6 +87,7 @@ public class Record {
 
     @JsonIgnore
     private Boolean truncated;
+    @JsonIgnore
     private Deserializer awsGlueKafkaDeserializer;
 
 


### PR DESCRIPTION
Adding @JsonIgnore on awsGlueKafkaDeserializer field to prevent serializing it on download feature

![image](https://github.com/tchiotludo/akhq/assets/2262145/e379d7f5-a53c-465e-b4f3-1a4d7de0f74f)
