### PR TITLE
sec: Add exact name match on resource

### DIFF
--- a/docs/docs/configuration/authentifications/groups.md
+++ b/docs/docs/configuration/authentifications/groups.md
@@ -13,10 +13,12 @@ Define groups with specific roles for your users
 
 * `akhq.security.groups`: Groups map definition
   * `key:` a uniq key used as name if not specified
-    * A list of role/patterns/clusters association
+    * A list of role/patterns/names/clusters association
       * `role`: name of an existing role
-      * `patterns`: list of regular expression that resources from the given role must match at least once get access
-      * `clusters`: list of regular expression that cluster must match at least once to get access
+      * `patterns`: list of regular expression that resources from the given role must match at least once get access (default `.*`)
+      * `names`: list of names that resources from the given role must match exactly, if both patterns and names are set
+         then akhq uses a logic `or`, to be use alone the `patterns` must be set to an empty list
+      * `clusters`: list of regular expression that cluster must match at least once to get access (default `.*`)
 
 ::: warning
 Please also set the `micronaut.security.token.jwt.signatures.secret.generator.secret` if you set a group.
@@ -34,6 +36,17 @@ Here is an example of a `reader` group definition based on the default reader ro
       reader:
         - role: reader
           patterns: [ "pub.*" ]
+          clusters: [ "public" ]
+```
+
+Hereafter is the same example including all topics matching the pattern `pub.*` and one single topic with name `subscriber`.
+
+```yaml
+    groups:
+      reader:
+        - role: reader
+          patterns: [ "pub.*" ]
+          names: ["subscriber"]
           clusters: [ "public" ]
 ```
 

--- a/src/main/java/org/akhq/configs/security/Group.java
+++ b/src/main/java/org/akhq/configs/security/Group.java
@@ -2,11 +2,13 @@ package org.akhq.configs.security;
 
 import lombok.*;
 
+import java.util.Collections;
 import java.util.List;
 
 @Data
 public class Group {
     private String role;
     private List<String> patterns = List.of(".*");
+    private List<String> names = Collections.emptyList();
     private List<String> clusters = List.of(".*");
 }

--- a/src/main/java/org/akhq/controllers/AbstractController.java
+++ b/src/main/java/org/akhq/controllers/AbstractController.java
@@ -53,7 +53,7 @@ abstract public class AbstractController {
         var groups = AKHQSecurityRule.decompressGroups(authentication.get());
 
         if (groups == null) {
-           return List.of();
+            return List.of();
         }
 
         List<Group> groupBindings = groups.values()
@@ -135,7 +135,7 @@ abstract public class AbstractController {
     }
 
     protected void checkIfClusterAndResourceAllowed(String cluster, List<String> resources) {
-        for(String resource : resources) {
+        for (String resource : resources) {
             checkIfClusterAndResourceAllowed(cluster, resource);
         }
     }
@@ -173,8 +173,9 @@ abstract public class AbstractController {
                         .anyMatch(pattern -> Pattern.matches(pattern, cluster));
 
                     if (StringUtils.isNotEmpty(resource)) {
-                        allowed = allowed && group.getPatterns().stream()
-                            .anyMatch(pattern -> Pattern.matches(pattern, resource));
+                        allowed = allowed && (group.getPatterns().stream()
+                            .anyMatch(pattern -> Pattern.matches(pattern, resource))
+                            || group.getNames().contains(resource));
                     }
 
                     return allowed;


### PR DESCRIPTION
This PR makes it possible to set RBAC on resources based on patterns (as before), on exact name matches and a combinaison of both.