### PR TITLE
remove @JsonIgnore for topic field in Record.java

### DIFF
--- a/src/main/java/org/akhq/models/Record.java
+++ b/src/main/java/org/akhq/models/Record.java
@@ -36,7 +36,6 @@ import java.util.stream.Collectors;
 @Getter
 @NoArgsConstructor
 public class Record {
-    @JsonIgnore
     private Topic topic;
     private int partition;
     private long offset;


### PR DESCRIPTION
remove @JsonIgnore for topic field in Record.java . This is required to fix the tail functionality.
@tchiotludo , PR 1628 added this to not include topic info in the downloaded data but this breaks the tail functionality which we use almost on a daily basis (and yes we use dev version in our lower env)

The ui goes blank when there's an incoming record in the topic we are tailing and  this error can be seen from inspect element 
```
Tail.jsx:112 TypeError: Cannot read properties of undefined (reading 'name')
    at rowId (Tail.jsx:398:33)
    at Table.jsx:519:17
    at Array.forEach (<anonymous>)
    at o.value (Table.jsx:517:10)
    at Wa (react-dom.production.min.js:182:192)
    at Ba (react-dom.production.min.js:181:224)
    at Ss (react-dom.production.min.js:263:490)
    at vc (react-dom.production.min.js:246:265)
    at mc (react-dom.production.min.js:246:194)
    at sc (react-dom.production.min.js:239:172)
```

Could you  review/merge this asap 