### PR TITLE
Adding Jackson view on Record to limit fields in download

### DIFF
--- a/src/main/java/org/akhq/controllers/TopicController.java
+++ b/src/main/java/org/akhq/controllers/TopicController.java
@@ -1,7 +1,9 @@
 package org.akhq.controllers;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.micronaut.context.annotation.Value;
@@ -484,9 +486,12 @@ public class TopicController extends AbstractController {
 
         Topic topic = topicRepository.findByName(cluster, topicName);
 
-        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper mapper = JsonMapper.builder()
+            .configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false)
+            .build();
         // For ZonedDatetime serialization
         mapper.findAndRegisterModules();
+        mapper.setConfig(mapper.getSerializationConfig().withView(Record.Views.Download.class));
 
         PipedOutputStream out = new PipedOutputStream();
         PipedInputStream in = new PipedInputStream(out);

--- a/src/main/java/org/akhq/models/Record.java
+++ b/src/main/java/org/akhq/models/Record.java
@@ -3,6 +3,7 @@ package org.akhq.models;
 import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDeserializerDataParser;
 import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryKafkaDeserializer;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.protobuf.Message;
 import com.google.protobuf.util.JsonFormat;
@@ -39,15 +40,21 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 public class Record {
     private Topic topic;
+    @JsonView(Views.Download.class)
     private int partition;
+    @JsonView(Views.Download.class)
     private long offset;
+    @JsonView(Views.Download.class)
     private ZonedDateTime timestamp;
     @JsonIgnore
     private TimestampType timestampType;
+    @JsonView(Views.Download.class)
     private String keySchemaId;
     private String keySubject;
+    @JsonView(Views.Download.class)
     private String valueSchemaId;
     private String valueSubject;
+    @JsonView(Views.Download.class)
     private List<KeyValue<String, String>> headers = new ArrayList<>();
     @JsonIgnore
     private Deserializer kafkaAvroDeserializer;
@@ -70,12 +77,14 @@ public class Record {
     @Getter(AccessLevel.NONE)
     private byte[] bytesKey;
 
+    @JsonView(Views.Download.class)
     @Getter(AccessLevel.NONE)
     private String key;
 
     @Getter(AccessLevel.NONE)
     private byte[] bytesValue;
 
+    @JsonView(Views.Download.class)
     @Getter(AccessLevel.NONE)
     @Setter(AccessLevel.NONE)
     private String value;
@@ -353,4 +362,10 @@ public class Record {
         return null;
     }
 
+    /**
+     * Jackson views declaration
+     */
+    public static class Views {
+        public static class Download {}
+    }
 }


### PR DESCRIPTION
The topic field in Record add too many info in the downloaded file (all the topic partitions, leader, logDir, etc.)
<img width="288" alt="image" src="https://github.com/tchiotludo/akhq/assets/2262145/0d478f4d-0f8c-478a-b600-d5770843f8b1">

By introducing a Jackson view used only for the download endpoint, we can restrict fields to the important ones: headers, key, value, partition, offset, timestamp, key/value schema id without impacting the other endpoints that are serialising the Record class