### PR TITLE
Fix startTestKafkaCluster task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -253,7 +253,13 @@ task testInjectData(type:JavaExec) {
 
 test.dependsOn "startTestKafkaCluster"
 
-task startTestKafkaCluster(type: com.github.psxpaul.task.JavaExecFork, dependsOn: 'testClasses') {
+task startTestKafkaCluster(type: com.github.psxpaul.task.JavaExecFork) {
+    dependsOn 'testClasses'
+    dependsOn 'buildLayers'
+    dependsOn 'shadowDistZip'
+    dependsOn 'shadowDistTar'
+    dependsOn 'distZip'
+    dependsOn 'distTar'
     group = 'verification'
     description = 'Start a global standalone test Kafka cluster during tests'
     classpath = sourceSets.test.runtimeClasspath


### PR DESCRIPTION
Missing dependsOn declarations for gradle to build properly.

Repro:
- Clone the repo and checkout `dev`
- ./gradlew build

Output:
```
> Task :startTestKafkaCluster FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Some problems were found with the configuration of task ':startTestKafkaCluster' (type 'JavaExecFork').
  - Gradle detected a problem with the following location: '/Users/shane.kennedy/dev/klarna/akhq'.

    Reason: Task ':startTestKafkaCluster' uses this output of task ':distTar' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
```

And similar messages for distZip, shadowDistTar, shadowDistZip, buildLayers

Java version
```
akhq git:dev
❯ java --version
openjdk 17 2021-09-14
OpenJDK Runtime Environment Temurin-17+35 (build 17+35)
OpenJDK 64-Bit Server VM Temurin-17+35 (build 17+35, mixed mode)
```

Gradle version
```
akhq git:dev
❯ ./gradlew -v

------------------------------------------------------------
Gradle 8.5
------------------------------------------------------------

Build time:   2023-11-29 14:08:57 UTC
Revision:     28aca86a7180baa17117e0e5ba01d8ea9feca598

Kotlin:       1.9.20
Groovy:       3.0.17
Ant:          Apache Ant(TM) version 1.10.13 compiled on January 4 2023
JVM:          17 (Eclipse Adoptium 17+35)
OS:           Mac OS X 14.4.1 aarch64
```

Fix: 
Add missing build dependencies to the startTestKafkaCluster task
