### PR TITLE
Use no op security service when security is off #1705

### DIFF
--- a/src/main/java/org/akhq/modules/AuditModule.java
+++ b/src/main/java/org/akhq/modules/AuditModule.java
@@ -1,22 +1,14 @@
 package org.akhq.modules;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.micronaut.context.ApplicationContext;
-import io.micronaut.context.annotation.Requires;
-import io.micronaut.context.annotation.Value;
-import io.micronaut.security.authentication.Authentication;
-import jakarta.annotation.PostConstruct;
+import io.micronaut.security.utils.SecurityService;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import org.akhq.configs.Audit;
 import org.akhq.models.audit.AuditEvent;
-import io.micronaut.security.utils.SecurityService;
-import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.clients.producer.RecordMetadata;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Singleton
@@ -30,10 +22,6 @@ public class AuditModule {
 
     @Inject
     Audit auditConfig;
-
-    @Inject
-    ApplicationContext applicationContext;
-
 
     private final ObjectMapper mapper = new ObjectMapper();
 

--- a/src/test/java/org/akhq/modules/audit/KafkaAuditModuleNoSecTest.java
+++ b/src/test/java/org/akhq/modules/audit/KafkaAuditModuleNoSecTest.java
@@ -1,0 +1,44 @@
+package org.akhq.modules.audit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.akhq.KafkaClusterExtension;
+import org.akhq.KafkaTestCluster;
+import org.akhq.repositories.TopicRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * This only tests instantiation
+ */
+@ExtendWith(KafkaClusterExtension.class)
+@MicronautTest(environments = "audit-no-security")
+public class KafkaAuditModuleNoSecTest {
+
+    @Inject
+    @InjectMocks
+    protected TopicRepository topicRepository;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void before() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    void topicAudit() throws ExecutionException, InterruptedException, IOException {
+        topicRepository.create(KafkaTestCluster.CLUSTER_ID, "dummy-no-sec", 1, (short) 1, Collections.emptyList()
+        );
+
+    }
+
+}

--- a/src/test/java/org/akhq/modules/audit/KafkaAuditModuleNoSecTest.java
+++ b/src/test/java/org/akhq/modules/audit/KafkaAuditModuleNoSecTest.java
@@ -40,7 +40,7 @@ public class KafkaAuditModuleNoSecTest extends AbstractTest  {
 
     @Test
     void topicAuditNoSec() throws ExecutionException, InterruptedException {
-        topicRepository.create(KafkaTestCluster.CLUSTER_ID, "dummy-no-sec", 1, (short) 1, Collections.emptyList()
+        topicRepository.create(KafkaTestCluster.CLUSTER_ID, "generated_dummy-no-sec", 1, (short) 1, Collections.emptyList()
         );
     }
 

--- a/src/test/java/org/akhq/modules/audit/KafkaAuditModuleNoSecTest.java
+++ b/src/test/java/org/akhq/modules/audit/KafkaAuditModuleNoSecTest.java
@@ -1,15 +1,18 @@
 package org.akhq.modules.audit;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micronaut.context.ApplicationContext;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
+import org.akhq.AbstractTest;
 import org.akhq.KafkaClusterExtension;
 import org.akhq.KafkaTestCluster;
+import org.akhq.modules.KafkaModule;
 import org.akhq.repositories.TopicRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
@@ -21,13 +24,14 @@ import java.util.concurrent.ExecutionException;
  */
 @ExtendWith(KafkaClusterExtension.class)
 @MicronautTest(environments = "audit-no-security")
-public class KafkaAuditModuleNoSecTest {
+public class KafkaAuditModuleNoSecTest extends AbstractTest  {
 
     @Inject
     @InjectMocks
     protected TopicRepository topicRepository;
 
-    private final ObjectMapper mapper = new ObjectMapper();
+    @Mock
+    ApplicationContext applicationContext;
 
     @BeforeEach
     void before() {
@@ -35,10 +39,9 @@ public class KafkaAuditModuleNoSecTest {
     }
 
     @Test
-    void topicAudit() throws ExecutionException, InterruptedException, IOException {
+    void topicAuditNoSec() throws ExecutionException, InterruptedException {
         topicRepository.create(KafkaTestCluster.CLUSTER_ID, "dummy-no-sec", 1, (short) 1, Collections.emptyList()
         );
-
     }
 
 }

--- a/src/test/resources/application-audit-no-security.yml
+++ b/src/test/resources/application-audit-no-security.yml
@@ -1,6 +1,6 @@
 micronaut:
   security:
-    enabled: true
+    enabled: false
 akhq:
   audit:
     enabled: true

--- a/src/test/resources/application-audit-no-security.yml
+++ b/src/test/resources/application-audit-no-security.yml
@@ -1,6 +1,6 @@
 micronaut:
   security:
-    enabled: false
+    enabled: true
 akhq:
   audit:
     enabled: true

--- a/src/test/resources/application-audit-no-security.yml
+++ b/src/test/resources/application-audit-no-security.yml
@@ -1,0 +1,8 @@
+micronaut:
+  security:
+    enabled: false
+akhq:
+  audit:
+    enabled: true
+    cluster-id: test
+    topic-name: audit


### PR DESCRIPTION
When security is not enabled, we inject a NoOp security service implementation, this means the username would not be looked up but the rest of the audit feature would still work. Fixes #1704