### PR TITLE
Using hook instead of props

### DIFF
--- a/client/src/utils/api.jsx
+++ b/client/src/utils/api.jsx
@@ -2,12 +2,15 @@ import React from 'react';
 import axios from 'axios';
 import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
+import { useNavigate } from 'react-router-dom';
 
 const configs = {
   withCredentials: true
 };
 
 const handleError = err => {
+  const navigate = useNavigate();
+
   let error = {
     status: err.response ? err.response.status : '',
     message: err.response ? err.response.data.message : 'Internal Server Error',
@@ -24,7 +27,7 @@ const handleError = err => {
   if (err.response && err.response.status < 500) {
     if (err.response.status === 401 || err.response.status === 403) {
       localStorage.setItem('toastMessage', error.message);
-      this.props.router.navigate({ pathname: '/ui/login' }, { replace: true });
+      navigate({ pathname: '/ui/login' }, { replace: true });
     } else {
       toast.warn(error.message);
     }


### PR DESCRIPTION
The api.jsx had no withRouter component and therefore had no access to props.navigate. This was replaced by calling the hook directly. Fixes issue: https://github.com/tchiotludo/akhq/issues/1707