### PR TITLE
Tag master docker releases with "latest"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,6 +143,13 @@ jobs:
           images: |
             tchiotludo/akhq
             ghcr.io/${{ github.repository }}
+          tags: |
+            # set latest tag for master branch
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
 
       - name: Publish to registries
         uses: docker/build-push-action@v2
@@ -166,4 +173,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-


### PR DESCRIPTION
The latest tag should reflect the latest build for master, today I don't think this is automated from my understanding of the github actions used in this repo for docker commands

This PR adds one line that forces a "latest" tag if the branch is master, and adds the defaults defined [here](https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input). Without adding the defaults I believe we would stop tagging the dev releases since including a `tag` metadata overwrites the defaults

This fixes #496 