### PR TITLE
Fix incorrect placeholder value for kafkaSecrets, adding few more examples for volumes related values

### DIFF
--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -60,14 +60,27 @@ secrets: {}
 #            basic-auth-username: basic-auth-user
 #            basic-auth-password: basic-auth-pass
 
-kafkaSecrets: []
 #Provide extra base64 encoded kubernetes secrets (keystore/truststore)
+kafkaSecrets: {}
+#  truststore.jks: MIIIE...
+#  keystore.jks: MIIIE...
 
 # Any extra volumes to define for the pod (like keystore/truststore)
 extraVolumes: []
+#   - name: certstore-secret
+#     secret:
+#       secretName: akhq-secrets
+#       items:
+#         - key: "truststore.jks"
+#           path: "truststore.jks"
+#         - key: "keystore.jks"
+#           path: "keystore.jks"
 
 # Any extra volume mounts to define for the akhq container
 extraVolumeMounts: []
+#   - name: certstore-secret
+#     mountPath: "/secrets"
+#     readOnly: true
 
 # Specify ServiceAccount for pod
 serviceAccountName: null


### PR DESCRIPTION
Default value of kafkaSecret does not reflect how the value is handled in [secret.yaml#L15](https://github.com/tchiotludo/akhq/blob/dev/helm/akhq/templates/secret.yaml#L15) template - it should be an object not an array. Another possible solution would be to change the template but I find it to be more invasive while my change is mostly documentation.

Example:

Parsed incorrectly:
```
kafkaSecrets:
  - truststore.jks: MIIIE...
```

Parsed correctly:
```
kafkaSecrets:
  truststore.jks: MIIIE...
```

I have also included few more examples of how to define the aforementioned keystore/truststore and how to mount them.

Thank you for the work on AKHQ project, it's amazing!