### PR TITLE
Adding loading animation on topic data search

### DIFF
--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -262,7 +262,7 @@ class TopicData extends Root {
 
             if (records.length) {
               const tableMessages = self._handleMessages(records, self.state.sortBy === 'Oldest');
-              self.setState({ recordCount: tableMessages.length, messages: tableMessages });
+              self.setState({ recordCount: tableMessages.length, messages: tableMessages, loading: false });
             }
           });
 
@@ -281,7 +281,11 @@ class TopicData extends Root {
     if (this.eventSource) {
       this.eventSource.close();
     }
-    this.setState({ isSearching: false });
+
+    this.cancelAxiosRequests();
+    this.renewCancelToken();
+
+    this.setState({ isSearching: false, loading: false });
   };
 
   _clearSearch = () => {
@@ -354,6 +358,7 @@ class TopicData extends Root {
 
   _searchMessages(changePage = false, replaceInNavigation = false) {
     this._stopEventSource();
+    this.setState({ loading: true });
     if (this._hasAnyFilterFilled()) {
       this._startEventSource(changePage, replaceInNavigation);
     } else {
@@ -931,7 +936,7 @@ class TopicData extends Root {
                   <Dropdown.Toggle className="nav-link dropdown-toggle">
                     <strong>Sort:</strong> ({sortBy})
                   </Dropdown.Toggle>
-                  {!loading && <Dropdown.Menu>{this._renderSortOptions()}</Dropdown.Menu>}
+                  <Dropdown.Menu>{this._renderSortOptions()}</Dropdown.Menu>
                 </Dropdown>
               </li>
               <li className="nav-item dropdown">
@@ -939,13 +944,11 @@ class TopicData extends Root {
                   <Dropdown.Toggle className="nav-link dropdown-toggle">
                     <strong>Partition:</strong> ({partition})
                   </Dropdown.Toggle>
-                  {!loading && (
                     <Dropdown.Menu>
                       <div style={{ minWidth: '300px' }} className="khq-offset-navbar">
                         {this._renderPartitionOptions()}
                       </div>
                     </Dropdown.Menu>
-                  )}
                 </Dropdown>
               </li>
               <li className="nav-item dropdown">
@@ -979,7 +982,6 @@ class TopicData extends Root {
                           'DD-MM-YYYY HH:mm'
                         )}
                   </Dropdown.Toggle>
-                  {!loading && (
                     <Dropdown.Menu>
                       <div style={{ display: 'flex' }}>
                         <div>
@@ -1020,7 +1022,6 @@ class TopicData extends Root {
                         </div>
                       </div>
                     </Dropdown.Menu>
-                  )}
                 </Dropdown>
               </li>
               <li className="nav-item dropdown">
@@ -1028,7 +1029,7 @@ class TopicData extends Root {
                   <Dropdown.Toggle className="nav-link dropdown-toggle">
                     <strong>Search:</strong> {this._renderCurrentSearchText()}
                   </Dropdown.Toggle>
-                  {!loading && <Dropdown.Menu>{this._renderSearchGroup()}</Dropdown.Menu>}
+                  <Dropdown.Menu>{this._renderSearchGroup()}</Dropdown.Menu>
                 </Dropdown>
               </li>
               <li className="nav-item dropdown">
@@ -1036,7 +1037,6 @@ class TopicData extends Root {
                   <Dropdown.Toggle className="nav-link dropdown-toggle">
                     <strong>Offsets:</strong>
                   </Dropdown.Toggle>
-                  {!loading && (
                     <Dropdown.Menu>
                       <div style={{ minWidth: '300px' }} className="khq-offset-navbar">
                         <div className="input-group">
@@ -1066,7 +1066,6 @@ class TopicData extends Root {
                         </div>
                       </div>
                     </Dropdown.Menu>
-                  )}
                 </Dropdown>
               </li>
               <li>

--- a/client/src/containers/Topic/TopicList/TopicList.jsx
+++ b/client/src/containers/Topic/TopicList/TopicList.jsx
@@ -79,10 +79,10 @@ class TopicList extends Root {
     }
 
     if (this.props.location.search !== prevProps.location.search) {
+      const { searchData } = this.state;
       // Handle back navigation
       if (this.props.router.navigationType === 'POP') {
         let { clusterId } = this.props.params;
-        const { searchData } = this.state;
         const query = new URLSearchParams(this.props.location.search);
         this.setState(
           {
@@ -96,7 +96,10 @@ class TopicList extends Root {
         );
       } else if (this.props.location.search === '') {
         // Handle sidebar click on topics from the component
-        this.setState({ pageNumber: 1 }, () => {
+        this.setState({
+          pageNumber: 1,
+          searchData : { ...searchData, search: '' }
+        }, () => {
           this._initializeVars(this.getTopics);
         });
       }
@@ -176,6 +179,10 @@ class TopicList extends Root {
 
   handleSearch = data => {
     const { searchData } = data;
+
+    // Cancel previous requests if there are some to prevent UI issues
+    this.cancelAxiosRequests();
+    this.renewCancelToken();
 
     this.setState({ pageNumber: 1, searchData }, () => {
       const { topicListView } = this.state.searchData;


### PR DESCRIPTION
This PR re-add loading animation on topic data search to prevent a "freeze" feeling when applying filters (other than the Search one). When user select a partition, offset or something like this, they will wait few seconds before getting results. But the app never shows the user that the search is in progress. This time it fixes the issues found in #1709 by removing the loading animation the first time we get results in the SSE.

I also added a cancel of pending requests on topic list and data to prevent strange behaviour when user do a search before waiting the previous one to complete + fixed a small navigation issue on topic list (when clicking on Topics menu from the Topic list page)

Finally, I removed the loading check on the search filter that prevent user from using filters when a search is in progress