### PR TITLE
Ability to Add an Authentication Header for External REST API Authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,10 +52,12 @@ docker-compose.override.yml
 helm/akhq/README.md
 helm/akhq/LICENSE
 
-
 ## Docs
 docs/node_modules
 docs/.vuepress/.temp
 docs/.vuepress/.cache
 docs/.vuepress/public/contributors.html
 docs/.vuepress/dist
+
+/.factorypath
+/client/.settings

--- a/build.gradle
+++ b/build.gradle
@@ -145,6 +145,15 @@ dependencies {
     implementation group: "com.google.protobuf", name: "protobuf-java", version: '3.25.0'
     implementation group: "com.google.protobuf", name: "protobuf-java-util", version: '3.25.0'
 
+    //cenk is testing
+    implementation("io.micronaut:micronaut-http-client")
+    implementation("io.micronaut:micronaut-inject")
+    implementation("io.micronaut:micronaut-runtime")
+    implementation("jakarta.inject:jakarta.inject-api")
+    implementation("org.reactivestreams:reactive-streams")
+
+
+
     // Password hashing
     implementation group: "org.mindrot", name: "jbcrypt", version: "0.4"
 

--- a/docs/docs/configuration/authentifications/external.md
+++ b/docs/docs/configuration/authentifications/external.md
@@ -84,9 +84,9 @@ akhq:
     rest:
       enabled: true
       url: https://external.service/get-roles-and-attributes
-      token:
-        header: "Authorization"
-        value: Bearer your-token
+      headers:
+        - name: Authorization
+          value: Bearer your-token
 ````
 
 ::: warning

--- a/docs/docs/configuration/authentifications/external.md
+++ b/docs/docs/configuration/authentifications/external.md
@@ -76,6 +76,19 @@ and expect the following JSON as response :
   }
 }
 ````
+
+If you want to send a static authentication token to the external service where it might be public, you can extend the configuration for the rest interface as follows:
+````yaml
+akhq:
+  security:
+    rest:
+      enabled: true
+      url: https://external.service/get-roles-and-attributes
+      token:
+        header: "Authorization"
+        value: Bearer your-token
+````
+
 ::: warning
 The response must contain the `Content-Type: application/json` header to prevent any issue when reading the response.
 :::

--- a/src/main/java/org/akhq/security/claim/RestApiClaimProvider.java
+++ b/src/main/java/org/akhq/security/claim/RestApiClaimProvider.java
@@ -4,11 +4,11 @@ import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.annotation.Body;
-import io.micronaut.http.annotation.Header;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
+
 import org.akhq.models.security.ClaimProvider;
 import org.akhq.models.security.ClaimRequest;
 import org.akhq.models.security.ClaimResponse;
@@ -17,7 +17,6 @@ import org.akhq.models.security.ClaimResponse;
 @Requires(property = "akhq.security.rest.enabled", value = StringUtils.TRUE)
 @Client("${akhq.security.rest.url}")
 @ExecuteOn(TaskExecutors.BLOCKING)
-@Header(name = "${akhq.security.rest.token-header.name}", value = "${akhq.security.rest.token-header.value}")
 public interface RestApiClaimProvider extends ClaimProvider {
     @Post
     @Override

--- a/src/main/java/org/akhq/security/claim/RestApiClaimProvider.java
+++ b/src/main/java/org/akhq/security/claim/RestApiClaimProvider.java
@@ -4,6 +4,7 @@ import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Header;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.scheduling.TaskExecutors;
@@ -16,6 +17,7 @@ import org.akhq.models.security.ClaimResponse;
 @Requires(property = "akhq.security.rest.enabled", value = StringUtils.TRUE)
 @Client("${akhq.security.rest.url}")
 @ExecuteOn(TaskExecutors.BLOCKING)
+@Header(name = "${akhq.security.rest.token-header.name}", value = "${akhq.security.rest.token-header.value}")
 public interface RestApiClaimProvider extends ClaimProvider {
     @Post
     @Override

--- a/src/main/java/org/akhq/security/claim/RestApiClaimProviderFilter.java
+++ b/src/main/java/org/akhq/security/claim/RestApiClaimProviderFilter.java
@@ -1,23 +1,27 @@
 package org.akhq.security.claim;
 
-import java.util.List;
-import java.util.Map;
-
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.annotation.ClientFilter;
-import io.micronaut.http.annotation.RequestFilter;
+import io.micronaut.http.filter.ClientFilterChain;
+import io.micronaut.http.filter.HttpClientFilter;
+import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
 
 @Primary
 @Requires(property = "akhq.security.rest.enabled", value = StringUtils.TRUE)
 @Requires(property = "akhq.security.rest.headers")
 @ClientFilter("${akhq.security.rest.url}")
-public class RestApiClaimProviderFilter {
+public class RestApiClaimProviderFilter implements HttpClientFilter {
     private static final Logger LOG = LoggerFactory.getLogger(RestApiClaimProviderFilter.class);
 
     private static final String HEADER_KEY = "name";
@@ -26,10 +30,10 @@ public class RestApiClaimProviderFilter {
     @Property(name = "akhq.security.rest.headers")
     private List<Map<String, String>> headers;
 
-    @RequestFilter
-    public void filter(MutableHttpRequest<?> request) {
-        LOG.trace("Modifying outgoing authentication request.");
-
+    @Override
+    public Publisher<? extends HttpResponse<?>> doFilter(MutableHttpRequest<?> request, ClientFilterChain chain) {
+        LOG.trace("Modifying outgoing authentication request. from muttable");
         headers.forEach(header -> request.header(header.get(HEADER_KEY), header.get(HEADER_VALUE)));
+        return Mono.from(chain.proceed(request));
     }
 }

--- a/src/main/java/org/akhq/security/claim/RestApiClaimProviderFilter.java
+++ b/src/main/java/org/akhq/security/claim/RestApiClaimProviderFilter.java
@@ -3,33 +3,25 @@ package org.akhq.security.claim;
 import java.util.List;
 import java.util.Map;
 
-import org.reactivestreams.Publisher;
-
-import edu.umd.cs.findbugs.annotations.Nullable;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.context.annotation.Value;
-import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.annotation.ClientFilter;
-import io.micronaut.http.filter.ClientFilterChain;
-import io.micronaut.http.filter.HttpClientFilter;
+import io.micronaut.http.annotation.RequestFilter;
 
 @Requires(property = "akhq.security.rest.enabled", value = StringUtils.TRUE)
 @Requires(property = "akhq.security.rest.headers")
-@ClientFilter("${akhq.security.rest.url}/**")
-public class RestApiClaimProviderFilter implements HttpClientFilter {
+@ClientFilter("${akhq.security.rest.url}")
+public class RestApiClaimProviderFilter {
     private static final String HEADER_KEY = "name";
     private static final String HEADER_VALUE = "value";
 
-    @Nullable
     @Value("${akhq.security.rest.headers}")
     private List<Map<String, String>> headers;
 
-    @Override
-    public Publisher<? extends HttpResponse<?>> doFilter(MutableHttpRequest<?> request, ClientFilterChain chain) {
+    @RequestFilter
+    public void filter(MutableHttpRequest<?> request) {
         this.headers.forEach(header -> request.header(header.get(HEADER_KEY), header.get(HEADER_VALUE)));
-
-        return chain.proceed(request);
     }
 }

--- a/src/main/java/org/akhq/security/claim/RestApiClaimProviderFilter.java
+++ b/src/main/java/org/akhq/security/claim/RestApiClaimProviderFilter.java
@@ -32,8 +32,9 @@ public class RestApiClaimProviderFilter implements HttpClientFilter {
 
     @Override
     public Publisher<? extends HttpResponse<?>> doFilter(MutableHttpRequest<?> request, ClientFilterChain chain) {
-        LOG.trace("Modifying outgoing authentication request. from muttable");
+        LOG.trace("Modifying outgoing authentication request.");
         headers.forEach(header -> request.header(header.get(HEADER_KEY), header.get(HEADER_VALUE)));
+
         return Mono.from(chain.proceed(request));
     }
 }

--- a/src/main/java/org/akhq/security/claim/RestApiClaimProviderFilter.java
+++ b/src/main/java/org/akhq/security/claim/RestApiClaimProviderFilter.java
@@ -1,0 +1,35 @@
+package org.akhq.security.claim;
+
+import java.util.List;
+import java.util.Map;
+
+import org.reactivestreams.Publisher;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.annotation.ClientFilter;
+import io.micronaut.http.filter.ClientFilterChain;
+import io.micronaut.http.filter.HttpClientFilter;
+
+@Requires(property = "akhq.security.rest.enabled", value = StringUtils.TRUE)
+@Requires(property = "akhq.security.rest.headers")
+@ClientFilter("${akhq.security.rest.url}/**")
+public class RestApiClaimProviderFilter implements HttpClientFilter {
+    private static final String HEADER_KEY = "name";
+    private static final String HEADER_VALUE = "value";
+
+    @Nullable
+    @Value("${akhq.security.rest.headers}")
+    private List<Map<String, String>> headers;
+
+    @Override
+    public Publisher<? extends HttpResponse<?>> doFilter(MutableHttpRequest<?> request, ClientFilterChain chain) {
+        this.headers.forEach(header -> request.header(header.get(HEADER_KEY), header.get(HEADER_VALUE)));
+
+        return chain.proceed(request);
+    }
+}

--- a/src/main/java/org/akhq/security/claim/RestApiClaimProviderFilter.java
+++ b/src/main/java/org/akhq/security/claim/RestApiClaimProviderFilter.java
@@ -3,25 +3,33 @@ package org.akhq.security.claim;
 import java.util.List;
 import java.util.Map;
 
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.util.StringUtils;
-import io.micronaut.context.annotation.Value;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.annotation.ClientFilter;
 import io.micronaut.http.annotation.RequestFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+@Primary
 @Requires(property = "akhq.security.rest.enabled", value = StringUtils.TRUE)
 @Requires(property = "akhq.security.rest.headers")
 @ClientFilter("${akhq.security.rest.url}")
 public class RestApiClaimProviderFilter {
+    private static final Logger LOG = LoggerFactory.getLogger(RestApiClaimProviderFilter.class);
+
     private static final String HEADER_KEY = "name";
     private static final String HEADER_VALUE = "value";
 
-    @Value("${akhq.security.rest.headers}")
+    @Property(name = "akhq.security.rest.headers")
     private List<Map<String, String>> headers;
 
     @RequestFilter
     public void filter(MutableHttpRequest<?> request) {
-        this.headers.forEach(header -> request.header(header.get(HEADER_KEY), header.get(HEADER_VALUE)));
+        LOG.trace("Modifying outgoing authentication request.");
+
+        headers.forEach(header -> request.header(header.get(HEADER_KEY), header.get(HEADER_VALUE)));
     }
 }

--- a/src/test/java/org/akhq/security/claim/RestApiClaimProviderTest.java
+++ b/src/test/java/org/akhq/security/claim/RestApiClaimProviderTest.java
@@ -100,11 +100,11 @@ public class RestApiClaimProviderTest {
 
             return "{\n" +
                     "  \"groups\" : {" +
-                    "\"limited\": [{" +
-                    "\"role\": \"topic-read\"," +
-                    "\"patterns\": [\"user.*\"]," +
-                    "\"clusters\": [\"pub.*\"]" +
-                    "}]" +
+                        "\"limited\": [{" +
+                            "\"role\": \"topic-read\"," +
+                            "\"patterns\": [\"user.*\"]," +
+                            "\"clusters\": [\"pub.*\"]" +
+                        "}]" +
                     "}" +
                     "}";
         }

--- a/src/test/java/org/akhq/security/claim/RestApiClaimProviderTest.java
+++ b/src/test/java/org/akhq/security/claim/RestApiClaimProviderTest.java
@@ -14,6 +14,7 @@ import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Filter;
+import io.micronaut.http.annotation.Header;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.filter.HttpServerFilter;
@@ -33,6 +34,7 @@ import java.text.ParseException;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import jakarta.annotation.security.PermitAll;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -90,7 +92,11 @@ public class RestApiClaimProviderTest {
     @Controller("/external-mock")
     static class RestApiExternalService {
         @Post
-        String generateClaim(@Body ClaimRequest request) {
+        String generateClaim(@Body ClaimRequest request, @Header("X-Custom-Authentication") Optional<String> authHeader) {
+            if (authHeader.isEmpty() || !"Bearer custom-authentication".equals(authHeader)) {
+                throw new RuntimeException("Invalid custom authentication header.");
+            }
+
             return
                 "{\n" +
                     "  \"groups\" : {" +
@@ -104,4 +110,3 @@ public class RestApiClaimProviderTest {
         }
     }
 }
-

--- a/src/test/java/org/akhq/security/claim/RestApiClaimProviderTest.java
+++ b/src/test/java/org/akhq/security/claim/RestApiClaimProviderTest.java
@@ -98,7 +98,8 @@ public class RestApiClaimProviderTest {
                 throw new RuntimeException("Invalid custom authentication header.");
             }
 
-            return "{\n" +
+            return
+                "{\n" +
                     "  \"groups\" : {" +
                         "\"limited\": [{" +
                             "\"role\": \"topic-read\"," +
@@ -106,7 +107,7 @@ public class RestApiClaimProviderTest {
                             "\"clusters\": [\"pub.*\"]" +
                         "}]" +
                     "}" +
-                    "}";
+                "}";
         }
     }
 }

--- a/src/test/java/org/akhq/security/claim/RestApiClaimProviderTest.java
+++ b/src/test/java/org/akhq/security/claim/RestApiClaimProviderTest.java
@@ -92,21 +92,21 @@ public class RestApiClaimProviderTest {
     @Controller("/external-mock")
     static class RestApiExternalService {
         @Post
-        String generateClaim(@Body ClaimRequest request, @Header("X-Custom-Authentication") Optional<String> authHeader) {
-            if (authHeader.isEmpty() || !"Bearer custom-authentication".equals(authHeader)) {
+        String generateClaim(@Body ClaimRequest request,
+                @Header("X-Custom-Authentication") Optional<String> authHeader) {
+            if (authHeader.isEmpty() || !authHeader.get().equals("Bearer custom-authentication")) {
                 throw new RuntimeException("Invalid custom authentication header.");
             }
 
-            return
-                "{\n" +
+            return "{\n" +
                     "  \"groups\" : {" +
-                        "\"limited\": [{" +
-                            "\"role\": \"topic-read\"," +
-                            "\"patterns\": [\"user.*\"]," +
-                            "\"clusters\": [\"pub.*\"]" +
-                        "}]" +
-                    "}"+
-                "}";
+                    "\"limited\": [{" +
+                    "\"role\": \"topic-read\"," +
+                    "\"patterns\": [\"user.*\"]," +
+                    "\"clusters\": [\"pub.*\"]" +
+                    "}]" +
+                    "}" +
+                    "}";
         }
     }
 }

--- a/src/test/resources/application-rest-api.yml
+++ b/src/test/resources/application-rest-api.yml
@@ -34,4 +34,7 @@ akhq:
           - admin
     rest:
       enabled: true
+      token-header:
+        name: X-Custom-Authentication
+        value: Bearer custom-authentication
       url: /external-mock

--- a/src/test/resources/application-rest-api.yml
+++ b/src/test/resources/application-rest-api.yml
@@ -34,7 +34,7 @@ akhq:
           - admin
     rest:
       enabled: true
-      token-header:
-        name: X-Custom-Authentication
-        value: Bearer custom-authentication
+      headers:
+        - name: X-Custom-Authentication
+          value: Bearer custom-authentication
       url: /external-mock

--- a/src/test/resources/application-rest-api.yml
+++ b/src/test/resources/application-rest-api.yml
@@ -34,7 +34,7 @@ akhq:
           - admin
     rest:
       enabled: true
+      url: /external-mock
       headers:
         - name: X-Custom-Authentication
           value: Bearer custom-authentication
-      url: /external-mock


### PR DESCRIPTION
Dear @tchiotludo,

Thank you for your time on still maintaining and improving this project and very excited for the upcoming release.

I have added a draft where it will allow users that are using the external REST authentication method to add a single authentication header while they are doing their requests.

This might become useful, at least in our case is, where the external authentication API is also exposed to the internet, and the user wants to limit this access just through a static token that is passed through the service.

This draft implements this functionality in the most basic form with the ability to add a single header to the request.

I would kindly request you to inform me back and what I can improve if you find this feature also a feasible thing to add to the next release.