### PR TITLE
fix(auth): set default value correctly for github api (#1775)

### DIFF
--- a/docs/docs/configuration/authentifications/github.md
+++ b/docs/docs/configuration/authentifications/github.md
@@ -22,6 +22,12 @@ micronaut:
             auth-method: client-secret-post
 ```
 
+You can also override the GitHub API url if needed. Default value is https://api.github.com
+
+```yaml
+github.api.url: https://override.api.github.com
+```
+
 To further tell AKHQ to display GitHub SSO options on the login page and customize claim mapping, configure Oauth in the AKHQ config:
 
 ```yaml

--- a/src/main/java/org/akhq/security/authentication/GithubApiClient.java
+++ b/src/main/java/org/akhq/security/authentication/GithubApiClient.java
@@ -8,7 +8,7 @@ import org.reactivestreams.Publisher;
 
 @Header(name = "User-Agent", value = "Micronaut")
 @Header(name = "Accept", value = "application/vnd.github.v3+json, application/json")
-@Client("${github.api.url}")
+@Client("${github.api.url:`https://api.github.com`}")
 public interface GithubApiClient {
 
     @Get("/user")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,7 +71,7 @@ micronaut:
   http:
     client:
       allow-block-event-loop: true
-      github.api.url: https://api.github.com
+
 
 jackson:
   serialization:


### PR DESCRIPTION
Fix #1775 

Set https://api.github.com as default value in the Client URL placeholder
Update doc to explain how to override it
Remove the default value from application.yml (and also because the definition was incorrect)