### PR TITLE
fix(AkhqRoutes): check for correct role defined before before calling into it

### DIFF
--- a/client/src/utils/AkhqRoutes.jsx
+++ b/client/src/utils/AkhqRoutes.jsx
@@ -159,7 +159,7 @@ class AkhqRoutes extends Root {
                 <Route exact path="/ui/:clusterId/topic/create" element={<TopicCreate />} />
               )}
 
-              {roles && roles.TOPIC && roles.TOPIC_DATA.includes('CREATE') && (
+              {roles && roles.TOPIC_DATA && roles.TOPIC_DATA.includes('CREATE') && (
                 <Route
                   exact
                   path="/ui/:clusterId/topic/:topicId/produce"
@@ -167,7 +167,7 @@ class AkhqRoutes extends Root {
                 />
               )}
 
-              {roles && roles.TOPIC && roles.TOPIC_DATA.includes('CREATE') && (
+              {roles && roles.TOPIC_DATA && roles.TOPIC_DATA.includes('CREATE') && (
                 <Route
                   exact
                   path="/ui/:clusterId/topic/:topicId/increasepartition"
@@ -175,7 +175,7 @@ class AkhqRoutes extends Root {
                 />
               )}
 
-              {roles && roles.TOPIC && roles.TOPIC_DATA.includes('CREATE') && (
+              {roles && roles.TOPIC_DATA && roles.TOPIC_DATA.includes('CREATE') && (
                 <Route exact path="/ui/:clusterId/topic/:topicId/copy" element={<TopicCopy />} />
               )}
 
@@ -187,7 +187,7 @@ class AkhqRoutes extends Root {
                 />
               )}
 
-              {roles && roles.TOPIC && roles.TOPIC_DATA.includes('READ') && (
+              {roles && roles.TOPIC_DATA && roles.TOPIC_DATA.includes('READ') && (
                 <Route exact path="/ui/:clusterId/tail" element={<Tail />} />
               )}
 


### PR DESCRIPTION
Closes #1784 

Due to errors mentioned in #1784, I suspect some of the boolean expressions checking for select actions on roles to be wrong. This PR will make sure a role is defined before trying to look up its actions.

PTAL, @AlexisSouquiere 