### PR TITLE
fix(docs): make links clickable on AWS Auth page

### DIFF
--- a/docs/docs/configuration/authentifications/aws-iam-auth.md
+++ b/docs/docs/configuration/authentifications/aws-iam-auth.md
@@ -19,5 +19,5 @@ akhq:
 ```
 
 ## References
-https://docs.aws.amazon.com/msk/latest/developerguide/iam-access-control.html
-https://github.com/aws/aws-msk-iam-auth/blob/main/README.md
+[https://docs.aws.amazon.com/msk/latest/developerguide/iam-access-control.html](https://docs.aws.amazon.com/msk/latest/developerguide/iam-access-control.html)
+[https://github.com/aws/aws-msk-iam-auth/blob/main/README.md](https://github.com/aws/aws-msk-iam-auth/blob/main/README.md)


### PR DESCRIPTION
This pull request makes the reference links clickable on the 'AWS MSK IAM Auth' documentation page : https://akhq.io/docs/configuration/authentifications/aws-iam-auth.html