### PR TITLE
feat(ui): support other naming strategies in schema dropdowns on topic produce

### DIFF
--- a/client/src/containers/Topic/TopicProduce/TopicProduce.jsx
+++ b/client/src/containers/Topic/TopicProduce/TopicProduce.jsx
@@ -122,8 +122,8 @@ class TopicProduce extends Form {
     let schema = await this.getApi(uriAllSchema(clusterId));
     let keySchema = [];
     let valueSchema = [];
-    schema.data.filter(s => s.includes('-key')).map(s => keySchema.push(s));
-    schema.data.filter(s => s.includes('-value')).map(s => valueSchema.push(s));
+    schema.data.filter(s => !s.includes('-value')).map(s => keySchema.push(s));
+    schema.data.filter(s => !s.includes('-key')).map(s => valueSchema.push(s));
     this.setState({
       keySchema: keySchema,
       valueSchema: valueSchema,


### PR DESCRIPTION
Fix #1783 

This PR allows subjects that don't follow TopicNameStrategy to be displayed in the key/value schema dropdowns
In the following example, the customSubject subject is now available in the 2 dropdowns 

Subjects list:
<img width="377" alt="image" src="https://github.com/tchiotludo/akhq/assets/2262145/e00faf65-f4c6-4eb2-ad5e-441fc03526ea">

Key dropdown
<img width="453" alt="image" src="https://github.com/tchiotludo/akhq/assets/2262145/93dbb983-4936-42db-81c4-97e0b2c7d66b">

Value dropdown
<img width="553" alt="image" src="https://github.com/tchiotludo/akhq/assets/2262145/31cf6059-105c-46e7-8788-e6a2adf6bb37">
