### PR TITLE
fix(ui): broken error handling for all api requests

### DIFF
--- a/client/src/utils/api.jsx
+++ b/client/src/utils/api.jsx
@@ -2,15 +2,12 @@ import React from 'react';
 import axios from 'axios';
 import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-import { useNavigate } from 'react-router-dom';
 
 const configs = {
   withCredentials: true
 };
 
 const handleError = err => {
-  const navigate = useNavigate();
-
   let error = {
     status: err.response ? err.response.status : '',
     message: err.response ? err.response.data.message : 'Internal Server Error',
@@ -27,7 +24,7 @@ const handleError = err => {
   if (err.response && err.response.status < 500) {
     if (err.response.status === 401 || err.response.status === 403) {
       localStorage.setItem('toastMessage', error.message);
-      navigate({ pathname: '/ui/login' }, { replace: true });
+      location.href = '/ui/login';
     } else {
       toast.warn(error.message);
     }


### PR DESCRIPTION
fixes: https://github.com/tchiotludo/akhq/issues/1807

This is currently affecting all error handling for failed api requests

handleError is not inside a component and so hooks can't be used.

React-router suggests using the redirect function instead of useNavigate but this only works if it's inside a loader/action which I don't think we necessarily are.

Tested and this works, normal error handling shows a toast and if I get a 401/403 im redirected to the login page and i still see a toast with the error message 👍 