### PR TITLE
feat(topic): give the true first offset on compacted topics

### DIFF
--- a/src/test/java/org/akhq/controllers/TopicControllerTest.java
+++ b/src/test/java/org/akhq/controllers/TopicControllerTest.java
@@ -117,20 +117,10 @@ class TopicControllerTest extends AbstractTest {
     @Test
     @Order(1)
     void dataApi() {
-        ResultNextList<Record> result;
-        String after = TOPIC_URL + "/data";
-
-        int count = 0;
-        while (after != null) {
-            result = this.retrieveNextList(HttpRequest.GET(after), Record.class);
-            assertEquals(300, result.getSize());
-            if (result.getResults() != null) {
-                count = count + result.getResults().size();
-            }
-            after = result.getAfter();
-        }
-
-        assertEquals(153, count);
+        ResultNextList<Record> result = this.retrieveNextList(HttpRequest.GET(TOPIC_URL + "/data"), Record.class);
+        // 50 messages with the same key on each partition (1 remaining after compaction) : 3 messages
+        // 50 random messages on each partition : 150 messages
+        assertEquals(153, result.getSize());
     }
 
     @Test

--- a/src/test/java/org/akhq/repositories/TopicRepositoryTest.java
+++ b/src/test/java/org/akhq/repositories/TopicRepositoryTest.java
@@ -171,7 +171,9 @@ class TopicRepositoryTest extends AbstractTest {
             .findFirst();
 
         assertTrue(compacted.isPresent());
-        assertEquals(0, compacted.get().getFirstOffset());
+        // 50 messages with the same key (1 remaining after compaction) : 1st offset is 49
+        assertEquals(49, compacted.get().getFirstOffset());
+        // 50 messages with the same key + 50 random messages : last offset is 100
         assertEquals(100, compacted.get().getLastOffset());
     }
 


### PR DESCRIPTION
Due to [KAFKA-7556](https://issues.apache.org/jira/browse/KAFKA-7556), the messages count is not currently accurate on compacted topics. It will never be exact but it can be improved. On compacted topics, the first offset taken into account to compute the counter is always 0, even after compaction.

Using KafkaConsumer.offsetsForTimes with 0L as timestamp instead KafkaConsumer.beginningOffsets to get the first offset solves the issue.

Before:
<img width="131" alt="image" src="https://github.com/tchiotludo/akhq/assets/2262145/2344e9c5-a1e5-4047-b4e6-2889aab45e3e">

After:
<img width="131" alt="image" src="https://github.com/tchiotludo/akhq/assets/2262145/d06a8d69-ddc4-48cc-8c1c-09a0aa0beb88">
