### PR TITLE
HMR in docker-compose-dev

### DIFF
--- a/client/vite.config.mjs
+++ b/client/vite.config.mjs
@@ -32,8 +32,9 @@ export default defineConfig(({ command, mode }) => {
       global: 'window'
     },
     server: {
-      port: 3000,
-      open: true,
+      clearScreen: false,
+      port: 4000,
+      open: false,
       proxy: {
         '/api': {
           target: env.APP_BASE_URL || 'http://localhost:8080'

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -33,8 +33,10 @@ services:
 
   ui:
     image: node:lts
-    command: 'sh -c "npm install && npm run build && npm run preview"'
+    command: 'sh -c "npm install && npm run start -- --host"'
     working_dir: /app/client
+    environment:
+      - APP_BASE_URL=http://akhq:8080
     tty: true
     volumes:
       - ./:/app:z


### PR DESCRIPTION
Much nicer for developing the frontend, two things that we lose with this however is 
1. Open in browser when the dev server is ready (I always thought this was gimick-y anyways 😅 ), this is necessary for it to work at all, otherwise the process exits because of [this error](https://github.com/codesandbox/codesandbox-client/issues/6642)
2. Vite no longer clears the terminal when it reloads, this was just my opinion but because it's running in compose vite isn't just clearing it's own logs it's clearing all the logs from the other containers, which is super annoying