### PR TITLE
Add annotations to configmaps

### DIFF
--- a/helm/akhq/templates/configmap.yaml
+++ b/helm/akhq/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "akhq.fullname" . }}
-  {{- with .Values.annotations }}
+  {{- with .Values.configmapAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/helm/akhq/templates/configmap.yaml
+++ b/helm/akhq/templates/configmap.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "akhq.fullname" . }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "akhq.name" . }}
     helm.sh/chart: {{ include "akhq.chart" . }}

--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -13,6 +13,10 @@ annotations: {}
 
 podAnnotations: {}
 
+configmapAnnotations: {}
+  # vault.security.banzaicloud.io/vault-role: akhq
+  # vault.security.banzaicloud.io/vault-serviceaccount: akhq
+
 # custom labels
 labels: {}
   # custom.label: 'true'


### PR DESCRIPTION
It's very usefull to insert annotations in configmaps also - for ex., if we wish use inline mutations when insert some sensitive information (secrets) from Vault for connect to external auth systems...