### PR TITLE
fix(ui): connect clusters list overflow

### DIFF
--- a/client/src/containers/SideBar/styles.scss
+++ b/client/src/containers/SideBar/styles.scss
@@ -55,3 +55,7 @@ $sidebarTransition: 0.5s;
 .sidenav-subnav---1EN61 {
   background-color: $primary !important;
 }
+.sidenav---sidenav-subnav---1EN61 {
+  max-height: calc(30vh);
+  overflow: auto !important;
+}


### PR DESCRIPTION
Reapply style that was removed during the frontend upgrade to fix a small regression on the connect clusters list with a lot of clusters (unable to scroll)

Before:
<img width="279" alt="image" src="https://github.com/tchiotludo/akhq/assets/2262145/b62e5e7c-7b81-48a7-8f1b-10f73be83412">

After:
<img width="287" alt="image" src="https://github.com/tchiotludo/akhq/assets/2262145/8e56559c-ce17-461c-873c-26d79571f5b5">
