### PR TITLE
Custom serializer for avro raw format

### DIFF
--- a/docs/docs/configuration/avro.md
+++ b/docs/docs/configuration/avro.md
@@ -29,4 +29,33 @@ akhq:
               value-schema-file: "Value.avsc"
 ```
 
+# Avro serialization
+
+Avro messages using Schema registry are automatically encoded if the registry is configured (see [Kafka cluster](../configuration/brokers.md)).
+
+You can also encoded raw binary Avro messages, that is messages must then be decoded directly with [DatumReader](https://avro.apache.org/docs/current/api/java/org/apache/avro/io/DatumReader.html) without any header.
+You must provide a `schemas-folder` and mappings which associate a `topic-regex` and a schema file name. The schema can be
+specified either for message keys with `key-schema-file` and/or for values with `value-schema-file`.
+
+Here is an example of configuration:
+
+```
+akhq:
+  connections:
+    kafka:
+      properties:
+        # standard kafka properties
+      serialization:
+        avro-raw:
+          schemas-folder: "/app/avro_schemas"
+          topics-mapping:
+            - topic-regex: "album.*"
+              value-schema-file: "Album.avsc"
+            - topic-regex: "film.*"
+              value-schema-file: "Film.avsc"
+            - topic-regex: "test.*"
+              key-schema-file: "Key.avsc"
+              value-schema-file: "Value.avsc"
+```
+
 Examples can be found in [tests](https://github.com/tchiotludo/akhq/tree/dev/src/main/java/org/akhq/utils).

--- a/src/main/java/org/akhq/configs/Connection.java
+++ b/src/main/java/org/akhq/configs/Connection.java
@@ -62,7 +62,7 @@ public class Connection extends AbstractProperties {
     }
 
     @Getter
-    @ConfigurationProperties("serialization") // TODO use other key
+    @ConfigurationProperties("serialization")
     public static class Serialization {
         AvroSerializationTopicsMapping avroRaw;
 

--- a/src/main/java/org/akhq/configs/Connection.java
+++ b/src/main/java/org/akhq/configs/Connection.java
@@ -20,6 +20,7 @@ public class Connection extends AbstractProperties {
     List<Connect> connect;
     List<KsqlDb> ksqldb;
     Deserialization deserialization = new Deserialization();
+    Serialization serialization = new Serialization();
     UiOptions uiOptions = new UiOptions();
 
     public Connection(@Parameter String name) {
@@ -55,6 +56,19 @@ public class Connection extends AbstractProperties {
         @Data
         @ConfigurationProperties("avro-raw")
         public static class AvroDeserializationTopicsMapping {
+            String schemasFolder;
+            List<AvroTopicsMapping> topicsMapping = new ArrayList<>();
+        }
+    }
+
+    @Getter
+    @ConfigurationProperties("serialization") // TODO use other key
+    public static class Serialization {
+        AvroSerializationTopicsMapping avroRaw;
+
+        @Data
+        @ConfigurationProperties("avro-raw")
+        public static class AvroSerializationTopicsMapping {
             String schemasFolder;
             List<AvroTopicsMapping> topicsMapping = new ArrayList<>();
         }

--- a/src/main/java/org/akhq/repositories/CustomSerializerRepository.java
+++ b/src/main/java/org/akhq/repositories/CustomSerializerRepository.java
@@ -1,0 +1,25 @@
+package org.akhq.repositories;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.util.HashMap;
+import java.util.Map;
+import org.akhq.modules.KafkaModule;
+import org.akhq.utils.JsonToAvroSerializer;
+
+@Singleton
+public class CustomSerializerRepository {
+    @Inject
+    private KafkaModule kafkaModule;
+    private final Map<String, JsonToAvroSerializer> jsonToAvroSerializers = new HashMap<>();
+
+    public JsonToAvroSerializer getJsonToAvroSerializer(String clusterId) {
+        if (!this.jsonToAvroSerializers.containsKey(clusterId)) {
+            this.jsonToAvroSerializers.put(
+                clusterId,
+                new JsonToAvroSerializer(this.kafkaModule.getConnection(clusterId).getSerialization().getAvroRaw())
+            );
+        }
+        return this.jsonToAvroSerializers.get(clusterId);
+    }
+}

--- a/src/main/java/org/akhq/repositories/RecordRepository.java
+++ b/src/main/java/org/akhq/repositories/RecordRepository.java
@@ -622,7 +622,7 @@ public class RecordRepository extends AbstractRepository {
             if (keySchema.isPresent() && StringUtils.isNotEmpty(keySchema.get())) {
                 keyAsBytes = getBytesBySchemaRegistry(clusterId, key.get(), keySchema.get());
             } else { // TODO test
-                keyAsBytes = getBytesByAvroSerializer(clusterId, topic, key.get());
+                keyAsBytes = getBytesByAvroSerializer(clusterId, topic, key.get(), true);
             }
         } else {
             try {
@@ -637,7 +637,7 @@ public class RecordRepository extends AbstractRepository {
         if (value.isPresent() && valueSchema.isPresent() && StringUtils.isNotEmpty(valueSchema.get())) {
             valueAsBytes = getBytesBySchemaRegistry(clusterId, value.get(), valueSchema.get());
         } else if (value.isPresent()) { // TODO test
-            valueAsBytes = getBytesByAvroSerializer(clusterId, topic, value.get());
+            valueAsBytes = getBytesByAvroSerializer(clusterId, topic, value.get(), false);
         }
 
         return produce(clusterId, topic, valueAsBytes, headers, keyAsBytes, partition, timestamp);
@@ -649,7 +649,7 @@ public class RecordRepository extends AbstractRepository {
         return serializer.serialize(data);
     }
 
-    private byte[] getBytesByAvroSerializer(String clusterId, String topic, String data) {
+    private byte[] getBytesByAvroSerializer(String clusterId, String topic, String data, boolean isKey) {
         JsonToAvroSerializer jsonToAvroSerializer = customSerializerRepository.getJsonToAvroSerializer(clusterId);
 
         if (jsonToAvroSerializer == null) {
@@ -657,7 +657,7 @@ public class RecordRepository extends AbstractRepository {
         }
 
         try {
-            return jsonToAvroSerializer.serialize(topic, data, false);
+            return jsonToAvroSerializer.serialize(topic, data, isKey);
         } catch (Exception exception) {
             return data.isEmpty() ? null : data.getBytes();
         }

--- a/src/main/java/org/akhq/repositories/RecordRepository.java
+++ b/src/main/java/org/akhq/repositories/RecordRepository.java
@@ -45,7 +45,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import jakarta.inject.Inject;
@@ -636,7 +635,7 @@ public class RecordRepository extends AbstractRepository {
 
         if (value.isPresent() && valueSchema.isPresent() && StringUtils.isNotEmpty(valueSchema.get())) {
             valueAsBytes = getBytesBySchemaRegistry(clusterId, value.get(), valueSchema.get());
-        } else if (value.isPresent()) { // TODO test
+        } else if (value.isPresent()) {
             valueAsBytes = getBytesByAvroSerializer(clusterId, topic, value.get(), false);
         }
 

--- a/src/main/java/org/akhq/repositories/RecordRepository.java
+++ b/src/main/java/org/akhq/repositories/RecordRepository.java
@@ -620,7 +620,7 @@ public class RecordRepository extends AbstractRepository {
         if (key.isPresent()) {
             if (keySchema.isPresent() && StringUtils.isNotEmpty(keySchema.get())) {
                 keyAsBytes = getBytesBySchemaRegistry(clusterId, key.get(), keySchema.get());
-            } else { // TODO test
+            } else {
                 keyAsBytes = getBytesByAvroSerializer(clusterId, topic, key.get(), true);
             }
         } else {

--- a/src/main/java/org/akhq/utils/AvroToJsonDeserializer.java
+++ b/src/main/java/org/akhq/utils/AvroToJsonDeserializer.java
@@ -2,7 +2,6 @@ package org.akhq.utils;
 
 import io.micronaut.core.serialize.exceptions.SerializationException;
 import lombok.extern.slf4j.Slf4j;
-import org.akhq.configs.AvroTopicsMapping;
 import org.akhq.configs.Connection;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
@@ -10,16 +9,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.DecoderFactory;
 
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
 
 /**
  * Class for deserialization of messages in Avro raw data binary format using topics mapping config.
@@ -27,57 +17,17 @@ import java.util.function.Function;
 @Slf4j
 public class AvroToJsonDeserializer {
     private final DecoderFactory decoderFactory = DecoderFactory.get();
-    private final Map<String, Schema> keySchemas;
-    private final Map<String, Schema> valueSchemas;
-    private final List<AvroTopicsMapping> topicsMapping;
-    private final String avroSchemasFolder;
+    private final RawAvroUtils rawAvroUtils;
     private final AvroToJsonSerializer avroToJsonSerializer;
 
     public AvroToJsonDeserializer(Connection.Deserialization.AvroDeserializationTopicsMapping avroDeserializationTopicsMapping, AvroToJsonSerializer avroToJsonSerializer) {
         if (avroDeserializationTopicsMapping == null) {
-            this.keySchemas = new HashMap<>();
-            this.valueSchemas = new HashMap<>();
-            this.topicsMapping = new ArrayList<>();
-            this.avroSchemasFolder = null;
+            this.rawAvroUtils = null;
             this.avroToJsonSerializer = null;
         } else {
-            this.avroSchemasFolder = avroDeserializationTopicsMapping.getSchemasFolder();
-            this.topicsMapping = avroDeserializationTopicsMapping.getTopicsMapping();
-            this.keySchemas = buildSchemas(AvroTopicsMapping::getKeySchemaFile);
-            this.valueSchemas = buildSchemas(AvroTopicsMapping::getValueSchemaFile);
+            this.rawAvroUtils = new RawAvroUtils(avroDeserializationTopicsMapping.getTopicsMapping(), avroDeserializationTopicsMapping.getSchemasFolder());
             this.avroToJsonSerializer = avroToJsonSerializer;
         }
-    }
-
-    /**
-     * Load Avro schemas from schema folder
-     *
-     * @return map where keys are topic regexes and value is Avro schema
-     */
-    private Map<String, Schema> buildSchemas(Function<AvroTopicsMapping, String> schemaFileMapper) {
-        Map<String, Schema> allSchemas = new HashMap<>();
-        for (AvroTopicsMapping mapping : topicsMapping) {
-            String schemaFile = schemaFileMapper.apply(mapping);
-
-            if (schemaFile != null) {
-                try {
-                    Schema schema = loadSchemaFile(mapping, schemaFile);
-                    allSchemas.put(mapping.getTopicRegex(), schema);
-                } catch (IOException e) {
-                    throw new RuntimeException(String.format("Cannot get a schema file for the topics regex [%s]", mapping.getTopicRegex()), e);
-                }
-            }
-        }
-        return allSchemas;
-    }
-
-    Schema loadSchemaFile(AvroTopicsMapping mapping, String schemaFile) throws IOException {
-        if (avroSchemasFolder != null && Files.exists(Path.of(avroSchemasFolder))) {
-            String fullPath = avroSchemasFolder + File.separator + schemaFile;
-            return new Schema.Parser().parse(Path.of(fullPath).toFile());
-        }
-        throw new FileNotFoundException("Avro schema file is not found for topic regex [" +
-            mapping.getTopicRegex() + "]. Folder is not specified or doesn't exist.");
     }
 
     /**
@@ -92,23 +42,7 @@ public class AvroToJsonDeserializer {
      * @return {@code null} if cannot deserialize or configuration is not matching, return decoded string otherwise
      */
     public String deserialize(String topic, byte[] buffer, boolean isKey) {
-        AvroTopicsMapping matchingConfig = findMatchingConfig(topic);
-        if (matchingConfig == null) {
-            log.debug("Avro deserialization config is not found for topic [{}]", topic);
-            return null;
-        }
-
-        if (matchingConfig.getKeySchemaFile() == null && matchingConfig.getValueSchemaFile() == null) {
-            throw new SerializationException(String.format("Avro deserialization is configured for topic [%s], " +
-                    "but schema is not specified neither for a key, nor for a value.", topic));
-        }
-
-        Schema schema;
-        if (isKey) {
-            schema = keySchemas.get(matchingConfig.getTopicRegex());
-        } else {
-            schema = valueSchemas.get(matchingConfig.getTopicRegex());
-        }
+        Schema schema = rawAvroUtils.getSchema(topic, isKey);
 
         if (schema == null) {
             return null;
@@ -122,17 +56,6 @@ public class AvroToJsonDeserializer {
                     "for topic [%s] and schema [%s]", topic, schema.getFullName()), e);
         }
         return result;
-    }
-
-    private AvroTopicsMapping findMatchingConfig(String topic) {
-        for (AvroTopicsMapping mapping : topicsMapping) {
-            if (topic.matches(mapping.getTopicRegex())) {
-                return new AvroTopicsMapping(
-                        mapping.getTopicRegex(),
-                        mapping.getKeySchemaFile(), mapping.getValueSchemaFile());
-            }
-        }
-        return null;
     }
 
     private String tryToDeserializeWithSchemaFile(byte[] buffer, Schema schema) throws IOException {

--- a/src/main/java/org/akhq/utils/JsonToAvroSerializer.java
+++ b/src/main/java/org/akhq/utils/JsonToAvroSerializer.java
@@ -1,0 +1,146 @@
+package org.akhq.utils;
+
+import io.micronaut.core.serialize.exceptions.SerializationException;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import lombok.extern.slf4j.Slf4j;
+import org.akhq.configs.AvroTopicsMapping;
+import org.akhq.configs.Connection;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.io.*;
+
+// TODO test + unify
+/**
+ * Class for serialization of messages in Json to Avro raw data binary format using topics mapping config.
+ */
+@Slf4j
+public class JsonToAvroSerializer {
+    private final EncoderFactory encoderFactory = EncoderFactory.get();
+    private final Map<String, Schema> keySchemas;
+    private final Map<String, Schema> valueSchemas;
+    private final List<AvroTopicsMapping> topicsMapping;
+    private final String avroSchemasFolder;
+
+    public JsonToAvroSerializer(Connection.Serialization.AvroSerializationTopicsMapping avroSerializationTopicsMapping) {
+        if (avroSerializationTopicsMapping == null) {
+            this.keySchemas = new HashMap<>();
+            this.valueSchemas = new HashMap<>();
+            this.topicsMapping = new ArrayList<>();
+            this.avroSchemasFolder = null;
+        } else {
+            this.avroSchemasFolder = avroSerializationTopicsMapping.getSchemasFolder();
+            this.topicsMapping = avroSerializationTopicsMapping.getTopicsMapping();
+            this.keySchemas = buildSchemas(AvroTopicsMapping::getKeySchemaFile);
+            this.valueSchemas = buildSchemas(AvroTopicsMapping::getValueSchemaFile);
+        }
+    }
+
+    /**
+     * Load Avro schemas from schema folder
+     *
+     * @return map where keys are topic regexes and value is Avro schema
+     */
+    private Map<String, Schema> buildSchemas(Function<AvroTopicsMapping, String> schemaFileMapper) {
+        Map<String, Schema> allSchemas = new HashMap<>();
+        for (AvroTopicsMapping mapping : topicsMapping) {
+            String schemaFile = schemaFileMapper.apply(mapping);
+
+            if (schemaFile != null) {
+                try {
+                    Schema schema = loadSchemaFile(mapping, schemaFile);
+                    allSchemas.put(mapping.getTopicRegex(), schema);
+                } catch (IOException e) {
+                    throw new RuntimeException(String.format("Cannot get a schema file for the topics regex [%s]", mapping.getTopicRegex()), e);
+                }
+            }
+        }
+        return allSchemas;
+    }
+
+    Schema loadSchemaFile(AvroTopicsMapping mapping, String schemaFile) throws IOException {
+        if (avroSchemasFolder != null && Files.exists(Path.of(avroSchemasFolder))) {
+            String fullPath = avroSchemasFolder + File.separator + schemaFile;
+            return new Schema.Parser().parse(Path.of(fullPath).toFile());
+        }
+        throw new FileNotFoundException("Avro schema file is not found for topic regex [" +
+            mapping.getTopicRegex() + "]. Folder is not specified or doesn't exist.");
+    }
+
+    /**
+     * Serialize from Json to Avro raw data binary format.
+     * Messages must be decoded directly with {@link org.apache.avro.io.DatumReader}, not {@link org.apache.avro.file.DataFileReader} or {@link org.apache.avro.message.BinaryMessageDecoder}.
+     * Topic name should match topic-regex from {@code akhq.connections.[clusterName].serialization.avro.topics-mapping} config
+     * and schema should be set for key or value in that config.
+     *
+     * @param topic  current topic name
+     * @param data   Json data to encode
+     * @param isKey  is this data represent key or value
+     * @return {@code null} if cannot serialize or configuration is not matching, return encoded string otherwise
+     */
+    public byte[] serialize(String topic, String data, boolean isKey) {
+        AvroTopicsMapping matchingConfig = findMatchingConfig(topic);
+        if (matchingConfig == null) {
+            log.debug("Avro serialization config is not found for topic [{}]", topic);
+            return null;
+        }
+
+        if (matchingConfig.getKeySchemaFile() == null && matchingConfig.getValueSchemaFile() == null) {
+            throw new SerializationException(String.format("Avro serialization is configured for topic [%s], " +
+                "but schema is not specified neither for a key, nor for a value.", topic));
+        }
+
+        Schema schema;
+        if (isKey) {
+            schema = keySchemas.get(matchingConfig.getTopicRegex());
+        } else {
+            schema = valueSchemas.get(matchingConfig.getTopicRegex());
+        }
+
+        if (schema == null) {
+            return null;
+        }
+
+        byte[] result;
+        try {
+            result = tryToSerializeWithSchemaFile(data, schema);
+        } catch (Exception e) {
+            throw new SerializationException(String.format("Cannot deserialize message with Avro deserializer " +
+                "for topic [%s] and schema [%s]", topic, schema.getFullName()), e);
+        }
+        return result;
+    }
+
+    private AvroTopicsMapping findMatchingConfig(String topic) {
+        for (AvroTopicsMapping mapping : topicsMapping) {
+            if (topic.matches(mapping.getTopicRegex())) {
+                return new AvroTopicsMapping(
+                    mapping.getTopicRegex(),
+                    mapping.getKeySchemaFile(), mapping.getValueSchemaFile());
+            }
+        }
+        return null;
+    }
+
+    private byte[] tryToSerializeWithSchemaFile(String json, Schema schema) throws IOException {
+        DatumReader<Object> reader = new GenericDatumReader<>(schema);
+        GenericDatumWriter<Object> writer = new GenericDatumWriter<>(schema);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        Decoder decoder = DecoderFactory.get().jsonDecoder(schema, json);
+        Encoder encoder = EncoderFactory.get().binaryEncoder(output, null);
+        Object datum = reader.read(null, decoder);
+        writer.write(datum, encoder);
+        encoder.flush();
+        return output.toByteArray();
+    }
+}

--- a/src/main/java/org/akhq/utils/JsonToAvroSerializer.java
+++ b/src/main/java/org/akhq/utils/JsonToAvroSerializer.java
@@ -2,79 +2,34 @@ package org.akhq.utils;
 
 import io.micronaut.core.serialize.exceptions.SerializationException;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;
-import org.akhq.configs.AvroTopicsMapping;
 import org.akhq.configs.Connection;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
-import org.apache.avro.io.*;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
 
-// TODO test + unify
+// TODO test
 /**
  * Class for serialization of messages in Json to Avro raw data binary format using topics mapping config.
  */
 @Slf4j
 public class JsonToAvroSerializer {
     private final EncoderFactory encoderFactory = EncoderFactory.get();
-    private final Map<String, Schema> keySchemas;
-    private final Map<String, Schema> valueSchemas;
-    private final List<AvroTopicsMapping> topicsMapping;
-    private final String avroSchemasFolder;
+    private final DecoderFactory decoderFactory = DecoderFactory.get();
+    private final RawAvroUtils rawAvroUtils;
 
     public JsonToAvroSerializer(Connection.Serialization.AvroSerializationTopicsMapping avroSerializationTopicsMapping) {
         if (avroSerializationTopicsMapping == null) {
-            this.keySchemas = new HashMap<>();
-            this.valueSchemas = new HashMap<>();
-            this.topicsMapping = new ArrayList<>();
-            this.avroSchemasFolder = null;
+            this.rawAvroUtils = null;
         } else {
-            this.avroSchemasFolder = avroSerializationTopicsMapping.getSchemasFolder();
-            this.topicsMapping = avroSerializationTopicsMapping.getTopicsMapping();
-            this.keySchemas = buildSchemas(AvroTopicsMapping::getKeySchemaFile);
-            this.valueSchemas = buildSchemas(AvroTopicsMapping::getValueSchemaFile);
+            this.rawAvroUtils = new RawAvroUtils(avroSerializationTopicsMapping.getTopicsMapping(), avroSerializationTopicsMapping.getSchemasFolder());
         }
-    }
-
-    /**
-     * Load Avro schemas from schema folder
-     *
-     * @return map where keys are topic regexes and value is Avro schema
-     */
-    private Map<String, Schema> buildSchemas(Function<AvroTopicsMapping, String> schemaFileMapper) {
-        Map<String, Schema> allSchemas = new HashMap<>();
-        for (AvroTopicsMapping mapping : topicsMapping) {
-            String schemaFile = schemaFileMapper.apply(mapping);
-
-            if (schemaFile != null) {
-                try {
-                    Schema schema = loadSchemaFile(mapping, schemaFile);
-                    allSchemas.put(mapping.getTopicRegex(), schema);
-                } catch (IOException e) {
-                    throw new RuntimeException(String.format("Cannot get a schema file for the topics regex [%s]", mapping.getTopicRegex()), e);
-                }
-            }
-        }
-        return allSchemas;
-    }
-
-    Schema loadSchemaFile(AvroTopicsMapping mapping, String schemaFile) throws IOException {
-        if (avroSchemasFolder != null && Files.exists(Path.of(avroSchemasFolder))) {
-            String fullPath = avroSchemasFolder + File.separator + schemaFile;
-            return new Schema.Parser().parse(Path.of(fullPath).toFile());
-        }
-        throw new FileNotFoundException("Avro schema file is not found for topic regex [" +
-            mapping.getTopicRegex() + "]. Folder is not specified or doesn't exist.");
     }
 
     /**
@@ -89,23 +44,7 @@ public class JsonToAvroSerializer {
      * @return {@code null} if cannot serialize or configuration is not matching, return encoded string otherwise
      */
     public byte[] serialize(String topic, String data, boolean isKey) {
-        AvroTopicsMapping matchingConfig = findMatchingConfig(topic);
-        if (matchingConfig == null) {
-            log.debug("Avro serialization config is not found for topic [{}]", topic);
-            return null;
-        }
-
-        if (matchingConfig.getKeySchemaFile() == null && matchingConfig.getValueSchemaFile() == null) {
-            throw new SerializationException(String.format("Avro serialization is configured for topic [%s], " +
-                "but schema is not specified neither for a key, nor for a value.", topic));
-        }
-
-        Schema schema;
-        if (isKey) {
-            schema = keySchemas.get(matchingConfig.getTopicRegex());
-        } else {
-            schema = valueSchemas.get(matchingConfig.getTopicRegex());
-        }
+        Schema schema = rawAvroUtils.getSchema(topic, isKey);
 
         if (schema == null) {
             return null;
@@ -121,23 +60,12 @@ public class JsonToAvroSerializer {
         return result;
     }
 
-    private AvroTopicsMapping findMatchingConfig(String topic) {
-        for (AvroTopicsMapping mapping : topicsMapping) {
-            if (topic.matches(mapping.getTopicRegex())) {
-                return new AvroTopicsMapping(
-                    mapping.getTopicRegex(),
-                    mapping.getKeySchemaFile(), mapping.getValueSchemaFile());
-            }
-        }
-        return null;
-    }
-
     private byte[] tryToSerializeWithSchemaFile(String json, Schema schema) throws IOException {
         DatumReader<Object> reader = new GenericDatumReader<>(schema);
         GenericDatumWriter<Object> writer = new GenericDatumWriter<>(schema);
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        Decoder decoder = DecoderFactory.get().jsonDecoder(schema, json);
-        Encoder encoder = EncoderFactory.get().binaryEncoder(output, null);
+        Decoder decoder = decoderFactory.jsonDecoder(schema, json);
+        Encoder encoder = encoderFactory.binaryEncoder(output, null);
         Object datum = reader.read(null, decoder);
         writer.write(datum, encoder);
         encoder.flush();

--- a/src/main/java/org/akhq/utils/JsonToAvroSerializer.java
+++ b/src/main/java/org/akhq/utils/JsonToAvroSerializer.java
@@ -1,20 +1,16 @@
 package org.akhq.utils;
 
 import io.micronaut.core.serialize.exceptions.SerializationException;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.akhq.configs.Connection;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
-import org.apache.avro.io.DatumReader;
-import org.apache.avro.io.Decoder;
-import org.apache.avro.io.DecoderFactory;
-import org.apache.avro.io.Encoder;
-import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.io.*;
 
-// TODO test
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
 /**
  * Class for serialization of messages in Json to Avro raw data binary format using topics mapping config.
  */

--- a/src/main/java/org/akhq/utils/RawAvroUtils.java
+++ b/src/main/java/org/akhq/utils/RawAvroUtils.java
@@ -1,0 +1,93 @@
+package org.akhq.utils;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import io.micronaut.core.serialize.exceptions.SerializationException;
+import lombok.extern.slf4j.Slf4j;
+import org.akhq.configs.AvroTopicsMapping;
+import org.apache.avro.Schema;
+
+@Slf4j
+public class RawAvroUtils {
+    private final Map<String, Schema> keySchemas;
+    private final Map<String, Schema> valueSchemas;
+    private final List<AvroTopicsMapping> topicsMapping;
+    private final String avroSchemasFolder;
+
+    public RawAvroUtils(List<AvroTopicsMapping> topicsMapping, String avroSchemasFolder) {
+        this.topicsMapping = topicsMapping;
+        this.avroSchemasFolder = avroSchemasFolder;
+        this.keySchemas = buildSchemas(AvroTopicsMapping::getKeySchemaFile);
+        this.valueSchemas = buildSchemas(AvroTopicsMapping::getValueSchemaFile);
+    }
+
+    /**
+     * Load Avro schemas from schema folder
+     *
+     * @return map where keys are topic regexes and value is Avro schema
+     */
+    private Map<String, Schema> buildSchemas(Function<AvroTopicsMapping, String> schemaFileMapper) {
+        Map<String, Schema> allSchemas = new HashMap<>();
+        for (AvroTopicsMapping mapping : topicsMapping) {
+            String schemaFile = schemaFileMapper.apply(mapping);
+
+            if (schemaFile != null) {
+                try {
+                    Schema schema = loadSchemaFile(mapping, schemaFile);
+                    allSchemas.put(mapping.getTopicRegex(), schema);
+                } catch (IOException e) {
+                    throw new RuntimeException(String.format("Cannot get a schema file for the topics regex [%s]", mapping.getTopicRegex()), e);
+                }
+            }
+        }
+        return allSchemas;
+    }
+
+    private Schema loadSchemaFile(AvroTopicsMapping mapping, String schemaFile) throws IOException {
+        if (avroSchemasFolder != null && Files.exists(Path.of(avroSchemasFolder))) {
+            String fullPath = avroSchemasFolder + File.separator + schemaFile;
+            return new Schema.Parser().parse(Path.of(fullPath).toFile());
+        }
+        throw new FileNotFoundException("Avro schema file is not found for topic regex [" +
+            mapping.getTopicRegex() + "]. Folder is not specified or doesn't exist.");
+    }
+
+    Schema getSchema(String topic, boolean isKey) {
+        AvroTopicsMapping matchingConfig = findMatchingConfig(topic);
+        if (matchingConfig == null) {
+            log.debug("Avro serialization config is not found for topic [{}]", topic);
+            return null;
+        }
+
+        if (matchingConfig.getKeySchemaFile() == null && matchingConfig.getValueSchemaFile() == null) {
+            throw new SerializationException(String.format("Avro serialization is configured for topic [%s], " +
+                "but schema is not specified neither for a key, nor for a value.", topic));
+        }
+
+        Schema schema;
+        if (isKey) {
+            return keySchemas.get(matchingConfig.getTopicRegex());
+        } else {
+            return valueSchemas.get(matchingConfig.getTopicRegex());
+        }
+    }
+
+    private AvroTopicsMapping findMatchingConfig(String topic) {
+        for (AvroTopicsMapping mapping : topicsMapping) {
+            if (topic.matches(mapping.getTopicRegex())) {
+                return new AvroTopicsMapping(
+                    mapping.getTopicRegex(),
+                    mapping.getKeySchemaFile(), mapping.getValueSchemaFile());
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/akhq/utils/RawAvroUtils.java
+++ b/src/main/java/org/akhq/utils/RawAvroUtils.java
@@ -63,7 +63,7 @@ public class RawAvroUtils {
     Schema getSchema(String topic, boolean isKey) {
         AvroTopicsMapping matchingConfig = findMatchingConfig(topic);
         if (matchingConfig == null) {
-            log.debug("Avro serialization config is not found for topic [{}]", topic);
+            log.debug("Avro raw config is not found for topic [{}]", topic);
             return null;
         }
 

--- a/src/test/java/org/akhq/utils/JsonToAvroSerializerTest.java
+++ b/src/test/java/org/akhq/utils/JsonToAvroSerializerTest.java
@@ -1,0 +1,180 @@
+package org.akhq.utils;
+
+import org.akhq.AlbumAvro;
+import org.akhq.FilmAvro;
+import org.akhq.configs.AvroTopicsMapping;
+import org.akhq.configs.Connection;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JsonToAvroSerializerTest {
+    Connection.Serialization.AvroSerializationTopicsMapping avroSerializationTopicsMapping;
+    AlbumAvro albumAvro;
+    FilmAvro filmAvro;
+
+    @BeforeEach
+    void before() throws URISyntaxException {
+        createTopicAvroSerializationMapping();
+        createAlbumObject();
+        createFilmObject();
+    }
+
+    private void createTopicAvroSerializationMapping() throws URISyntaxException {
+        avroSerializationTopicsMapping = new Connection.Serialization.AvroSerializationTopicsMapping();
+
+        URI uri = ClassLoader.getSystemResource("avro").toURI();
+        String avroSchemaFolder = Paths.get(uri).toString();
+        avroSerializationTopicsMapping.setSchemasFolder(avroSchemaFolder);
+
+        AvroTopicsMapping albumTopicsMapping = new AvroTopicsMapping();
+        albumTopicsMapping.setTopicRegex("album.*");
+        albumTopicsMapping.setValueSchemaFile("Album.avsc");
+
+        AvroTopicsMapping filmTopicsMapping = new AvroTopicsMapping();
+        filmTopicsMapping.setTopicRegex("film.*");
+        filmTopicsMapping.setValueSchemaFile("Film.avsc");
+
+        // Do not specify schema neither for a key, nor for a value
+        AvroTopicsMapping incorrectTopicsMapping = new AvroTopicsMapping();
+        incorrectTopicsMapping.setTopicRegex("incorrect.*");
+
+        avroSerializationTopicsMapping.setTopicsMapping(
+            Arrays.asList(albumTopicsMapping, filmTopicsMapping, incorrectTopicsMapping));
+    }
+
+    private void createAlbumObject() {
+        List<String> artists = Collections.singletonList("Imagine Dragons");
+        List<String> songTitles = Arrays.asList("Birds", "Zero", "Natural", "Machine");
+        Album album = new Album("Origins", artists, 2018, songTitles);
+        albumAvro = AlbumAvro.newBuilder()
+            .setTitle(album.getTitle())
+            .setArtist(album.getArtists())
+            .setReleaseYear(album.getReleaseYear())
+            .setSongTitle(album.getSongsTitles())
+            .build();
+    }
+
+    private void createFilmObject() {
+        List<String> starring = Arrays.asList("Harrison Ford", "Mark Hamill", "Carrie Fisher", "Adam Driver", "Daisy Ridley");
+        Film film = new Film("Star Wars: The Force Awakens", "J. J. Abrams", 2015, 135, starring);
+        filmAvro = FilmAvro.newBuilder()
+            .setName(film.getName())
+            .setProducer(film.getProducer())
+            .setReleaseYear(film.getReleaseYear())
+            .setDuration(film.getDuration())
+            .setStarring(film.getStarring())
+            .build();
+    }
+
+    @Test
+    void serializeAlbum() throws IOException, URISyntaxException {
+        JsonToAvroSerializer jsonToAvroSerializer = new JsonToAvroSerializer(avroSerializationTopicsMapping);
+        final String jsonAlbum = "{" +
+            "\"title\":\"Origins\"," +
+            "\"artist\":[\"Imagine Dragons\"]," +
+            "\"releaseYear\":2018," +
+            "\"songTitle\":[\"Birds\",\"Zero\",\"Natural\",\"Machine\"]" +
+            "}";
+        byte[] encodedAlbum = jsonToAvroSerializer.serialize("album.topic.name", jsonAlbum, false);
+        byte[] expectedAlbum = toByteArray("Album.avsc", albumAvro);
+        assertEquals(expectedAlbum, encodedAlbum);
+    }
+
+    @Test
+    void serializeFilm() throws IOException, URISyntaxException {
+        JsonToAvroSerializer jsonToAvroSerializer = new JsonToAvroSerializer(avroSerializationTopicsMapping);
+        final String jsonFilm = "{" +
+            "\"name\":\"Star Wars: The Force Awakens\"," +
+            "\"producer\":\"J. J. Abrams\"," +
+            "\"releaseYear\":2015," +
+            "\"duration\":135," +
+            "\"starring\":[\"Harrison Ford\",\"Mark Hamill\",\"Carrie Fisher\",\"Adam Driver\",\"Daisy Ridley\"]" +
+            "}";
+        byte[] encodedFilm = jsonToAvroSerializer.serialize("film.topic.name", jsonFilm, false);
+        byte[] expectedFilm = toByteArray("Film.avsc", filmAvro);
+        assertEquals(expectedFilm, encodedFilm);
+    }
+
+    @Test
+    void serializeForNotMatchingTopic() {
+        JsonToAvroSerializer jsonToAvroSerializer = new JsonToAvroSerializer(avroSerializationTopicsMapping);
+        final String jsonFilm = "{" +
+            "\"name\":\"Star Wars: The Force Awakens\"," +
+            "\"producer\":\"J. J. Abrams\"," +
+            "\"releaseYear\":2015," +
+            "\"duration\":135," +
+            "\"starring\":[\"Harrison Ford\",\"Mark Hamill\",\"Carrie Fisher\",\"Adam Driver\",\"Daisy Ridley\"]" +
+            "}";
+        byte[] encodedFilm = jsonToAvroSerializer.serialize("random.topic.name", jsonFilm, false);
+        assertNull(encodedFilm);
+    }
+
+    @Test
+    void serializeForKeyWhenItsTypeNotSet() {
+        JsonToAvroSerializer jsonToAvroSerializer = new JsonToAvroSerializer(avroSerializationTopicsMapping);
+        final String jsonFilm = "{" +
+            "\"name\":\"Star Wars: The Force Awakens\"," +
+            "\"producer\":\"J. J. Abrams\"," +
+            "\"releaseYear\":2015," +
+            "\"duration\":135," +
+            "\"starring\":[\"Harrison Ford\",\"Mark Hamill\",\"Carrie Fisher\",\"Adam Driver\",\"Daisy Ridley\"]" +
+            "}";
+        byte[] encodedFilm = jsonToAvroSerializer.serialize("random.topic.name", jsonFilm, true);
+        assertNull(encodedFilm);
+    }
+
+    @Test
+    void serializeWhenTypeNotSetForKeyAndValue() {
+        JsonToAvroSerializer jsonToAvroSerializer = new JsonToAvroSerializer(avroSerializationTopicsMapping);
+        final String jsonFilm = "{" +
+            "\"name\":\"Star Wars: The Force Awakens\"," +
+            "\"producer\":\"J. J. Abrams\"," +
+            "\"releaseYear\":2015," +
+            "\"duration\":135," +
+            "\"starring\":[\"Harrison Ford\",\"Mark Hamill\",\"Carrie Fisher\",\"Adam Driver\",\"Daisy Ridley\"]" +
+            "}";
+        Exception exception = assertThrows(RuntimeException.class, () -> {
+            jsonToAvroSerializer.serialize("incorrect.topic.name", jsonFilm, true);
+        });
+        String expectedMessage = "schema is not specified neither for a key, nor for a value";
+        String actualMessage = exception.getMessage();
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    private <T> byte[] toByteArray(String schemaName, T datum) throws IOException, URISyntaxException {
+        Schema schema = resolveSchema(schemaName);
+
+        DatumWriter<T> writer = new GenericDatumWriter<>(schema);
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        Encoder encoder = EncoderFactory.get().binaryEncoder(bos, null);
+        writer.write(datum, encoder);
+        encoder.flush();
+        bos.close();
+
+        return bos.toByteArray();
+    }
+
+    private Schema resolveSchema(String schemaName) throws URISyntaxException, IOException {
+        URI uri = ClassLoader.getSystemResource("avro").toURI();
+        File schemaFile = Paths.get(uri).resolve(schemaName).toFile();
+
+        return new Schema.Parser().parse(schemaFile);
+    }
+}


### PR DESCRIPTION
This PR partially implements https://github.com/tchiotludo/akhq/issues/1077.

It allows the encoding of Avro raw binary format, with a mapping configuration, for example:
```
      akhq:
          connections:
            my-cluster:
              serialization:
                avro-raw:
                  schemas-folder: "/app/avro_schemas"
                  topics-mapping:
                    - topic-regex: "data.*"
                      value-schema-file: "Schema.avsc"
```
see also https://github.com/tchiotludo/akhq/pull/843