### PR TITLE
bugfix: encode schemaId in URL to handle special characters

### DIFF
--- a/client/src/containers/Schema/SchemaDetail/Schema.jsx
+++ b/client/src/containers/Schema/SchemaDetail/Schema.jsx
@@ -54,7 +54,7 @@ class Schema extends Root {
       },
       () => {
         this.props.router.navigate(
-          `/ui/${clusterId}/schema/details/${schemaId}/${this.state.selectedTab}`,
+          `/ui/${clusterId}/schema/details/${encodeURIComponent(schemaId)}/${this.state.selectedTab}`,
           {
             replace: true
           }


### PR DESCRIPTION
Related to the issue https://github.com/tchiotludo/akhq/issues/1916

Encoding `schemaId` ensures that special characters in the ID do not break the URL routing.

![Capture d’écran 2024-08-27 à 13 01 06](https://github.com/user-attachments/assets/12b2e0eb-876a-4afd-a95c-cd5edb0b8cd7)
