### PR TITLE
fix(docs): make links clickable on GitHub SSO page

### DIFF
--- a/docs/docs/configuration/authentifications/github.md
+++ b/docs/docs/configuration/authentifications/github.md
@@ -51,4 +51,4 @@ akhq:
 The username field can be any string field, the roles field has to be a JSON array.
 
 ## References
-https://micronaut-projects.github.io/micronaut-security/latest/guide/#oauth2-configuration
+[https://micronaut-projects.github.io/micronaut-security/latest/guide/#oauth2-configuration](https://micronaut-projects.github.io/micronaut-security/latest/guide/#oauth2-configuration)


### PR DESCRIPTION
This pull request makes the referenced link clickable on the 'GitHub SSO / OAuth2' documentation page : https://akhq.io/docs/configuration/authentifications/github.html