### PR TITLE
bugfix: update isChecked condition in TopicData table

### DIFF
--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -1189,7 +1189,7 @@ class TopicData extends Root {
             loading={loading}
             reduce={true}
             firstHeader={firstColumns}
-            isChecked={this.props.exportSome}
+            isChecked={messages?.length === this.state.messagesToExport?.length}
             columns={[
               {
                 id: 'checkboxes',


### PR DESCRIPTION
Fix #1928

When a user deselects any topic after selecting all, the 'Select All' checkbox will now automatically uncheck itself.

![demo2](https://github.com/user-attachments/assets/84b2ab0e-61dd-4ac8-98f1-5303931e218b)

