### PR TITLE
Adding kafka properties to KafkaProtobufDeserializer.

### DIFF
--- a/.github/workflows/alpian-release.yml
+++ b/.github/workflows/alpian-release.yml
@@ -1,0 +1,50 @@
+name: Alpian Release
+
+# Releasing is done in the GitHub UI: create a Release with tag <upstream-version>-alpian
+# (e.g. 0.28.0-alpian) on the matching fork branch, and write the release notes there.
+# This workflow builds the shadow jar, publishes it to this fork's GitHub Packages Maven
+# repo, and attaches it to the release. The tag IS the published version — nothing here
+# computes, creates, or pushes tags.
+#
+# GitHub Packages Maven versions are IMMUTABLE: to re-publish the same upstream version,
+# tag 0.28.0-alpian-2 rather than reusing the tag.
+#
+# Upstream's Main workflow skips *-alpian tags (see main.yml), so this is the only
+# pipeline that runs for a fork release.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write # attach the jar to the release
+  packages: write # publish jar (GitHub Packages)
+
+jobs:
+  release:
+    name: Publish shadow jar
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - uses: gradle/actions/setup-gradle@v6
+
+      # No tests: this fork carries a handful of patches on top of an upstream release,
+      # none of them on a core path.
+      - name: Build and publish shadow jar to GitHub Packages
+        env:
+          PUBLISH_VERSION: ${{ github.event.release.tag_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew shadowJar publish
+
+      # Same bytes as the ones published to Packages — a plain download URL for anyone
+      # who does not want to go through Maven.
+      - name: Attach jar to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.event.release.tag_name }}" build/libs/akhq-*-all.jar --clobber

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,9 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    # Upstream-only: the alpian fork tracks upstream releases and does not act on its own
+    # code-scanning alerts. Avoids a full java+javascript build on every dependabot PR.
+    if: ${{ github.repository == 'tchiotludo/akhq' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,8 @@ jobs:
   check:
     name: Docs
     runs-on: ubuntu-latest
+    # Upstream-only: publishes akhq.io docs, which the alpian fork has no business updating.
+    if: ${{ github.repository == 'tchiotludo/akhq' }}
     permissions:
       contents: write
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,10 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
+    # Upstream-only. On the alpian fork this pipeline has no DockerHub/Slack secrets, and on
+    # an *-alpian tag it would also cut a second GitHub release and run chart-releaser on top
+    # of alpian-release.yml. Fork releases are handled by alpian-release.yml instead.
+    if: ${{ github.repository == 'tchiotludo/akhq' }}
     permissions:
       contents: write
       packages: write

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,9 @@ plugins {
     id "eu.eventloopsoftware.avro-gradle-plugin" version "0.1.2"
     // idea
     id "org.jetbrains.gradle.plugin.idea-ext" version "1.4.1"
+
+    // alpian fork: publish the shadow jar to GitHub Packages
+    id "maven-publish"
 }
 java {
     sourceCompatibility = JavaVersion.toVersion("25")
@@ -315,6 +318,38 @@ shadowJar {
     zip64 = true
     transform(com.github.jengelman.gradle.plugins.shadow.transformers.PreserveFirstFoundResourceTransformer) {
         include('git.properties')
+    }
+}
+
+/**********************************************************************************************************************\
+ * Publishing (alpian fork)
+ *
+ * Publishes only the fat jar (akhq-<version>-all.jar) to GitHub Packages of this fork.
+ * The version is overridden at publication level so the upstream `version` above stays untouched
+ * and merging upstream release tags never conflicts here.
+ **********************************************************************************************************************/
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            // the fat jar is the one and only artifact, published without the "all" classifier
+            artifact(tasks.shadowJar) {
+                classifier = null
+            }
+            version = System.getenv('PUBLISH_VERSION') ?: project.version
+        }
+    }
+    repositories {
+        // Only configured on CI; local builds use publishToMavenLocal
+        if (System.getenv('GITHUB_REPOSITORY')) {
+            maven {
+                name = 'GitHubPackages'
+                url = "https://maven.pkg.github.com/${System.getenv('GITHUB_REPOSITORY')}"
+                credentials {
+                    username = System.getenv('GITHUB_ACTOR')
+                    password = System.getenv('GITHUB_TOKEN')
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Adding kafka properties to KafkaProtobufDeserializer, to be able to execute schema registry rules.

In class: `AbstractKafkaSchemaSerDe`, method `protected Object executeRules`, line 671
```
      RuleContext ctx = new RuleContext(config.originals(), source, target,
          subject, topic, headers,
          isKey ? original : key(),
          isKey ? null : original,
          isKey, ruleMode, rule, i, rules);
```
`config.originals()` will throw a null pointer exception and fail the deserialization. 

Not sure if my fix is the best way, I guess maybe a method that takes all the kafka properties from both kafka and the schema registry including the URL and username/password with the default key that are defined in the `connection` configuration?