### PR TITLE
fix(docs): Update documentation for DELETE action in CONSUMER_GROUP resource

### DIFF
--- a/docs/docs/configuration/authentifications/groups.md
+++ b/docs/docs/configuration/authentifications/groups.md
@@ -48,7 +48,7 @@ You can still associate a resource with a non-supported action from the table. I
 | READ           | X     | X          | X              | X               | X         | X      | X    | X   | X      |
 | CREATE         | X     | X          |                |                 | X         | X      |      |     |        |
 | UPDATE         | X     | X          |                |                 |           | X      |      |     |        |
-| DELETE         | X     | X          |                |                 | X         | X      |      |     |        |
+| DELETE         | X     | X          | X              |                 | X         | X      |      |     |        |
 | UPDATE_OFFSET  |       |            | X              |                 |           |        |      |     |        |
 | DELETE_OFFSET  |       |            | X              |                 |           |        |      |     |        |
 | READ_CONFIG    | X     |            |                |                 |           |        | X    |     |        |


### PR DESCRIPTION
Related to issue: https://github.com/tchiotludo/akhq/issues/1933

This MR updates the documentation to reflect the support for the DELETE action under the `CONSUMER_GROUP` resource in AKHQ. The previous documentation did not mention the ability to delete an entire consumer group, which is a supported feature in AKHQ.

### Changes:
- Added information about the DELETE action in the `CONSUMER_GROUP` section of the documentation.