### PR TITLE
Fix documentation: connector is missing Update role

### DIFF
--- a/docs/docs/configuration/authentifications/groups.md
+++ b/docs/docs/configuration/authentifications/groups.md
@@ -47,7 +47,7 @@ You can still associate a resource with a non-supported action from the table. I
 |----------------|-------|------------|----------------|-----------------|-----------|--------|------|-----|--------|
 | READ           | X     | X          | X              | X               | X         | X      | X    | X   | X      |
 | CREATE         | X     | X          |                |                 | X         | X      |      |     |        |
-| UPDATE         | X     | X          |                |                 |           | X      |      |     |        |
+| UPDATE         | X     | X          |                |                 | x         | X      |      |     |        |
 | DELETE         | X     | X          | X              |                 | X         | X      |      |     |        |
 | UPDATE_OFFSET  |       |            | X              |                 |           |        |      |     |        |
 | DELETE_OFFSET  |       |            | X              |                 |           |        |      |     |        |

--- a/docs/docs/configuration/authentifications/groups.md
+++ b/docs/docs/configuration/authentifications/groups.md
@@ -47,7 +47,7 @@ You can still associate a resource with a non-supported action from the table. I
 |----------------|-------|------------|----------------|-----------------|-----------|--------|------|-----|--------|
 | READ           | X     | X          | X              | X               | X         | X      | X    | X   | X      |
 | CREATE         | X     | X          |                |                 | X         | X      |      |     |        |
-| UPDATE         | X     | X          |                |                 | x         | X      |      |     |        |
+| UPDATE         | X     | X          |                |                 | X         | X      |      |     |        |
 | DELETE         | X     | X          | X              |                 | X         | X      |      |     |        |
 | UPDATE_OFFSET  |       |            | X              |                 |           |        |      |     |        |
 | DELETE_OFFSET  |       |            | X              |                 |           |        |      |     |        |


### PR DESCRIPTION
Fix #1974 

# Reason for the change

In the [AKHQ Documentation for Authentication using Groups](https://akhq.io/docs/configuration/authentifications/groups.html), the Connect section in the Roles table does not mention the Update role. This omission may cause confusion, implying that "Connect cannot have this role." However, Connect can indeed have this permission, and without it, updating the connector configuration is not possible.

I propose adding the Update role to the Connect section to clarify this and prevent misunderstandings.