### PR TITLE
chore(helm): add granular custom labels for ingress and networkPolicy

### DIFF
--- a/helm/akhq/Chart.yaml
+++ b/helm/akhq/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.25.1"
+appVersion: "0.25.2"
 description: Kafka GUI for Apache Kafka to manage topics, topics data, consumers group, schema registry, connect and more...
 name: akhq
-version: 0.25.1
+version: 0.25.2
 keywords:
   - kafka
   - confluent

--- a/helm/akhq/templates/ingress.yaml
+++ b/helm/akhq/templates/ingress.yaml
@@ -10,6 +10,9 @@ metadata:
     helm.sh/chart: {{ include "akhq.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- range $key, $value := .Values.ingress.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- tpl (toYaml .) $ | nindent 4 }}

--- a/helm/akhq/templates/networkpolicy.yaml
+++ b/helm/akhq/templates/networkpolicy.yaml
@@ -8,9 +8,9 @@ metadata:
     helm.sh/chart: {{ include "akhq.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-     {{- with .Values.labels }}
-       {{- toYaml . | nindent 4 }}
-     {{- end }}
+    {{- range $key, $value := .Values.networkPolicy.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   policyTypes:
     - Ingress

--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -139,6 +139,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  labels: {}
   paths:
     - /
   pathType: "ImplementationSpecific"
@@ -191,3 +192,4 @@ affinity: {}
 
 networkPolicy:
   enabled: true
+  labels: {}


### PR DESCRIPTION
Added support for more granular custom labels for _ingress_ and _networkPolicy_ resources to improve configurability, adapting the approach in `service.yaml`. In our use case, and generally, injecting all custom labels into resources is not ideal, especially when working with label selectors, so I implemented a more targeted approach.