### PR TITLE
Fixed mistake in role name for Ksqldb aside buttons

### DIFF
--- a/client/src/containers/KsqlDB/KsqlDBList/KsqlDBList.jsx
+++ b/client/src/containers/KsqlDB/KsqlDBList/KsqlDBList.jsx
@@ -102,7 +102,7 @@ class KsqlDBList extends Component {
             </div>
           </div>
         </div>
-        {roles && roles.KSQDLDB && roles.KSQLDB.includes('EXECUTE') && (
+        {roles && roles.KSQLDB && roles.KSQLDB.includes('EXECUTE') && (
           <aside>
             <li className="aside-button">
               <Link


### PR DESCRIPTION
Fix a mistake in role name for Ksqldb aside buttons ('KSQDLDB' instead…… of 'KSQLDB').

This is blocking the display of this buttons, and therefore it is not possible to run query or statemetn from web interface.