### PR TITLE
fix(masking): fixes multi-level nested fields, and hides non-JSON entries

### DIFF
--- a/docs/docs/configuration/akhq.md
+++ b/docs/docs/configuration/akhq.md
@@ -168,6 +168,10 @@ With the above configuration, it will appear as:
 This means, by default, everything is masked.
 This is useful in production scenarios where data must be carefully selected and made available to
 users of AKHQ - usually this is for regulatory compliance of personal/sensitive information.
+
+PLEASE NOTE: This has the side effect of being unable to show unstructured data at all. This is because if the schema registry
+is down, the binary data would otherwise be unfilterable. Instead, a placeholder message is shown.
+
 If you wish to mask data this way, you can:
 - Set a value in `akhq.security.data-masking.jsonMaskReplacement` (this defaults to `xxxx`)
 - Set `akhq.security.data-masking.mode` to `json_mask_by_default`

--- a/src/main/java/org/akhq/utils/JsonMaskByDefaultMasker.java
+++ b/src/main/java/org/akhq/utils/JsonMaskByDefaultMasker.java
@@ -34,6 +34,8 @@ public class JsonMaskByDefaultMasker implements Masker {
                     .findFirst()
                     .map(filter -> applyMasking(record, filter.getKeys()))
                     .orElseGet(() -> applyMasking(record, List.of()));
+            } else {
+                record.setValue("This record is unable to be masked as it is not a structured object. This record is unavailable to view due to safety measures from json_mask_by_default to not leak sensitive data. Please contact akhq administrator.");
             }
         } catch (Exception e) {
             LOG.error("Error masking record at topic {}, partition {}, offset {} due to {}", record.getTopic(), record.getPartition(), record.getOffset(), e.getMessage());
@@ -59,7 +61,7 @@ public class JsonMaskByDefaultMasker implements Masker {
             JsonObject objectNode = node.getAsJsonObject();
             for(Map.Entry<String, JsonElement> entry : objectNode.entrySet()) {
                 if(entry.getValue().isJsonObject()) {
-                    maskAllExcept(entry.getKey() + ".", entry.getValue().getAsJsonObject(), keys);
+                    maskAllExcept(currentKey + entry.getKey() + ".", entry.getValue().getAsJsonObject(), keys);
                 } else {
                     if(!keys.contains(currentKey + entry.getKey())) {
                         objectNode.addProperty(entry.getKey(), jsonMaskReplacement);

--- a/src/test/java/org/akhq/utils/JsonShowByDefaultMaskerTest.java
+++ b/src/test/java/org/akhq/utils/JsonShowByDefaultMaskerTest.java
@@ -99,6 +99,23 @@ class JsonShowByDefaultMaskerTest extends MaskerTestHelper {
         );
     }
 
+    @Test
+    void ifRecordHasMultiLevelNestedValuesShouldBeProcessedCorrectly() {
+        Record record = sampleRecord(
+            "users",
+            "some-key",
+            sampleValueWithMultilevelNestedValues()
+        );
+
+        Record maskedRecord = masker.maskRecord(record);
+
+        assertEquals(
+            """
+                {"specialId":123,"status":"ACTIVE","name":"xxxx","dateOfBirth":"xxxx","address":{"firstLine":"xxxx","town":"xxxx","country":"United Kingdom"},"metadata":{"trusted":true,"rating":"10","notes":"All in good order","other":{"shouldBeUnmasked":"Example multi-level-nested-value","shouldBeMasked":"xxxx"}}}""",
+            maskedRecord.getValue()
+        );
+    }
+
     private String sampleValue() {
         return """
             {
@@ -115,6 +132,31 @@ class JsonShowByDefaultMaskerTest extends MaskerTestHelper {
                  "trusted": true,
                  "rating": "10",
                  "notes": "All in good order"
+               }
+            }
+            """;
+    }
+
+    private String sampleValueWithMultilevelNestedValues() {
+        return """
+            {
+               "specialId": 123,
+               "status": "ACTIVE",
+               "name": "John Smith",
+               "dateOfBirth": "01-01-1991",
+               "address": {
+                 "firstLine": "123 Example Avenue",
+                 "town": "Faketown",
+                 "country": "United Kingdom"
+               },
+               "metadata": {
+                 "trusted": true,
+                 "rating": "10",
+                 "notes": "All in good order",
+                 "other": {
+                    "shouldBeUnmasked": "Example multi-level-nested-value",
+                    "shouldBeMasked": "Example multi-level-nested-value"
+                 }
                }
             }
             """;

--- a/src/test/resources/application-json-mask-by-default-data-masking.yml
+++ b/src/test/resources/application-json-mask-by-default-data-masking.yml
@@ -11,3 +11,4 @@ akhq:
             - address.country
             - metadata.trusted
             - metadata.rating
+            - metadata.other.shouldBeUnmasked

--- a/src/test/resources/application-json-show-by-default-data-masking.yml
+++ b/src/test/resources/application-json-show-by-default-data-masking.yml
@@ -10,3 +10,4 @@ akhq:
             - dateOfBirth
             - address.firstLine
             - address.town
+            - metadata.other.shouldBeMasked


### PR DESCRIPTION
Hi! Follow up to previous PR as I realised there were a few small issues after deploying to another environment:

1) Returning the original values if it isn't JSON-formattable is actually dangerous, as it means if the schema registry is down or if the wrong schema registry is selected in AKHQ in a multi-schema-registry-setup, the binary format data will still show as a String which in most cases still displays some of the sensitive data. To be safe, this means `json_mask_by_default` will now ONLY show structured data and anything else will display a placeholder message. This prevents any unwanted data leakage.

2) Fixes multi-level nested objects for the 'mask by default' option. Before we weren't prepending `currentKey`. So for example given a request to expose `one.two.three`,  `one.two.three` would still be masked - the filter would have needed to specify just `two.three` (which is incorrect and would also mean `another.two.three` would also be unmasked). This fixes it to work as expected, so `one.two.three` unmasks `one.two.three` and also isn't applied to `another.two.three`