### PR TITLE
fix(helm): resolve conflict with extraEnv AKHQ_CONFIGURATION and Conf…

### DIFF
--- a/helm/akhq/templates/configmap.yaml
+++ b/helm/akhq/templates/configmap.yaml
@@ -1,4 +1,9 @@
 {{- if .Values.configuration }}
+{{- range .Values.extraEnv }}
+{{- if eq .name "AKHQ_CONFIGURATION" }}
+{{- fail "Can't use AKHQ_CONFIGURATION extraEnv together with ConfigMap configuration." }}
+{{- end }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -38,12 +38,12 @@ extraEnv: []
 #   value: "/any/additional/jars/desired.jar:/go/here.jar"
 
 ## Or you can also use configmap for the configuration...
-configuration:
-  akhq:
-    server:
-      access-log:
-        enabled: false
-        name: org.akhq.log.access
+configuration: {}
+  # akhq:
+  #   server:
+  #     access-log:
+  #       enabled: false
+  #       name: org.akhq.log.access
 
 ##... and secret for connection information
 existingSecrets: ""


### PR DESCRIPTION
…igMap configuration

Issue #2007

- Add `fail` statement when both `AKHQ_CONFIGURATION` and configMap were to be generated
- Set `.Values.configuration` to empty map, so it's generated only when explicitly defined