### PR TITLE
fix(copy): remove schema from formData to fix validation error on copy

### DIFF
--- a/client/src/containers/Topic/TopicProduce/TopicProduce.jsx
+++ b/client/src/containers/Topic/TopicProduce/TopicProduce.jsx
@@ -126,7 +126,7 @@ class TopicProduce extends Form {
   }
 
   async initByTopicEvent(copyValues) {
-    const { headers, ...topicValuesDefault } = copyValues;
+    const { headers, keySchema, valueSchema, ...topicValuesDefault } = copyValues;
 
     let nHeaders = headers.length === 0 ? 1 : 0;
 


### PR DESCRIPTION
Fix #1971

Removed extra values in the form data (key / value schema) that prevented the form validation to be true.

There is still an area for improvement as the schema information from the message is not taken into account. The selected key/value schema is will be the one corresponding to the topic (not the one from the message if a different schema is used - user will have to select the right one in the dropdown)

