### PR TITLE
fix(docker): extend (not override) base image entrypoint

### DIFF
--- a/docker/usr/local/bin/docker-entrypoint.sh
+++ b/docker/usr/local/bin/docker-entrypoint.sh
@@ -6,4 +6,9 @@ if [ "${AKHQ_CONFIGURATION}" ]; then
     echo "${AKHQ_CONFIGURATION}" > /app/application.yml
 fi
 
-exec "$@"
+# We currently override the base image ENTRYPOINT in our Dockerfile making it harder
+# to get access to the CA certificates feature provided by the base image ENTRYPOINT:
+# https://github.com/docker-library/docs/blob/master/eclipse-temurin/content.md#can-i-add-my-internal-ca-certificates-to-the-truststore
+# To fix this issue, we invoke the base image ENTRYPOINT script (/__cacert_entrypoint.sh) before the arguments.
+# Credits to https://superuser.com/a/1460890
+exec /__cacert_entrypoint.sh "$@"


### PR DESCRIPTION
In the image build we currently override the base image ENTRYPOINT. This makes it harder to get CA certificates added to the JVM truststore, ref. [Eclipse Temurin feature](https://github.com/docker-library/docs/blob/master/eclipse-temurin/content.md#can-i-add-my-internal-ca-certificates-to-the-truststore).

My use case is to use OIDC providers using private PKI certificates.

I have verified that I am able to use the Eclipse Temurin feature by overriding both the `command` and `args` in my AKHQ Kubernetes workload. But I had to use the `akhq:dev` image.

@tchiotludo Would it be possible to get a new AKHQ release soon? With or without this PR included. 😉 I want to use the Eclipse Temurin feature, and the latest tag (`0.25.1`) is just too old.....