### PR TITLE
fix(masking): Various performance, functional, and readability fixes for JSON-based masking

### DIFF
--- a/docs/docs/configuration/akhq.md
+++ b/docs/docs/configuration/akhq.md
@@ -180,7 +180,30 @@ With the above configuration, it will appear as:
 }
 ```
 
-Note how the configuration fields automatically propagates to all objects in an array where relevant.
+Note how arrays are automatically understood where relevant.
+In other words, `address.firstLine` will apply to both of the following:
+```json
+{
+  "address": {
+    "firstLine": "This field!"
+  }
+}
+```
+
+and
+
+```json
+{
+  "address": [
+    {
+      "firstLine": "This field!"
+    },
+    {
+      "firstLine": "And this one!"
+    }
+  ]
+}
+```
 
 ### Mask by default config
 This means, by default, everything is masked.
@@ -272,7 +295,30 @@ With the above configuration, it will appear as:
 }
 ```
 
-Note how the configuration fields automatically propagates to all objects in an array where relevant.
+Note how arrays are automatically understood where relevant.
+In other words, `address.firstLine` will apply to both of the following:
+```json
+{
+  "address": {
+    "firstLine": "This field!"
+  }
+}
+```
+
+and
+
+```json
+{
+  "address": [
+    {
+      "firstLine": "This field!"
+    },
+    {
+      "firstLine": "And this one!"
+    }
+  ]
+}
+```
 
 ### No masking required
 You can set `akhq.security.data-masking.mode` to `none` to disable masking altogether.

--- a/docs/docs/configuration/akhq.md
+++ b/docs/docs/configuration/akhq.md
@@ -121,6 +121,7 @@ akhq:
             - dateOfBirth
             - address.firstLine
             - address.town
+            - metadata.notes
 ```
 
 Given a record on `users` that looks like:
@@ -131,11 +132,18 @@ Given a record on `users` that looks like:
   "status": "ACTIVE",
   "name": "John Smith",
   "dateOfBirth": "01-01-1991",
-  "address": {
-    "firstLine": "123 Example Avenue",
-    "town": "Faketown",
-    "country": "United Kingdom"
-  },
+  "address": [
+    {
+      "firstLine": "123 Example Avenue",
+      "town": "Faketown",
+      "country": "United Kingdom"
+    },
+    {
+      "firstLine": "123 Previous Avenue",
+      "town": "Previoustown",
+      "country": "United Kingdom"
+    }
+  ],
   "metadata": {
     "trusted": true,
     "rating": "10",
@@ -152,18 +160,27 @@ With the above configuration, it will appear as:
   "status": "ACTIVE",
   "name": "xxxx",
   "dateOfBirth": "xxxx",
-  "address": {
-    "firstLine": "xxxx",
-    "town": "xxxx",
-    "country": "United Kingdom"
-  },
+  "address": [
+    {
+      "firstLine": "xxxx",
+      "town": "xxxx",
+      "country": "United Kingdom"
+    },
+    {
+      "firstLine": "xxxx",
+      "town": "xxxx",
+      "country": "United Kingdom"
+    }
+  ],
   "metadata": {
     "trusted": true,
     "rating": "10",
-    "notes": "All in good order"
+    "notes": "xxxx"
   }
 }
 ```
+
+Note how the configuration fields automatically propagates to all objects in an array where relevant.
 
 ### Mask by default config
 This means, by default, everything is masked.
@@ -207,11 +224,18 @@ Given a record on `users` that looks like:
   "status": "ACTIVE",
   "name": "John Smith",
   "dateOfBirth": "01-01-1991",
-  "address": {
-    "firstLine": "123 Example Avenue",
-    "town": "Faketown",
-    "country": "United Kingdom"
-  },
+  "address": [
+    {
+      "firstLine": "123 Example Avenue",
+      "town": "Faketown",
+      "country": "United Kingdom"
+    },
+    {
+      "firstLine": "123 Previous Avenue",
+      "town": "Previoustown",
+      "country": "United Kingdom"
+    }
+  ],
   "metadata": {
     "trusted": true,
     "rating": "10",
@@ -228,11 +252,18 @@ With the above configuration, it will appear as:
   "status": "ACTIVE",
   "name": "xxxx",
   "dateOfBirth": "xxxx",
-  "address": {
-    "firstLine": "xxxx",
-    "town": "xxxx",
-    "country": "United Kingdom"
-  },
+  "address": [
+    {
+      "firstLine": "xxxx",
+      "town": "xxxx",
+      "country": "United Kingdom"
+    },
+    {
+      "firstLine": "xxxx",
+      "town": "xxxx",
+      "country": "United Kingdom"
+    }
+  ],
   "metadata": {
     "trusted": true,
     "rating": "10",
@@ -240,6 +271,8 @@ With the above configuration, it will appear as:
   }
 }
 ```
+
+Note how the configuration fields automatically propagates to all objects in an array where relevant.
 
 ### No masking required
 You can set `akhq.security.data-masking.mode` to `none` to disable masking altogether.

--- a/src/main/java/org/akhq/utils/JsonMaskByDefaultMasker.java
+++ b/src/main/java/org/akhq/utils/JsonMaskByDefaultMasker.java
@@ -1,8 +1,6 @@
 package org.akhq.utils;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.google.gson.*;
 import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 import lombok.SneakyThrows;
@@ -10,64 +8,116 @@ import org.akhq.configs.DataMasking;
 import org.akhq.configs.JsonMaskingFilter;
 import org.akhq.models.Record;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Singleton
 @Requires(property = "akhq.security.data-masking.mode", value = "json_mask_by_default")
 public class JsonMaskByDefaultMasker implements Masker {
 
-    private final List<JsonMaskingFilter> jsonMaskingFilters;
+    private final Map<String, List<String>> topicToKeysMap;
     private final String jsonMaskReplacement;
+    private static final String NON_JSON_MESSAGE = "This record is unable to be masked as it is not a structured object. This record is unavailable to view due to safety measures from json_mask_by_default to not leak sensitive data.";
+    private static final String ERROR_MESSAGE = "An exception occurred during an attempt to mask this record. This record is unavailable to view due to safety measures from json_mask_by_default to not leak sensitive data. Please contact akhq administrator.";
 
     public JsonMaskByDefaultMasker(DataMasking dataMasking) {
-        this.jsonMaskingFilters = dataMasking.getJsonFilters();
         this.jsonMaskReplacement = dataMasking.getJsonMaskReplacement();
+        this.topicToKeysMap = buildTopicKeysMap(dataMasking);
+    }
+
+    private Map<String, List<String>> buildTopicKeysMap(DataMasking dataMasking) {
+        return dataMasking.getJsonFilters().stream()
+            .collect(Collectors.toMap(
+                JsonMaskingFilter::getTopic,
+                JsonMaskingFilter::getKeys,
+                (a, b) -> a,
+                HashMap::new
+            ));
     }
 
     public Record maskRecord(Record record) {
-        try {
-            if(isJson(record)) {
-                return jsonMaskingFilters
-                    .stream()
-                    .filter(jsonMaskingFilter -> record.getTopic().getName().equalsIgnoreCase(jsonMaskingFilter.getTopic()))
-                    .findFirst()
-                    .map(filter -> applyMasking(record, filter.getKeys()))
-                    .orElseGet(() -> applyMasking(record, List.of()));
-            } else {
-                record.setValue("This record is unable to be masked as it is not a structured object. This record is unavailable to view due to safety measures from json_mask_by_default to not leak sensitive data. Please contact akhq administrator.");
-            }
-        } catch (Exception e) {
-            LOG.error("Error masking record at topic {}, partition {}, offset {} due to {}", record.getTopic(), record.getPartition(), record.getOffset(), e.getMessage());
-            record.setValue("An exception occurred during an attempt to mask this record. This record is unavailable to view due to safety measures from json_mask_by_default to not leak sensitive data. Please contact akhq administrator.");
+        if (!isJson(record)) {
+            return createNonJsonRecord(record);
         }
+
+        try {
+            List<String> unmaskedKeys = getUnmaskedKeysForTopic(record.getTopic().getName());
+            return applyMasking(record, unmaskedKeys);
+        } catch (Exception e) {
+            logMaskingError(record, e);
+            return createErrorRecord(record);
+        }
+    }
+
+    private List<String> getUnmaskedKeysForTopic(String topic) {
+        return topicToKeysMap.getOrDefault(topic.toLowerCase(), Collections.emptyList());
+    }
+
+    private Record createNonJsonRecord(Record record) {
+        record.setValue(NON_JSON_MESSAGE);
         return record;
+    }
+
+    private Record createErrorRecord(Record record) {
+        record.setValue(ERROR_MESSAGE);
+        return record;
+    }
+
+    private void logMaskingError(Record record, Exception e) {
+        LOG.error("Error masking record at topic {}, partition {}, offset {} due to {}",
+            record.getTopic(), record.getPartition(), record.getOffset(), e.getMessage());
     }
 
     @SneakyThrows
-    private Record applyMasking(Record record, List<String> keys) {
-        JsonObject jsonElement = JsonParser.parseString(record.getValue()).getAsJsonObject();
-        maskAllExcept(jsonElement, keys);
-        record.setValue(jsonElement.toString());
+    private Record applyMasking(Record record, List<String> unmaskedKeys) {
+        JsonObject root = JsonParser.parseString(record.getValue()).getAsJsonObject();
+        maskJson(root, "", unmaskedKeys);
+        record.setValue(root.toString());
         return record;
     }
 
-    private void maskAllExcept(JsonObject jsonElement, List<String> keys) {
-        maskAllExcept("",  jsonElement, keys);
+    private void maskJson(JsonElement element, String path, List<String> unmaskedKeys) {
+        if (element.isJsonObject()) {
+            maskJsonObject(element.getAsJsonObject(), path, unmaskedKeys);
+        } else if (element.isJsonArray()) {
+            maskJsonArray(element.getAsJsonArray(), path, unmaskedKeys);
+        }
     }
 
-    private void maskAllExcept(String currentKey, JsonObject node, List<String> keys) {
-        if (node.isJsonObject()) {
-            JsonObject objectNode = node.getAsJsonObject();
-            for(Map.Entry<String, JsonElement> entry : objectNode.entrySet()) {
-                if(entry.getValue().isJsonObject()) {
-                    maskAllExcept(currentKey + entry.getKey() + ".", entry.getValue().getAsJsonObject(), keys);
-                } else {
-                    if(!keys.contains(currentKey + entry.getKey())) {
-                        objectNode.addProperty(entry.getKey(), jsonMaskReplacement);
-                    }
-                }
+    private void maskJsonObject(JsonObject obj, String path, List<String> unmaskedKeys) {
+        for (Map.Entry<String, JsonElement> entry : obj.entrySet()) {
+            String newPath = path + entry.getKey();
+            JsonElement value = entry.getValue();
+
+            if (shouldMaskPrimitive(value, newPath, unmaskedKeys)) {
+                entry.setValue(new JsonPrimitive(jsonMaskReplacement));
+            } else if (isNestedStructure(value)) {
+                maskJson(value, newPath + ".", unmaskedKeys);
             }
         }
+    }
+
+    private void maskJsonArray(JsonArray array, String path, List<String> unmaskedKeys) {
+        boolean shouldMask = !unmaskedKeys.contains(path.substring(0, path.length() - 1));
+
+        for (int i = 0; i < array.size(); i++) {
+            JsonElement arrayElement = array.get(i);
+            if (arrayElement.isJsonPrimitive() && shouldMask) {
+                array.set(i, new JsonPrimitive(jsonMaskReplacement));
+            } else if (isNestedStructure(arrayElement)) {
+                maskJson(arrayElement, path, unmaskedKeys);
+            }
+        }
+    }
+
+    private boolean shouldMaskPrimitive(JsonElement value, String path, List<String> unmaskedKeys) {
+        return value.isJsonPrimitive() && !unmaskedKeys.contains(path);
+    }
+
+    private boolean isNestedStructure(JsonElement value) {
+        return value.isJsonObject() || value.isJsonArray();
     }
 }

--- a/src/main/java/org/akhq/utils/JsonMaskByDefaultMasker.java
+++ b/src/main/java/org/akhq/utils/JsonMaskByDefaultMasker.java
@@ -21,7 +21,7 @@ public class JsonMaskByDefaultMasker implements Masker {
     private final Map<String, List<String>> topicToKeysMap;
     private final String jsonMaskReplacement;
     private static final String NON_JSON_MESSAGE = "This record is unable to be masked as it is not a structured object. This record is unavailable to view due to safety measures from json_mask_by_default to not leak sensitive data.";
-    private static final String ERROR_MESSAGE = "An exception occurred during an attempt to mask this record. This record is unavailable to view due to safety measures from json_mask_by_default to not leak sensitive data. Please contact akhq administrator.";
+    private static final String ERROR_MESSAGE = "An exception occurred during an attempt to mask this record. This record is unavailable to view due to safety measures from json_mask_by_default to not leak sensitive data.";
 
     public JsonMaskByDefaultMasker(DataMasking dataMasking) {
         this.jsonMaskReplacement = dataMasking.getJsonMaskReplacement();

--- a/src/main/java/org/akhq/utils/JsonMaskByDefaultMasker.java
+++ b/src/main/java/org/akhq/utils/JsonMaskByDefaultMasker.java
@@ -73,7 +73,7 @@ public class JsonMaskByDefaultMasker implements Masker {
 
     @SneakyThrows
     private Record applyMasking(Record record, List<String> unmaskedKeys) {
-        JsonObject root = JsonParser.parseString(record.getValue()).getAsJsonObject();
+        JsonElement root = JsonParser.parseString(record.getValue());
         maskJson(root, "", unmaskedKeys);
         record.setValue(root.toString());
         return record;

--- a/src/main/java/org/akhq/utils/JsonMaskByDefaultMasker.java
+++ b/src/main/java/org/akhq/utils/JsonMaskByDefaultMasker.java
@@ -1,120 +1,91 @@
 package org.akhq.utils;
 
-import com.google.gson.*;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
 import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 import lombok.SneakyThrows;
 import org.akhq.configs.DataMasking;
-import org.akhq.configs.JsonMaskingFilter;
 import org.akhq.models.Record;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Singleton
 @Requires(property = "akhq.security.data-masking.mode", value = "json_mask_by_default")
-public class JsonMaskByDefaultMasker implements Masker {
+public class JsonMaskByDefaultMasker extends JsonMasker {
 
-    private final Map<String, List<String>> topicToKeysMap;
-    private final String jsonMaskReplacement;
     private static final String NON_JSON_MESSAGE = "This record is unable to be masked as it is not a structured object. This record is unavailable to view due to safety measures from json_mask_by_default to not leak sensitive data.";
     private static final String ERROR_MESSAGE = "An exception occurred during an attempt to mask this record. This record is unavailable to view due to safety measures from json_mask_by_default to not leak sensitive data.";
 
     public JsonMaskByDefaultMasker(DataMasking dataMasking) {
-        this.jsonMaskReplacement = dataMasking.getJsonMaskReplacement();
-        this.topicToKeysMap = buildTopicKeysMap(dataMasking);
-    }
-
-    private Map<String, List<String>> buildTopicKeysMap(DataMasking dataMasking) {
-        return dataMasking.getJsonFilters().stream()
-            .collect(Collectors.toMap(
-                JsonMaskingFilter::getTopic,
-                JsonMaskingFilter::getKeys,
-                (a, b) -> a,
-                HashMap::new
-            ));
+        super(dataMasking);
     }
 
     public Record maskRecord(Record record) {
         if (!isJson(record)) {
-            return createNonJsonRecord(record);
+            record.setValue(NON_JSON_MESSAGE);
+            return record;
         }
 
         try {
-            List<String> unmaskedKeys = getUnmaskedKeysForTopic(record.getTopic().getName());
-            return applyMasking(record, unmaskedKeys);
+            List<String> keysToUnmask = getKeysForTopic(record.getTopic().getName());
+            return applyMasking(record, keysToUnmask);
         } catch (Exception e) {
-            logMaskingError(record, e);
-            return createErrorRecord(record);
+            LOG.error("Error masking record at topic {}, partition {}, offset {} due to {}",
+                record.getTopic(), record.getPartition(), record.getOffset(), e.getMessage());
+            record.setValue(ERROR_MESSAGE);
+            return record;
         }
     }
 
-    private List<String> getUnmaskedKeysForTopic(String topic) {
-        return topicToKeysMap.getOrDefault(topic.toLowerCase(), Collections.emptyList());
-    }
-
-    private Record createNonJsonRecord(Record record) {
-        record.setValue(NON_JSON_MESSAGE);
-        return record;
-    }
-
-    private Record createErrorRecord(Record record) {
-        record.setValue(ERROR_MESSAGE);
-        return record;
-    }
-
-    private void logMaskingError(Record record, Exception e) {
-        LOG.error("Error masking record at topic {}, partition {}, offset {} due to {}",
-            record.getTopic(), record.getPartition(), record.getOffset(), e.getMessage());
-    }
-
     @SneakyThrows
-    private Record applyMasking(Record record, List<String> unmaskedKeys) {
+    private Record applyMasking(Record record, List<String> keysToUnmask) {
         JsonElement root = JsonParser.parseString(record.getValue());
-        maskJson(root, "", unmaskedKeys);
+        maskJson(root, "", keysToUnmask);
         record.setValue(root.toString());
         return record;
     }
 
-    private void maskJson(JsonElement element, String path, List<String> unmaskedKeys) {
+    private void maskJson(JsonElement element, String path, List<String> keysToUnmask) {
         if (element.isJsonObject()) {
-            maskJsonObject(element.getAsJsonObject(), path, unmaskedKeys);
+            maskJsonObject(element.getAsJsonObject(), path, keysToUnmask);
         } else if (element.isJsonArray()) {
-            maskJsonArray(element.getAsJsonArray(), path, unmaskedKeys);
+            maskJsonArray(element.getAsJsonArray(), path, keysToUnmask);
         }
     }
 
-    private void maskJsonObject(JsonObject obj, String path, List<String> unmaskedKeys) {
+    private void maskJsonObject(JsonObject obj, String path, List<String> keysToUnmask) {
         for (Map.Entry<String, JsonElement> entry : obj.entrySet()) {
             String newPath = path + entry.getKey();
             JsonElement value = entry.getValue();
 
-            if (shouldMaskPrimitive(value, newPath, unmaskedKeys)) {
+            if (shouldMaskPrimitive(value, newPath, keysToUnmask)) {
                 entry.setValue(new JsonPrimitive(jsonMaskReplacement));
             } else if (isNestedStructure(value)) {
-                maskJson(value, newPath + ".", unmaskedKeys);
+                maskJson(value, newPath + ".", keysToUnmask);
             }
         }
     }
 
-    private void maskJsonArray(JsonArray array, String path, List<String> unmaskedKeys) {
-        boolean shouldMask = !unmaskedKeys.contains(path.substring(0, path.length() - 1));
+    private void maskJsonArray(JsonArray array, String path, List<String> keysToUnmask) {
+        boolean shouldMask = !keysToUnmask.contains(path.substring(0, path.length() - 1));
 
         for (int i = 0; i < array.size(); i++) {
             JsonElement arrayElement = array.get(i);
             if (arrayElement.isJsonPrimitive() && shouldMask) {
                 array.set(i, new JsonPrimitive(jsonMaskReplacement));
             } else if (isNestedStructure(arrayElement)) {
-                maskJson(arrayElement, path, unmaskedKeys);
+                maskJson(arrayElement, path, keysToUnmask);
             }
         }
     }
 
-    private boolean shouldMaskPrimitive(JsonElement value, String path, List<String> unmaskedKeys) {
-        return value.isJsonPrimitive() && !unmaskedKeys.contains(path);
+    private boolean shouldMaskPrimitive(JsonElement value, String path, List<String> keysToUnmask) {
+        return value.isJsonPrimitive() && !keysToUnmask.contains(path);
     }
 
     private boolean isNestedStructure(JsonElement value) {

--- a/src/main/java/org/akhq/utils/JsonMasker.java
+++ b/src/main/java/org/akhq/utils/JsonMasker.java
@@ -1,0 +1,34 @@
+package org.akhq.utils;
+
+import org.akhq.configs.DataMasking;
+import org.akhq.configs.JsonMaskingFilter;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public abstract class JsonMasker implements Masker {
+    private final Map<String, List<String>> topicToKeysMap;
+    protected final String jsonMaskReplacement;
+
+    public JsonMasker(DataMasking dataMasking) {
+        this.jsonMaskReplacement = dataMasking.getJsonMaskReplacement();
+        this.topicToKeysMap = buildTopicKeysMap(dataMasking);
+    }
+
+    private Map<String, List<String>> buildTopicKeysMap(DataMasking dataMasking) {
+        return dataMasking.getJsonFilters().stream()
+            .collect(Collectors.toMap(
+                JsonMaskingFilter::getTopic,
+                JsonMaskingFilter::getKeys,
+                (a, b) -> a,
+                HashMap::new
+            ));
+    }
+
+    protected List<String> getKeysForTopic(String topic) {
+        return topicToKeysMap.getOrDefault(topic.toLowerCase(), Collections.emptyList());
+    }
+}

--- a/src/main/java/org/akhq/utils/JsonShowByDefaultMasker.java
+++ b/src/main/java/org/akhq/utils/JsonShowByDefaultMasker.java
@@ -1,8 +1,6 @@
 package org.akhq.utils;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.google.gson.*;
 import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 import lombok.SneakyThrows;
@@ -10,56 +8,115 @@ import org.akhq.configs.DataMasking;
 import org.akhq.configs.JsonMaskingFilter;
 import org.akhq.models.Record;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Singleton
 @Requires(property = "akhq.security.data-masking.mode", value = "json_show_by_default")
 public class JsonShowByDefaultMasker implements Masker {
 
-    private final List<JsonMaskingFilter> jsonMaskingFilters;
+    private final Map<String, List<String>> topicToKeysMap;
     private final String jsonMaskReplacement;
+    private static final String ERROR_MESSAGE = "Error masking record";
 
     public JsonShowByDefaultMasker(DataMasking dataMasking) {
-        this.jsonMaskingFilters = dataMasking.getJsonFilters();
         this.jsonMaskReplacement = dataMasking.getJsonMaskReplacement();
+        this.topicToKeysMap = buildTopicKeysMap(dataMasking);
+    }
+
+    private Map<String, List<String>> buildTopicKeysMap(DataMasking dataMasking) {
+        return dataMasking.getJsonFilters().stream()
+            .collect(Collectors.toMap(
+                JsonMaskingFilter::getTopic,
+                JsonMaskingFilter::getKeys,
+                (a, b) -> a,
+                HashMap::new
+            ));
     }
 
     public Record maskRecord(Record record) {
         try {
-            if(isJson(record)) {
-                return jsonMaskingFilters
-                    .stream()
-                    .filter(jsonMaskingFilter -> record.getTopic().getName().equalsIgnoreCase(jsonMaskingFilter.getTopic()))
-                    .findFirst()
-                    .map(filter -> applyMasking(record, filter.getKeys()))
-                    .orElse(record);
+            if (!isJson(record)) {
+                return record;
             }
+            return maskJsonRecord(record);
         } catch (Exception e) {
-            LOG.error("Error masking record", e);
+            LOG.error(ERROR_MESSAGE, e);
+            return record;
         }
-        return record;
+    }
+
+    private Record maskJsonRecord(Record record) {
+        String topic = record.getTopic().getName().toLowerCase();
+        List<String> maskedKeys = topicToKeysMap.get(topic);
+        return maskedKeys != null ? applyMasking(record, maskedKeys) : record;
     }
 
     @SneakyThrows
-    private Record applyMasking(Record record, List<String> keys) {
-        JsonObject jsonElement = JsonParser.parseString(record.getValue()).getAsJsonObject();
-        for(String key : keys) {
-            maskField(jsonElement, key.split("\\."), 0);
-        }
-        record.setValue(jsonElement.toString());
+    private Record applyMasking(Record record, List<String> maskedKeys) {
+        JsonObject root = JsonParser.parseString(record.getValue()).getAsJsonObject();
+        String[][] pathArrays = preProcessPaths(maskedKeys);
+        maskPaths(root, pathArrays);
+        record.setValue(root.toString());
         return record;
     }
 
-    private void maskField(JsonObject node, String[] keys, int index) {
-        if (index == keys.length - 1) {
-            if (node.has(keys[index])) {
-                node.addProperty(keys[index], jsonMaskReplacement);
-            }
+    private String[][] preProcessPaths(List<String> maskedKeys) {
+        return maskedKeys.stream()
+            .map(key -> key.split("\\."))
+            .toArray(String[][]::new);
+    }
+
+    private void maskPaths(JsonObject root, String[][] pathArrays) {
+        for (String[] path : pathArrays) {
+            maskJson(root, path, 0);
+        }
+    }
+
+    private void maskJson(JsonElement element, String[] path, int index) {
+        if (index == path.length) return;
+
+        String currentKey = path[index];
+        if (element.isJsonObject()) {
+            handleJsonObject(element.getAsJsonObject(), path, index, currentKey);
+        } else if (element.isJsonArray()) {
+            handleJsonArray(element.getAsJsonArray(), path, index);
+        }
+    }
+
+    private void handleJsonObject(JsonObject obj, String[] path, int index, String currentKey) {
+        if (!obj.has(currentKey)) return;
+
+        if (index == path.length - 1) {
+            maskTargetElement(obj, currentKey);
         } else {
-            JsonElement childNode = node.get(keys[index]);
-            if (childNode != null && childNode.isJsonObject()) {
-                maskField(childNode.getAsJsonObject(), keys, index + 1);
+            maskJson(obj.get(currentKey), path, index + 1);
+        }
+    }
+
+    private void handleJsonArray(JsonArray array, String[] path, int index) {
+        for (int i = 0; i < array.size(); i++) {
+            JsonElement arrayElement = array.get(i);
+            if (arrayElement.isJsonObject()) {
+                maskJson(arrayElement, path, index);
             }
+        }
+    }
+
+    private void maskTargetElement(JsonObject obj, String currentKey) {
+        JsonElement target = obj.get(currentKey);
+        if (target.isJsonArray()) {
+            maskArrayElement(target.getAsJsonArray());
+        } else {
+            obj.addProperty(currentKey, jsonMaskReplacement);
+        }
+    }
+
+    private void maskArrayElement(JsonArray array) {
+        for (int i = 0; i < array.size(); i++) {
+            array.set(i, new JsonPrimitive(jsonMaskReplacement));
         }
     }
 }

--- a/src/main/java/org/akhq/utils/JsonShowByDefaultMasker.java
+++ b/src/main/java/org/akhq/utils/JsonShowByDefaultMasker.java
@@ -56,7 +56,7 @@ public class JsonShowByDefaultMasker implements Masker {
 
     @SneakyThrows
     private Record applyMasking(Record record, List<String> maskedKeys) {
-        JsonObject root = JsonParser.parseString(record.getValue()).getAsJsonObject();
+        JsonElement root = JsonParser.parseString(record.getValue());
         String[][] pathArrays = preProcessPaths(maskedKeys);
         maskPaths(root, pathArrays);
         record.setValue(root.toString());
@@ -69,7 +69,7 @@ public class JsonShowByDefaultMasker implements Masker {
             .toArray(String[][]::new);
     }
 
-    private void maskPaths(JsonObject root, String[][] pathArrays) {
+    private void maskPaths(JsonElement root, String[][] pathArrays) {
         for (String[] path : pathArrays) {
             maskJson(root, path, 0);
         }

--- a/src/main/java/org/akhq/utils/JsonShowByDefaultMasker.java
+++ b/src/main/java/org/akhq/utils/JsonShowByDefaultMasker.java
@@ -1,72 +1,53 @@
 package org.akhq.utils;
 
-import com.google.gson.*;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
 import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 import lombok.SneakyThrows;
 import org.akhq.configs.DataMasking;
-import org.akhq.configs.JsonMaskingFilter;
 import org.akhq.models.Record;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @Singleton
 @Requires(property = "akhq.security.data-masking.mode", value = "json_show_by_default")
-public class JsonShowByDefaultMasker implements Masker {
+public class JsonShowByDefaultMasker extends JsonMasker {
 
-    private final Map<String, List<String>> topicToKeysMap;
-    private final String jsonMaskReplacement;
     private static final String ERROR_MESSAGE = "Error masking record";
 
     public JsonShowByDefaultMasker(DataMasking dataMasking) {
-        this.jsonMaskReplacement = dataMasking.getJsonMaskReplacement();
-        this.topicToKeysMap = buildTopicKeysMap(dataMasking);
+        super(dataMasking);
     }
 
-    private Map<String, List<String>> buildTopicKeysMap(DataMasking dataMasking) {
-        return dataMasking.getJsonFilters().stream()
-            .collect(Collectors.toMap(
-                JsonMaskingFilter::getTopic,
-                JsonMaskingFilter::getKeys,
-                (a, b) -> a,
-                HashMap::new
-            ));
-    }
-
+    @Override
     public Record maskRecord(Record record) {
         try {
             if (!isJson(record)) {
                 return record;
             }
-            return maskJsonRecord(record);
+            String topic = record.getTopic().getName().toLowerCase();
+            List<String> keysToMask = getKeysForTopic(topic);
+            return keysToMask.isEmpty() ? record : applyMasking(record, keysToMask);
         } catch (Exception e) {
             LOG.error(ERROR_MESSAGE, e);
             return record;
         }
     }
 
-    private Record maskJsonRecord(Record record) {
-        String topic = record.getTopic().getName().toLowerCase();
-        List<String> maskedKeys = topicToKeysMap.get(topic);
-        return maskedKeys != null ? applyMasking(record, maskedKeys) : record;
-    }
-
     @SneakyThrows
-    private Record applyMasking(Record record, List<String> maskedKeys) {
+    private Record applyMasking(Record record, List<String> keysToMask) {
         JsonElement root = JsonParser.parseString(record.getValue());
-        String[][] pathArrays = preProcessPaths(maskedKeys);
+        String[][] pathArrays = keysToMask
+            .stream()
+            .map(key -> key.split("\\."))
+            .toArray(String[][]::new);
         maskPaths(root, pathArrays);
         record.setValue(root.toString());
         return record;
-    }
-
-    private String[][] preProcessPaths(List<String> maskedKeys) {
-        return maskedKeys.stream()
-            .map(key -> key.split("\\."))
-            .toArray(String[][]::new);
     }
 
     private void maskPaths(JsonElement root, String[][] pathArrays) {

--- a/src/test/java/org/akhq/utils/JsonMaskByDefaultMaskerTest.java
+++ b/src/test/java/org/akhq/utils/JsonMaskByDefaultMaskerTest.java
@@ -66,7 +66,7 @@ class JsonMaskByDefaultMaskerTest implements JsonMaskerTest {
         try (MockedStatic<JsonParser> mockStatic = Mockito.mockStatic(JsonParser.class)) {
             mockStatic.when(() -> JsonParser.parseString(SAMPLE_VALUE)).thenThrow(new RuntimeException("Bad exception!"));
             Record record1 = getMasker().maskRecord(record);
-            assertEquals("An exception occurred during an attempt to mask this record. This record is unavailable to view due to safety measures from json_mask_by_default to not leak sensitive data. Please contact akhq administrator.", record1.getValue());
+            assertEquals("An exception occurred during an attempt to mask this record. This record is unavailable to view due to safety measures from json_mask_by_default to not leak sensitive data.", record1.getValue());
         }
     }
 

--- a/src/test/java/org/akhq/utils/JsonMaskByDefaultMaskerTest.java
+++ b/src/test/java/org/akhq/utils/JsonMaskByDefaultMaskerTest.java
@@ -4,183 +4,85 @@ import com.google.gson.JsonParser;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
 import org.akhq.models.Record;
+import lombok.Getter;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.akhq.utils.MaskerTestHelper.sampleRecord;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Getter
 @MicronautTest(environments = "json-mask-by-default-data-masking")
-class JsonMaskByDefaultMaskerTest extends MaskerTestHelper {
+class JsonMaskByDefaultMaskerTest implements JsonMaskerTest {
 
     @Inject
-    Masker masker;
+    public JsonMaskByDefaultMasker masker;
 
     @Test
-    void shouldUseJsonMaskByDefaultMasker() {
-        assertInstanceOf(JsonMaskByDefaultMasker.class, masker);
-    }
-
-    @Test
-    void shouldMaskRecordValue() {
-        Record record = sampleRecord(
-            "users",
-            "some-key",
-            sampleValue()
-        );
-
-        Record maskedRecord = masker.maskRecord(record);
-
-        assertEquals(
-            "{\"specialId\":123,\"status\":\"ACTIVE\",\"name\":\"xxxx\",\"dateOfBirth\":\"xxxx\",\"address\":{\"firstLine\":\"xxxx\",\"town\":\"xxxx\",\"country\":\"United Kingdom\"},\"metadata\":{\"trusted\":true,\"rating\":\"10\",\"notes\":\"xxxx\"}}",
-            maskedRecord.getValue()
-        );
-    }
-
-    @Test
-    void forUndefinedTopicShouldDefaultMaskAllValues() {
-        Record record = sampleRecord(
-            "different-topic",
-            "some-key",
-            sampleValue()
-        );
-
-        Record maskedRecord = masker.maskRecord(record);
-
-        assertEquals(
-            "{\"specialId\":\"xxxx\",\"status\":\"xxxx\",\"name\":\"xxxx\",\"dateOfBirth\":\"xxxx\",\"address\":{\"firstLine\":\"xxxx\",\"town\":\"xxxx\",\"country\":\"xxxx\"},\"metadata\":{\"trusted\":\"xxxx\",\"rating\":\"xxxx\",\"notes\":\"xxxx\"}}",
-            maskedRecord.getValue()
-        );
-    }
-
-    @Test
-    void forTombstoneShouldReturnItself() {
-        Record record = sampleRecord(
-            "users",
-            "some-key",
-            null
-        );
-
-        Record maskedRecord = masker.maskRecord(record);
-
-        assertEquals(
-            record,
-            maskedRecord
-        );
-    }
-
-    @Test
-    void forNonJsonValueShouldReturnItself() {
+    public void forNonJsonValueShouldReturnDisclaimer() {
         Record record = sampleRecord(
             "users",
             "some-key",
             "not a valid json"
         );
 
-        Record maskedRecord = masker.maskRecord(record);
+        Record maskedRecord = getMasker().maskRecord(record);
 
         assertEquals(
             "This record is unable to be masked as it is not a structured object. " +
                 "This record is unavailable to view due to safety measures from json_mask_by_default to not leak " +
-                "sensitive data. Please contact akhq administrator.",
+                "sensitive data.",
             maskedRecord.getValue()
         );
     }
 
     @Test
-    void forNonJsonValueThatLooksLikeJsonValueShouldReturnDisclaimer() {
+    public void forNonJsonValueThatLooksLikeJsonValueShouldReturnDisclaimer() {
         Record record = sampleRecord(
             "users",
             "some-key",
             "{not a valid json}"
         );
 
-        Record maskedRecord = masker.maskRecord(record);
+        Record maskedRecord = getMasker().maskRecord(record);
 
         assertEquals(
             "This record is unable to be masked as it is not a structured object. " +
                 "This record is unavailable to view due to safety measures from json_mask_by_default to not leak " +
-                "sensitive data. Please contact akhq administrator.",
+                "sensitive data.",
             maskedRecord.getValue()
         );
     }
 
     @Test
-    void ifJsonParsingThrowsExceptionShouldReturnFalse() {
-        String sampleStringToParse = sampleValue();
+    public void ifJsonParsingThrowsExceptionShouldReturnFalse() {
         Record record = sampleRecord(
             "different-topic",
             "some-key",
-            sampleStringToParse
+            SAMPLE_VALUE
         );
 
         try (MockedStatic<JsonParser> mockStatic = Mockito.mockStatic(JsonParser.class)) {
-            mockStatic.when(() -> JsonParser.parseString(sampleStringToParse)).thenThrow(new RuntimeException("Bad exception!"));
-            Record record1 = masker.maskRecord(record);
+            mockStatic.when(() -> JsonParser.parseString(SAMPLE_VALUE)).thenThrow(new RuntimeException("Bad exception!"));
+            Record record1 = getMasker().maskRecord(record);
             assertEquals("An exception occurred during an attempt to mask this record. This record is unavailable to view due to safety measures from json_mask_by_default to not leak sensitive data. Please contact akhq administrator.", record1.getValue());
         }
     }
 
     @Test
-    void ifRecordHasMultiLevelNestedValuesShouldBeProcessedCorrectly() {
+    public void forUndefinedTopicShouldDefaultMaskAllValues() {
         Record record = sampleRecord(
-            "users",
+            "different-topic",
             "some-key",
-            sampleValueWithMultilevelNestedValues()
+            SAMPLE_VALUE
         );
 
-        Record maskedRecord = masker.maskRecord(record);
+        Record maskedRecord = getMasker().maskRecord(record);
 
         assertEquals(
-            """
-                {"specialId":123,"status":"ACTIVE","name":"xxxx","dateOfBirth":"xxxx","address":{"firstLine":"xxxx","town":"xxxx","country":"United Kingdom"},"metadata":{"trusted":true,"rating":"10","notes":"xxxx","other":{"shouldBeUnmasked":"Example multi-level-nested-value","shouldBeMasked":"xxxx"}}}""",
+            "{\"specialId\":\"xxxx\",\"status\":\"xxxx\",\"name\":\"xxxx\",\"dateOfBirth\":\"xxxx\",\"address\":{\"firstLine\":\"xxxx\",\"town\":\"xxxx\",\"country\":\"xxxx\"},\"metadata\":{\"trusted\":\"xxxx\",\"rating\":\"xxxx\",\"notes\":\"xxxx\"}}",
             maskedRecord.getValue()
         );
-    }
-
-    private String sampleValue() {
-        return """
-            {
-               "specialId": 123,
-               "status": "ACTIVE",
-               "name": "John Smith",
-               "dateOfBirth": "01-01-1991",
-               "address": {
-                 "firstLine": "123 Example Avenue",
-                 "town": "Faketown",
-                 "country": "United Kingdom"
-               },
-               "metadata": {
-                 "trusted": true,
-                 "rating": "10",
-                 "notes": "All in good order"
-               }
-            }
-            """;
-    }
-
-    private String sampleValueWithMultilevelNestedValues() {
-        return """
-            {
-               "specialId": 123,
-               "status": "ACTIVE",
-               "name": "John Smith",
-               "dateOfBirth": "01-01-1991",
-               "address": {
-                 "firstLine": "123 Example Avenue",
-                 "town": "Faketown",
-                 "country": "United Kingdom"
-               },
-               "metadata": {
-                 "trusted": true,
-                 "rating": "10",
-                 "notes": "All in good order",
-                 "other": {
-                    "shouldBeUnmasked": "Example multi-level-nested-value",
-                    "shouldBeMasked": "Example multi-level-nested-value"
-                 }
-               }
-            }
-            """;
     }
 }

--- a/src/test/java/org/akhq/utils/JsonMaskerTest.java
+++ b/src/test/java/org/akhq/utils/JsonMaskerTest.java
@@ -1,0 +1,150 @@
+package org.akhq.utils;
+
+import org.akhq.models.Record;
+import org.junit.jupiter.api.Test;
+
+import static org.akhq.utils.MaskerTestHelper.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+interface JsonMaskerTest {
+
+    String SAMPLE_VALUE = """
+            {
+               "specialId": 123,
+               "status": "ACTIVE",
+               "name": "John Smith",
+               "dateOfBirth": "01-01-1991",
+               "address": {
+                 "firstLine": "123 Example Avenue",
+                 "town": "Faketown",
+                 "country": "United Kingdom"
+               },
+               "metadata": {
+                 "trusted": true,
+                 "rating": "10",
+                 "notes": "All in good order"
+               }
+            }
+            """;
+
+    String SAMPLE_VALUE_WITH_MULTI_LEVEL_NESTED_OBJECTS = """
+            {
+               "specialId": 123,
+               "status": "ACTIVE",
+               "name": "John Smith",
+               "dateOfBirth": "01-01-1991",
+               "address": {
+                 "firstLine": "123 Example Avenue",
+                 "town": "Faketown",
+                 "country": "United Kingdom"
+               },
+               "metadata": {
+                 "trusted": true,
+                 "rating": "10",
+                 "notes": "All in good order",
+                 "other": {
+                    "shouldBeUnmasked": "Example multi-level-nested-value",
+                    "shouldBeMasked": "Example multi-level-nested-value"
+                 }
+               }
+            }
+            """;
+
+    String SAMPLE_VALUE_WITH_ARRAYS = """
+            {
+               "specialId": 123,
+               "status": "ACTIVE",
+               "name": "John Smith",
+               "dateOfBirth": "01-01-1991",
+               "address": [
+                   {
+                     "firstLine": "123 Example Avenue",
+                     "town": "Faketown",
+                     "country": "United Kingdom"
+                   },
+                   {
+                     "firstLine": "Old Address",
+                     "town": "Previoustown",
+                     "country": "United Kingdom"
+                   }
+               ],
+               "metadata": {
+                 "trusted": true,
+                 "rating": "10",
+                 "notes": "All in good order",
+                 "other": {
+                    "shouldBeUnmasked": "Example multi-level-nested-value",
+                    "shouldBeMasked": "Example multi-level-nested-value",
+                    "arrayToMask": [ "one", "two", "three" ],
+                    "arrayToShow": [ "one", "two", "three" ]
+                 }
+               }
+            }
+            """;
+
+    Masker getMasker();
+
+    @Test
+    default void shouldMaskRecordValue() {
+        Record record = sampleRecord(
+            "users",
+            "some-key",
+            SAMPLE_VALUE
+        );
+
+        Record maskedRecord = getMasker().maskRecord(record);
+
+        assertEquals(
+            "{\"specialId\":123,\"status\":\"ACTIVE\",\"name\":\"xxxx\",\"dateOfBirth\":\"xxxx\",\"address\":{\"firstLine\":\"xxxx\",\"town\":\"xxxx\",\"country\":\"United Kingdom\"},\"metadata\":{\"trusted\":true,\"rating\":\"10\",\"notes\":\"All in good order\"}}",
+            maskedRecord.getValue()
+        );
+    }
+
+    @Test
+    default void forTombstoneShouldReturnItself() {
+        Record record = sampleRecord(
+            "users",
+            "some-key",
+            null
+        );
+
+        Record maskedRecord = getMasker().maskRecord(record);
+
+        assertEquals(
+            record,
+            maskedRecord
+        );
+    }
+
+    @Test
+    default void ifRecordHasMultiLevelNestedValuesShouldBeProcessedCorrectly() {
+        Record record = sampleRecord(
+            "users",
+            "some-key",
+            SAMPLE_VALUE_WITH_MULTI_LEVEL_NESTED_OBJECTS
+        );
+
+        Record maskedRecord = getMasker().maskRecord(record);
+
+        assertEquals(
+            """
+                {"specialId":123,"status":"ACTIVE","name":"xxxx","dateOfBirth":"xxxx","address":{"firstLine":"xxxx","town":"xxxx","country":"United Kingdom"},"metadata":{"trusted":true,"rating":"10","notes":"All in good order","other":{"shouldBeUnmasked":"Example multi-level-nested-value","shouldBeMasked":"xxxx"}}}""",
+            maskedRecord.getValue()
+        );
+    }
+
+    @Test
+    default void ifRecordUsesArrays_handlingOfFieldsWorksAsExpected() {
+        Record record = sampleRecord(
+            "users",
+            "some-key",
+            SAMPLE_VALUE_WITH_ARRAYS
+        );
+        Record maskedRecord = getMasker().maskRecord(record);
+        assertEquals(
+            """
+            {"specialId":123,"status":"ACTIVE","name":"xxxx","dateOfBirth":"xxxx","address":[{"firstLine":"xxxx","town":"xxxx","country":"United Kingdom"},{"firstLine":"xxxx","town":"xxxx","country":"United Kingdom"}],"metadata":{"trusted":true,"rating":"10","notes":"All in good order","other":{"shouldBeUnmasked":"Example multi-level-nested-value","shouldBeMasked":"xxxx","arrayToMask":["xxxx","xxxx","xxxx"],"arrayToShow":["one","two","three"]}}}""",
+            maskedRecord.getValue()
+        );
+    }
+}

--- a/src/test/java/org/akhq/utils/JsonMaskerTest.java
+++ b/src/test/java/org/akhq/utils/JsonMaskerTest.java
@@ -76,7 +76,8 @@ interface JsonMaskerTest {
                     "shouldBeUnmasked": "Example multi-level-nested-value",
                     "shouldBeMasked": "Example multi-level-nested-value",
                     "arrayToMask": [ "one", "two", "three" ],
-                    "arrayToShow": [ "one", "two", "three" ]
+                    "arrayToShow": [ "one", "two", "three" ],
+                    "jsonArray": [ { "showThis": "Hello", "maskThis": "World" }, { "showThis": "How are", "maskThis": "You" } ]
                  }
                }
             }
@@ -143,7 +144,7 @@ interface JsonMaskerTest {
         Record maskedRecord = getMasker().maskRecord(record);
         assertEquals(
             """
-            {"specialId":123,"status":"ACTIVE","name":"xxxx","dateOfBirth":"xxxx","address":[{"firstLine":"xxxx","town":"xxxx","country":"United Kingdom"},{"firstLine":"xxxx","town":"xxxx","country":"United Kingdom"}],"metadata":{"trusted":true,"rating":"10","notes":"All in good order","other":{"shouldBeUnmasked":"Example multi-level-nested-value","shouldBeMasked":"xxxx","arrayToMask":["xxxx","xxxx","xxxx"],"arrayToShow":["one","two","three"]}}}""",
+            {"specialId":123,"status":"ACTIVE","name":"xxxx","dateOfBirth":"xxxx","address":[{"firstLine":"xxxx","town":"xxxx","country":"United Kingdom"},{"firstLine":"xxxx","town":"xxxx","country":"United Kingdom"}],"metadata":{"trusted":true,"rating":"10","notes":"All in good order","other":{"shouldBeUnmasked":"Example multi-level-nested-value","shouldBeMasked":"xxxx","arrayToMask":["xxxx","xxxx","xxxx"],"arrayToShow":["one","two","three"],"jsonArray":[{"showThis":"Hello","maskThis":"xxxx"},{"showThis":"How are","maskThis":"xxxx"}]}}}""",
             maskedRecord.getValue()
         );
     }

--- a/src/test/java/org/akhq/utils/JsonMaskerTest.java
+++ b/src/test/java/org/akhq/utils/JsonMaskerTest.java
@@ -3,7 +3,7 @@ package org.akhq.utils;
 import org.akhq.models.Record;
 import org.junit.jupiter.api.Test;
 
-import static org.akhq.utils.MaskerTestHelper.*;
+import static org.akhq.utils.MaskerTestHelper.sampleRecord;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 interface JsonMaskerTest {

--- a/src/test/java/org/akhq/utils/JsonShowByDefaultMaskerTest.java
+++ b/src/test/java/org/akhq/utils/JsonShowByDefaultMaskerTest.java
@@ -2,163 +2,34 @@ package org.akhq.utils;
 
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
+import lombok.Getter;
 import org.akhq.models.Record;
 import org.junit.jupiter.api.Test;
 
+import static org.akhq.utils.MaskerTestHelper.sampleRecord;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
+@Getter
 @MicronautTest(environments = "json-show-by-default-data-masking")
-class JsonShowByDefaultMaskerTest extends MaskerTestHelper {
+class JsonShowByDefaultMaskerTest implements JsonMaskerTest {
 
     @Inject
-    Masker masker;
+    JsonShowByDefaultMasker masker;
 
     @Test
-    void shouldUseJsonShowByDefaultMasker() {
-        assertInstanceOf(JsonShowByDefaultMasker.class, masker);
-    }
-
-    @Test
-    void shouldMaskRecordValue() {
-        Record record = sampleRecord(
-            "users",
-            "some-key",
-            sampleValue()
-        );
-
-        Record maskedRecord = masker.maskRecord(record);
-
-        assertEquals(
-            "{\"specialId\":123,\"status\":\"ACTIVE\",\"name\":\"xxxx\",\"dateOfBirth\":\"xxxx\",\"address\":{\"firstLine\":\"xxxx\",\"town\":\"xxxx\",\"country\":\"United Kingdom\"},\"metadata\":{\"trusted\":true,\"rating\":\"10\",\"notes\":\"All in good order\"}}",
-            maskedRecord.getValue()
-        );
-    }
-
-    @Test
-    void shouldDoNothingForUndefinedTopic() {
+    public void forUndefinedTopicShouldDefaultShowAllValues() {
         Record record = sampleRecord(
             "different-topic",
             "some-key",
-            sampleValue()
+            SAMPLE_VALUE
         );
 
-        Record maskedRecord = masker.maskRecord(record);
+        Record maskedRecord = getMasker().maskRecord(record);
 
         assertEquals(
-            sampleValue(),
+            SAMPLE_VALUE,
             maskedRecord.getValue()
         );
     }
 
-    @Test
-    void forTombstoneShouldReturnItself() {
-        Record record = sampleRecord(
-            "users",
-            "some-key",
-            null
-        );
-
-        Record maskedRecord = masker.maskRecord(record);
-
-        assertEquals(
-            record,
-            maskedRecord
-        );
-    }
-
-    @Test
-    void forNonJsonValueShouldReturnItself() {
-        Record record = sampleRecord(
-            "users",
-            "some-key",
-            "not a valid json"
-        );
-
-        Record maskedRecord = masker.maskRecord(record);
-
-        assertEquals(
-            record,
-            maskedRecord
-        );
-    }
-
-    @Test
-    void forNonJsonValueThatLooksLikeJsonValueShouldReturnItself() {
-        Record record = sampleRecord(
-            "users",
-            "some-key",
-            "{not a valid json}"
-        );
-
-        Record maskedRecord = masker.maskRecord(record);
-
-        assertEquals(
-            record,
-            maskedRecord
-        );
-    }
-
-    @Test
-    void ifRecordHasMultiLevelNestedValuesShouldBeProcessedCorrectly() {
-        Record record = sampleRecord(
-            "users",
-            "some-key",
-            sampleValueWithMultilevelNestedValues()
-        );
-
-        Record maskedRecord = masker.maskRecord(record);
-
-        assertEquals(
-            """
-                {"specialId":123,"status":"ACTIVE","name":"xxxx","dateOfBirth":"xxxx","address":{"firstLine":"xxxx","town":"xxxx","country":"United Kingdom"},"metadata":{"trusted":true,"rating":"10","notes":"All in good order","other":{"shouldBeUnmasked":"Example multi-level-nested-value","shouldBeMasked":"xxxx"}}}""",
-            maskedRecord.getValue()
-        );
-    }
-
-    private String sampleValue() {
-        return """
-            {
-               "specialId": 123,
-               "status": "ACTIVE",
-               "name": "John Smith",
-               "dateOfBirth": "01-01-1991",
-               "address": {
-                 "firstLine": "123 Example Avenue",
-                 "town": "Faketown",
-                 "country": "United Kingdom"
-               },
-               "metadata": {
-                 "trusted": true,
-                 "rating": "10",
-                 "notes": "All in good order"
-               }
-            }
-            """;
-    }
-
-    private String sampleValueWithMultilevelNestedValues() {
-        return """
-            {
-               "specialId": 123,
-               "status": "ACTIVE",
-               "name": "John Smith",
-               "dateOfBirth": "01-01-1991",
-               "address": {
-                 "firstLine": "123 Example Avenue",
-                 "town": "Faketown",
-                 "country": "United Kingdom"
-               },
-               "metadata": {
-                 "trusted": true,
-                 "rating": "10",
-                 "notes": "All in good order",
-                 "other": {
-                    "shouldBeUnmasked": "Example multi-level-nested-value",
-                    "shouldBeMasked": "Example multi-level-nested-value"
-                 }
-               }
-            }
-            """;
-    }
 }

--- a/src/test/java/org/akhq/utils/MaskerTestHelper.java
+++ b/src/test/java/org/akhq/utils/MaskerTestHelper.java
@@ -6,7 +6,7 @@ import org.apache.kafka.clients.admin.TopicDescription;
 
 import java.util.List;
 
-public class MaskerTestHelper {
+class MaskerTestHelper {
 
     static Record sampleRecord(String topicName,
                                   String key,

--- a/src/test/resources/application-json-mask-by-default-data-masking.yml
+++ b/src/test/resources/application-json-mask-by-default-data-masking.yml
@@ -11,4 +11,6 @@ akhq:
             - address.country
             - metadata.trusted
             - metadata.rating
+            - metadata.notes
             - metadata.other.shouldBeUnmasked
+            - metadata.other.arrayToShow

--- a/src/test/resources/application-json-mask-by-default-data-masking.yml
+++ b/src/test/resources/application-json-mask-by-default-data-masking.yml
@@ -14,3 +14,4 @@ akhq:
             - metadata.notes
             - metadata.other.shouldBeUnmasked
             - metadata.other.arrayToShow
+            - metadata.other.jsonArray.showThis

--- a/src/test/resources/application-json-show-by-default-data-masking.yml
+++ b/src/test/resources/application-json-show-by-default-data-masking.yml
@@ -11,3 +11,4 @@ akhq:
             - address.firstLine
             - address.town
             - metadata.other.shouldBeMasked
+            - metadata.other.arrayToMask

--- a/src/test/resources/application-json-show-by-default-data-masking.yml
+++ b/src/test/resources/application-json-show-by-default-data-masking.yml
@@ -12,3 +12,4 @@ akhq:
             - address.town
             - metadata.other.shouldBeMasked
             - metadata.other.arrayToMask
+            - metadata.other.jsonArray.maskThis


### PR DESCRIPTION
Several fixes here:
1) I realised after further usage and some extensive testing in more complex scenarios that JSON Arrays weren't handled correctly - they were always either masked at the whole field level (on Mask By Default mode), or left unmasked (on Show By Default mode). Now, the same settings that apply now also apply to nested objects inside arrays, or if the array contains primitives, the higher level array will apply. So for example, given:

```
address.firstLine
```

this will now apply to both:

```
{
  "address": {
      "firstLine": "value"
  }
}
```
and now also to all the `firstLine` values in an array type, too (this was not working correctly previously):
```
{
  "address": [
    {
      "firstLine": "value"
    },
    {
      "firstLine": "someOtherValue"
    }
  ]
}
```

Primitives will be handled as expected as well, where a filter like:

```
address.values
```

would now result that the following object:

```
{
    "address": {
      "values": [ "one", "two", "three" ]
    }
}
```

will correctly look like:

```
{
    "address": {
      "values": [ "xxxx", "xxxx", "xxxx" ]
    }
}
```

instead of the current:

```
{
    "address": {
      "values": "xxxx"
    }
}
```
which is currently losing the format, as well as non-sensitive information such as array length.

2) Some readability improvements & fixes, also updating tests to be uniform, so the exact same test code is not repeated. Now the `JsonMaskerTest` interface defines the core tests the input and output, with the `ShowByDefault` and `MaskByDefault` tests implementing the interface (with their own backing `application.yml` which makes them fit the test criteria) and have their own specific tests written in the class only

3) Small performance improvements, including defining the topic -> filtering keys in the constructor rather than constantly re-evaluating
 
4) Remove the phrase "Please contact akhq administrator" which is likely to cause confusion and bring people here, when the issue isn't AKHQ but that a record has not fulfilled the criteria for masking