### PR TITLE
chore: remove version from docker compose files

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,5 +1,3 @@
-version: '3.6'
-
 volumes:
   zookeeper-data:
     driver: local

--- a/docker-compose-multiple-clusters.yml
+++ b/docker-compose-multiple-clusters.yml
@@ -1,4 +1,3 @@
-version: '3.6'
 volumes:
   zookeeper-data-0:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.6'
-
 volumes:
   zookeeper-data:
     driver: local

--- a/docs/docs/configuration/docker.md
+++ b/docs/docs/configuration/docker.md
@@ -25,7 +25,6 @@ docker run -d \
 Override the `JVM_OPTS_FILE` with docker-compose:
 
 ```yaml
-version: '3.7'
 services:
   akhq:
     image: tchiotludo/akhq-jvm:dev

--- a/docs/docs/dev.md
+++ b/docs/docs/dev.md
@@ -22,7 +22,7 @@ Or build it with a `./gradlew shadowJar`, the jar will be located here `build/li
 ## Development Server
 
 A docker-compose is provided to start a development environment.
-Just install docker & docker-compose, clone the repository and issue a simple `docker-compose -f docker-compose-dev.yml up` to start a dev server.
+Just install docker & docker compose plugin, clone the repository and issue a simple `docker compose -f docker-compose-dev.yml up` to start a dev server.
 Dev server is a java server & webpack-dev-server with live reload.
 
 The configuration for the dev server is in `application.dev.yml`.


### PR DESCRIPTION
To avoid the warning:

```
WARN[0000] /home/user/projects/akhq/docker-compose-dev.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

Also standardising on the newer Docker compose (go) plugin (`docker compose`) instead of the old python program `docker-compose`. You have are already started using `docker compose` in some places of the readme:

https://github.com/tchiotludo/akhq/blob/1d801b9cf3d102bff398fca6c2a93c359a865923/docs/docs/README.md#L4-L5

