### PR TITLE
fix(frontend/copy-topic): remove faulty props to input form

### DIFF
--- a/client/src/containers/Topic/TopicCopy/TopicCopy.jsx
+++ b/client/src/containers/Topic/TopicCopy/TopicCopy.jsx
@@ -204,7 +204,6 @@ class TopicCopy extends Form {
                 false,
                 '',
                 '',
-                `partition-input ${name}-input`
               )}
             </span>
           </div>


### PR DESCRIPTION
The line removed does not have any effect on the code, it just creates a lot of warnings in the console when browsing the copy topic page:

![image](https://github.com/user-attachments/assets/9b7ba923-1471-4c21-a006-533c4435a8ec)


It seems like this has never worked, this eight param becomes the `rest` argument in the `renderInput` function:

https://github.com/tchiotludo/akhq/blob/d52bc0055b70892a36936652d3140703a91720ed/client/src/components/Form/Form.jsx#L85-L110

Which will be just spread in the `Input` component:

https://github.com/tchiotludo/akhq/blob/d52bc0055b70892a36936652d3140703a91720ed/client/src/components/Form/Input/Input.jsx#L27-L28

When logging the `rest` object it is this:

```js
{0: 'p', 1: 'a', 2: 'r', 3: 't', 4: 'i', 5: 't', 6: 'i', 7: 'o', 8: 'n', 9: '-', 10: 'i', 11: 'n', 12: 'p', 13: 'u', 14: 't', 15: ' ', 16: 'p', 17: 'a', 18: 'r', 19: 't', 20: 'i', 21: 't', 22: 'i', 23: 'o', 24: 'n', 25: '-', 26: '0', 27: '-', 28: 'i', 29: 'n', 30: 'p', 31: 'u', 32: 't', type: 'number', id: 'partition-0', value: '0', onChange: ƒ}
```

... which is the removed line, just exploded.