### PR TITLE
chore: fix react warnings in datepicker

### DIFF
--- a/client/src/components/DatePicker/DatePicker.jsx
+++ b/client/src/components/DatePicker/DatePicker.jsx
@@ -59,6 +59,7 @@ class DatePicker extends Component {
             <input
               value={this.getDisplayValue(value)}
               className="form-control"
+              readOnly={true}
               placeholder={this.getDisplayValue(value)}
             />
             {onClear && (
@@ -101,7 +102,10 @@ class DatePicker extends Component {
 
 DatePicker.propTypes = {
   label: PropTypes.string,
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.instanceOf(Date)
+  ]),
   onChange: PropTypes.func,
   showDateTimeInput: PropTypes.bool,
   showTimeInput: PropTypes.bool,


### PR DESCRIPTION
Two tiny changes:

- The input-field above the datepicker is a read-only field populated by what the user selects in the datepicker below:
  
  ![image](https://github.com/user-attachments/assets/41596aa9-8318-4302-861c-30f06c3cff5b)
  
  Without the `readOnly` attribute we get this warning in the console: 
  
  ```
  Warning: You provided a `value` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultValue`. Otherwise, set either `onChange` or `readOnly`.
  ```
- The `DatePicker.value` field[ starts out as a string](https://github.com/tchiotludo/akhq/blob/d52bc0055b70892a36936652d3140703a91720ed/client/src/components/DatePicker/DatePicker.jsx#L9), but as soon as a user clicks a date in the datepicker it is set to a JS `Date` , and then we get warnings in the log:
  ```
  Warning: Failed prop type: Invalid prop `value` of type `date` supplied to `DatePicker`, expected `string`.
  ```