### PR TITLE
fix(ui): update date field in produce to topic

### DIFF
--- a/client/src/components/DatePicker/DatePicker.jsx
+++ b/client/src/components/DatePicker/DatePicker.jsx
@@ -102,10 +102,7 @@ class DatePicker extends Component {
 
 DatePicker.propTypes = {
   label: PropTypes.string,
-  value: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.instanceOf(Date)
-  ]),
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
   onChange: PropTypes.func,
   showDateTimeInput: PropTypes.bool,
   showTimeInput: PropTypes.bool,

--- a/client/src/containers/Topic/TopicCopy/TopicCopy.jsx
+++ b/client/src/containers/Topic/TopicCopy/TopicCopy.jsx
@@ -203,7 +203,7 @@ class TopicCopy extends Form {
                 'number',
                 false,
                 '',
-                '',
+                ''
               )}
             </span>
           </div>

--- a/client/src/containers/Topic/TopicProduce/TopicProduce.jsx
+++ b/client/src/containers/Topic/TopicProduce/TopicProduce.jsx
@@ -550,7 +550,7 @@ class TopicProduce extends Form {
               >
                 <input
                   className="form-control"
-                  defaultValue={
+                  value={
                     datetime !== '' &&
                     ' ' +
                       formatDateTime(


### PR DESCRIPTION
The input field for selecting the timestamp of a record to produce is not updated when clicking the date time picker (but this is a pure UI glitch, because it is the state field `datetime` that is sent to backend regardless of what it says in the input field):

![image](https://github.com/user-attachments/assets/a2793cd4-656a-4f88-8bd7-2d26c252ffc6)
