### PR TITLE
docs: fix typos in api summaries

### DIFF
--- a/src/main/java/org/akhq/controllers/AkhqController.java
+++ b/src/main/java/org/akhq/controllers/AkhqController.java
@@ -55,7 +55,7 @@ public class AkhqController extends AbstractController {
 
     @HasAnyPermission()
     @Get("api/cluster")
-    @Operation(tags = {"AKHQ"}, summary = "Get all cluster for current instance")
+    @Operation(tags = {"AKHQ"}, summary = "Get all clusters for current instance")
     public List<ClusterDefinition> list() {
         // Get all the clusters the logged user can access resources
         List<String> clusters = this.getUserGroups().stream()

--- a/src/main/java/org/akhq/controllers/GroupController.java
+++ b/src/main/java/org/akhq/controllers/GroupController.java
@@ -79,7 +79,7 @@ public class GroupController extends AbstractController {
     }
 
     @Get("{groupName}/offsets")
-    @Operation(tags = {"consumer group"}, summary = "Retrieve a consumer group offsets")
+    @Operation(tags = {"consumer group"}, summary = "Retrieve consumer group offsets")
     public List<TopicPartition.ConsumerGroupOffset> offsets(String cluster, String groupName) throws ExecutionException, InterruptedException {
         checkIfClusterAndResourceAllowed(cluster, groupName);
 
@@ -87,7 +87,7 @@ public class GroupController extends AbstractController {
     }
 
     @Get("{groupName}/members")
-    @Operation(tags = {"consumer group"}, summary = "Retrieve a consumer group members")
+    @Operation(tags = {"consumer group"}, summary = "Retrieve consumer group members")
     public List<Consumer> members(String cluster, String groupName) throws ExecutionException, InterruptedException {
         checkIfClusterAndResourceAllowed(cluster, groupName);
 
@@ -95,7 +95,7 @@ public class GroupController extends AbstractController {
     }
 
     @Get("{groupName}/acls")
-    @Operation(tags = {"consumer group"}, summary = "Retrieve a consumer group acls")
+    @Operation(tags = {"consumer group"}, summary = "Retrieve consumer group acls")
     public List<AccessControl> acls(String cluster, String groupName) throws ExecutionException, InterruptedException {
         checkIfClusterAndResourceAllowed(cluster, groupName);
 
@@ -178,7 +178,7 @@ public class GroupController extends AbstractController {
 
     @AKHQSecured(resource = Role.Resource.CONSUMER_GROUP, action = Role.Action.DELETE_OFFSET)
     @Delete("{groupName}/topic/{topicName}")
-    @Operation(tags = {"consumer group"}, summary = "Delete group offsets of given topic")
+    @Operation(tags = {"consumer group"}, summary = "Delete consumer group offsets for the given topic")
     public HttpResponse<?> deleteConsumerGroupOffsets(String cluster, String groupName, String topicName) throws ExecutionException {
         checkIfClusterAndResourceAllowed(cluster, groupName);
 

--- a/src/main/java/org/akhq/controllers/NodeController.java
+++ b/src/main/java/org/akhq/controllers/NodeController.java
@@ -48,7 +48,7 @@ public class NodeController extends AbstractController {
     }
 
     @Get("api/{cluster}/node/partitions")
-    @Operation(tags = {"topic"}, summary = "partition counts")
+    @Operation(tags = {"topic"}, summary = "Partition counts")
     public List<NodePartition> nodePartitions(String cluster) throws ExecutionException, InterruptedException {
         checkIfClusterAllowed(cluster);
 
@@ -93,7 +93,7 @@ public class NodeController extends AbstractController {
     }
 
     @Get("api/{cluster}/node/{nodeId}")
-    @Operation(tags = {"node"}, summary = "Retrieve a nodes")
+    @Operation(tags = {"node"}, summary = "Retrieve a node")
     public Node node(String cluster, Integer nodeId) throws ExecutionException, InterruptedException {
         checkIfClusterAndResourceAllowed(cluster, nodeId.toString());
 

--- a/src/main/java/org/akhq/controllers/SchemaController.java
+++ b/src/main/java/org/akhq/controllers/SchemaController.java
@@ -58,7 +58,7 @@ public class SchemaController extends AbstractController {
 
 
     @Get("api/{cluster}/schema")
-    @Operation(tags = {"schema registry"}, summary = "List all schemas")
+    @Operation(tags = {"schema registry"}, summary = "List all schemas paginated")
     public ResultPagedList<Schema> list(
         HttpRequest<?> request,
         String cluster,
@@ -79,7 +79,7 @@ public class SchemaController extends AbstractController {
     }
 
     @Get("api/{cluster}/schema/topic/{topic}")
-    @Operation(tags = {"schema registry"}, summary = "List all schemas prefered schemas for this topic")
+    @Operation(tags = {"schema registry"}, summary = "List all preferred schemas for a topic")
     public TopicSchema listSchemaForTopic(
         HttpRequest<?> request,
         String cluster,


### PR DESCRIPTION
Found a few typos in the summaries while browsing the code. BTW, are these published somewhere?