### PR TITLE
fix(ui): Style issue with the time input in the DatePicker (#2075)

### DIFF
--- a/client/src/containers/Topic/TopicProduce/TopicProduce.jsx
+++ b/client/src/containers/Topic/TopicProduce/TopicProduce.jsx
@@ -584,7 +584,7 @@ class TopicProduce extends Form {
                 <div className="input-group">
                   <DatePicker
                     showDateTimeInput
-                    showTimeInput
+                    showTimeSelect
                     value={datetime}
                     onChange={value => {
                       this.setState({


### PR DESCRIPTION
It should be working now.

![image](https://github.com/user-attachments/assets/b301ef5c-2f27-4002-8580-2bf8904a9806)

I tested on edge and firefox.

I produced 3 messages with date in the future.
The time is displayed and picked up  correctly.

![image](https://github.com/user-attachments/assets/7a0ea0fe-8dd3-44c4-b519-37460dad9cc4)

Let me know if I forgot something.

