### PR TITLE
feat: backend send topic permissions and enforce in topic list

### DIFF
--- a/client/src/components/Table/Table.jsx
+++ b/client/src/components/Table/Table.jsx
@@ -151,8 +151,9 @@ class Table extends Component {
 
   renderRow(row, index) {
     const {
-      actions,
+      actions: unconfirmedActions,
       columns,
+      confirmAction,
       extraRow,
       onExpand,
       noRowBackgroundChange,
@@ -161,6 +162,10 @@ class Table extends Component {
       reduce
     } = this.props;
     const { extraExpanded } = this.state;
+    let actions = unconfirmedActions ?? [];
+    if (confirmAction && unconfirmedActions) {
+      actions = unconfirmedActions.filter(action => confirmAction(row, action));
+    }
 
     let extraRowColCollapsed;
     let extraRowColExpanded;
@@ -189,7 +194,6 @@ class Table extends Component {
                 className={column.readOnly ? 'not-allowed' : ''}
                 onDoubleClick={() => {
                   if (
-                    actions &&
                     actions.find(action => action === constants.TABLE_DETAILS) &&
                     !column.expand
                   ) {
@@ -211,7 +215,6 @@ class Table extends Component {
               className={column.readOnly ? 'not-allowed' : ''}
               onDoubleClick={() => {
                 if (
-                  actions &&
                   actions.find(action => action === constants.TABLE_DETAILS) &&
                   !column.expand
                 ) {
@@ -225,7 +228,7 @@ class Table extends Component {
             </td>
           );
         })}
-        {actions && actions.length > 0 && this.renderActions(row)}
+        {unconfirmedActions && unconfirmedActions.length > 0 && this.renderActions(row)}
       </tr>
     ];
     if (
@@ -338,8 +341,12 @@ class Table extends Component {
   }
 
   renderActions(row) {
-    const { actions, onAdd, onDelete, onEdit, onRestart, onShare, onDownload, onCopy, idCol } =
+    const { actions: unconfirmedActions, confirmAction, onAdd, onDelete, onEdit, onRestart, onShare, onDownload, onCopy, idCol } =
       this.props;
+    let actions = unconfirmedActions ?? [];
+    if (confirmAction && unconfirmedActions) {
+      actions = unconfirmedActions.filter(action => confirmAction(row, action));
+    }
 
     let idColVal = idCol ? row[this.props.idCol] : row.id;
 
@@ -357,6 +364,8 @@ class Table extends Component {
               <FontAwesomeIcon icon={faSearch} />
             </span>
           </td>
+        ) || unconfirmedActions.find(el => el === constants.TABLE_ADD) && (
+          <td className="khq-row-action khq-row-action-main" />
         )}
         {actions.find(el => el === constants.TABLE_DETAILS) && (
           <td className="khq-row-action khq-row-action-main action-hover">
@@ -364,6 +373,8 @@ class Table extends Component {
               <FontAwesomeIcon icon={faSearch} />
             </Link>
           </td>
+        ) || unconfirmedActions.find(el => el === constants.TABLE_DETAILS) && (
+          <td className="khq-row-action khq-row-action-main" />
         )}
         {actions.find(el => el === constants.TABLE_CONFIG) && (
           <td className="khq-row-action khq-row-action-main action-hover">
@@ -371,6 +382,8 @@ class Table extends Component {
               <FontAwesomeIcon icon={faGear} />
             </Link>
           </td>
+        ) || unconfirmedActions.find(el => el === constants.CONFIG) && (
+          <td className="khq-row-action khq-row-action-main" />
         )}
         {actions.find(el => el === constants.TABLE_DELETE) && (
           <td className="khq-row-action khq-row-action-main action-hover">
@@ -384,6 +397,8 @@ class Table extends Component {
               <FontAwesomeIcon icon={faTrash} />
             </span>
           </td>
+        ) || unconfirmedActions.find(el => el === constants.TABLE_DELETE) && (
+          <td className="khq-row-action khq-row-action-main" />
         )}
         {actions.find(el => el === constants.TABLE_EDIT) && (
           <td className="khq-row-action khq-row-action-main action-hover">
@@ -397,6 +412,8 @@ class Table extends Component {
               <FontAwesomeIcon icon={faSearch} />
             </span>
           </td>
+        ) || unconfirmedActions.find(el => el === constants.TABLE_EDIT) && (
+          <td className="khq-row-action khq-row-action-main" />
         )}
         {actions.find(el => el === constants.TABLE_RESTART) && (
           <td className="khq-row-action khq-row-action-main action-hover">
@@ -410,6 +427,8 @@ class Table extends Component {
               <FontAwesomeIcon icon={faRefresh} />
             </span>
           </td>
+        ) || unconfirmedActions.find(el => el === constants.TABLE_RESTART) && (
+          <td className="khq-row-action khq-row-action-main" />
         )}
         {actions.find(el => el === constants.TABLE_COPY) && (
           <td className="khq-row-action khq-row-action-main action-hover">
@@ -423,6 +442,8 @@ class Table extends Component {
               <FontAwesomeIcon icon={faClone} />
             </span>
           </td>
+        ) || unconfirmedActions.find(el => el === constants.TABLE_COPY) && (
+          <td className="khq-row-action khq-row-action-main" />
         )}
         {actions.find(el => el === constants.TABLE_SHARE) && (
           <td className="khq-row-action khq-row-action-main action-hover">
@@ -436,6 +457,8 @@ class Table extends Component {
               <FontAwesomeIcon icon={faShare} />
             </span>
           </td>
+        ) || unconfirmedActions.find(el => el === constants.TABLE_SHARE) && (
+          <td className="khq-row-action khq-row-action-main" />
         )}
         {actions.find(el => el === constants.TABLE_DOWNLOAD) && (
           <td className="khq-row-action khq-row-action-main action-hover">
@@ -449,6 +472,8 @@ class Table extends Component {
               <FontAwesomeIcon icon={faDownload} />
             </span>
           </td>
+        ) || unconfirmedActions.find(el => el === constants.TABLE_DOWNLOAD) && (
+          <td className="khq-row-action khq-row-action-main" />
         )}
       </>
     );

--- a/client/src/components/Table/Table.jsx
+++ b/client/src/components/Table/Table.jsx
@@ -382,7 +382,7 @@ class Table extends Component {
               <FontAwesomeIcon icon={faGear} />
             </Link>
           </td>
-        ) || unconfirmedActions.find(el => el === constants.CONFIG) && (
+        ) || unconfirmedActions.find(el => el === constants.TABLE_CONFIG) && (
           <td className="khq-row-action khq-row-action-main" />
         )}
         {actions.find(el => el === constants.TABLE_DELETE) && (

--- a/client/src/containers/Topic/TopicList/TopicList.jsx
+++ b/client/src/containers/Topic/TopicList/TopicList.jsx
@@ -278,23 +278,28 @@ class TopicList extends Root {
         replicationFactor: topic.replicaCount,
         replicationInSync: topic.inSyncReplicaCount,
         groupComponent: undefined,
-        internal: topic.internal
+        internal: topic.internal,
+        permissions: topic.permissions
       };
       collapseConsumerGroups[topic.name] = uiOptionsTopic.showAllConsumerGroups ? true : false;
     });
     this.setState({ collapseConsumerGroups });
     setState();
 
-    const topicsName = topics.map(topic => topic.name).join(',');
 
     if (!uiOptionsTopic.skipConsumerGroups) {
+      const topicsNameConsumerGroupRead = topics
+        .filter(topic => topic.permissions.consumerGroupRead)
+        .map(topic => topic.name)
+        .join(',');
+
       const groupsListView =
         uiOptions && uiOptions.topic && uiOptions.topic.groupsDefaultView
           ? uiOptions.topic.groupsDefaultView
           : SETTINGS_VALUES.TOPIC.CONSUMER_GROUP_DEFAULT_VIEW.ALL;
 
       this.getApi(
-        uriConsumerGroupByTopics(selectedCluster, encodeURIComponent(topicsName), groupsListView)
+        uriConsumerGroupByTopics(selectedCluster, encodeURIComponent(topicsNameConsumerGroupRead), groupsListView)
       ).then(value => {
         topics.forEach(topic => {
           tableTopics[topic.name].groupComponent =
@@ -312,7 +317,11 @@ class TopicList extends Root {
     }
 
     if (!uiOptionsTopic.skipLastRecord && roles.TOPIC_DATA && roles.TOPIC_DATA.includes('READ')) {
-      this.getApi(uriTopicLastRecord(selectedCluster, encodeURIComponent(topicsName))).then(
+      const topicsNameDataRead = topics
+        .filter(topic => topic.permissions.topicDataRead)
+        .map(topic => topic.name)
+        .join(',');
+      this.getApi(uriTopicLastRecord(selectedCluster, encodeURIComponent(topicsNameDataRead))).then(
         value => {
           topics.forEach(topic => {
             tableTopics[topic.name].lastWrite = value.data[topic.name]
@@ -516,7 +525,7 @@ class TopicList extends Root {
 
     let detailsHref = undefined;
     const actions = [constants.TABLE_CONFIG];
-    if (roles.TOPIC_DATA && roles.TOPIC_DATA.includes('READ')) {
+    if (roles.TOPIC_DATA && roles.TOPIC.includes('READ_CONFIG') && roles.TOPIC_DATA.includes('READ')) {
       actions.push(constants.TABLE_DETAILS);
       detailsHref = id => `/ui/${selectedCluster}/topic/${id}/data`;
     }
@@ -573,6 +582,7 @@ class TopicList extends Root {
             replicationCols,
             uiOptionsTopic.skipConsumerGroups ? [] : consumerGprCols
           )}
+          confirmAction={confirmAction}
           data={topics}
           updateData={data => {
             this.setState({ topics: data });
@@ -607,6 +617,25 @@ class TopicList extends Root {
         />
       </div>
     );
+  }
+}
+
+/**
+ * Check if the user has the permission to perform the action
+ * @param {Object} topic
+ * @param {String} action
+ * @returns {Boolean}
+ */
+const confirmAction = (topic, action) => {
+  switch (action) {
+    case constants.TABLE_DETAILS:
+      return topic.permissions.topicDataRead && topic.permissions.readConfig;
+    case constants.TABLE_CONFIG:
+      return topic.permissions.readConfig;
+    case constants.TABLE_DELETE:
+      return topic.permissions.delete;
+    default:
+      return true;
   }
 }
 

--- a/client/src/containers/Topic/TopicProduce/TopicProduce.jsx
+++ b/client/src/containers/Topic/TopicProduce/TopicProduce.jsx
@@ -6,7 +6,6 @@ import Dropdown from 'react-bootstrap/Dropdown';
 import { formatDateTime } from '../../../utils/converters';
 import { popProduceToTopicValues } from '../../../utils/localstorage';
 import {
-  uriTopics,
   uriTopicsPartitions,
   uriTopicsProduce,
   uriAllSchema,

--- a/src/main/java/org/akhq/controllers/AbstractController.java
+++ b/src/main/java/org/akhq/controllers/AbstractController.java
@@ -9,6 +9,8 @@ import io.micronaut.security.authentication.AuthorizationException;
 import io.micronaut.security.utils.SecurityService;
 import jakarta.inject.Inject;
 import org.akhq.configs.security.Group;
+import org.akhq.configs.security.Role.Action;
+import org.akhq.configs.security.Role.Resource;
 import org.akhq.configs.security.SecurityProperties;
 import org.akhq.models.security.ClaimProvider;
 import org.akhq.security.annotation.AKHQSecured;
@@ -89,6 +91,9 @@ abstract public class AbstractController {
             return List.of();
         }
 
+        var securedResource = annotation.resource();
+        var securedAction = annotation.action();
+
         return getUserGroups().stream()
             // Keep only group matching the cluster
             .filter(group -> group.getClusters()
@@ -99,8 +104,8 @@ abstract public class AbstractController {
             .map(gb -> securityProperties.getRoles().get(gb.getRole())
                 .stream()
                 // Find roles with a resource and action matching the calling method AKHQSecured annotation
-                .filter(role -> role.getResources().contains(annotation.resource())
-                    && role.getActions().contains(annotation.action()))
+                .filter(role -> role.getResources().contains(securedResource)
+                    && role.getActions().contains(securedAction))
                 // Keep only the restriction attribute containing the patterns
                 .map(role -> gb.getPatterns())
                 .collect(Collectors.toList()))
@@ -135,40 +140,17 @@ abstract public class AbstractController {
     }
 
     protected void checkIfClusterAndResourceAllowed(String cluster, List<String> resources) {
-        for(String resource : resources) {
+        for (String resource : resources) {
             checkIfClusterAndResourceAllowed(cluster, resource);
         }
     }
 
     protected void checkIfClusterAndResourceAllowed(String cluster, String resource) {
-        // Authentication disabled, we allow everything
-        if (!applicationContext.containsBean(SecurityService.class))
-            return;
-
         boolean isAllowed;
 
         try {
             AKHQSecured annotation = getCallingAKHQSecuredAnnotation();
-
-            isAllowed = getUserGroups().stream()
-                // Get only group with role matching the method annotation resource and action
-                .filter(groupBinding -> securityProperties.getRoles().entrySet().stream()
-                    .filter(role -> groupBinding.getRole().equals(role.getKey()))
-                    .flatMap(role -> role.getValue().stream())
-                    .anyMatch(roleBinding -> roleBinding.getResources().contains(annotation.resource())
-                        && roleBinding.getActions().contains(annotation.action())))
-                // Check that resource and cluster patterns match
-                .anyMatch(group -> {
-                    boolean allowed = group.getClusters().stream()
-                        .anyMatch(pattern -> Pattern.matches(pattern, cluster));
-
-                    if (StringUtils.isNotEmpty(resource)) {
-                        allowed = allowed && group.getPatterns().stream()
-                            .anyMatch(pattern -> Pattern.matches(pattern, resource));
-                    }
-
-                    return allowed;
-                });
+            isAllowed = checkIfClusterAndResourceAllowed(cluster, resource, annotation.action(), annotation.resource());
         } catch (NoSuchMethodException e) {
             isAllowed = false;
         }
@@ -177,5 +159,32 @@ abstract public class AbstractController {
             throw new AuthorizationException(applicationContext.getBean(SecurityService.class).getAuthentication()
                 .orElse(null));
         }
+    }
+
+    protected boolean checkIfClusterAndResourceAllowed(String cluster, String resource, Action action, Resource resourceType) {
+        // Authentication disabled, we allow everything
+        if (!applicationContext.containsBean(SecurityService.class))
+            return true;
+
+
+        return getUserGroups().stream()
+            // Get only group with role matching the method annotation resource and action
+            .filter(groupBinding -> securityProperties.getRoles().entrySet().stream()
+                .filter(role -> groupBinding.getRole().equals(role.getKey()))
+                .flatMap(role -> role.getValue().stream())
+                .anyMatch(roleBinding -> roleBinding.getResources().contains(resourceType)
+                    && roleBinding.getActions().contains(action)))
+            // Check that resource and cluster patterns match
+            .anyMatch(group -> {
+                boolean allowed = group.getClusters().stream()
+                    .anyMatch(pattern -> Pattern.matches(pattern, cluster));
+
+                if (StringUtils.isNotEmpty(resource)) {
+                    allowed = allowed && group.getPatterns().stream()
+                        .anyMatch(pattern -> Pattern.matches(pattern, resource));
+                }
+
+                return allowed;
+            });
     }
 }

--- a/src/main/java/org/akhq/controllers/TopicController.java
+++ b/src/main/java/org/akhq/controllers/TopicController.java
@@ -111,18 +111,18 @@ public class TopicController extends AbstractController {
             buildUserBasedResourceFilters(cluster)
         );
         topicList.forEach(topic -> {
-            var permissions = new TopicPermissions(
-                checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.CREATE, Role.Resource.TOPIC),
-                checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.READ, Role.Resource.TOPIC),
-                checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.UPDATE, Role.Resource.TOPIC),
-                checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.DELETE, Role.Resource.TOPIC),
-                checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.READ_CONFIG, Role.Resource.TOPIC),
-                checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.ALTER_CONFIG, Role.Resource.TOPIC),
-                checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.READ, Role.Resource.TOPIC_DATA),
-                checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.CREATE, Role.Resource.TOPIC_DATA),
-                checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.DELETE, Role.Resource.TOPIC_DATA),
-                checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.READ, Role.Resource.CONSUMER_GROUP)
-            );
+            var permissions = TopicPermissions.builder()
+                .create(checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.CREATE, Role.Resource.TOPIC))
+                .read(checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.READ, Role.Resource.TOPIC))
+                .update(checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.UPDATE, Role.Resource.TOPIC))
+                .delete(checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.DELETE, Role.Resource.TOPIC))
+                .readConfig(checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.READ_CONFIG, Role.Resource.TOPIC))
+                .alterConfig(checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.ALTER_CONFIG, Role.Resource.TOPIC))
+                .topicDataRead(checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.READ, Role.Resource.TOPIC_DATA))
+                .topicDataCreate(checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.CREATE, Role.Resource.TOPIC_DATA))
+                .topicDataDelete(checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.DELETE, Role.Resource.TOPIC_DATA))
+                .consumerGroupRead(checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.READ, Role.Resource.CONSUMER_GROUP))
+                .build();
             topic.setPermissions(permissions);
         });
 

--- a/src/main/java/org/akhq/controllers/TopicController.java
+++ b/src/main/java/org/akhq/controllers/TopicController.java
@@ -103,13 +103,30 @@ public class TopicController extends AbstractController {
         URIBuilder uri = URIBuilder.fromURI(request.getUri());
         Pagination pagination = new Pagination(uiPageSize.orElse(pageSize), uri, page.orElse(1));
 
-        return ResultPagedList.of(this.topicRepository.list(
+        var topicList = this.topicRepository.list(
             cluster,
             pagination,
             show.orElse(TopicRepository.TopicListView.HIDE_INTERNAL),
             search,
             buildUserBasedResourceFilters(cluster)
-        ));
+        );
+        topicList.forEach(topic -> {
+            var permissions = new TopicPermissions(
+                checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.CREATE, Role.Resource.TOPIC),
+                checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.READ, Role.Resource.TOPIC),
+                checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.UPDATE, Role.Resource.TOPIC),
+                checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.DELETE, Role.Resource.TOPIC),
+                checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.READ_CONFIG, Role.Resource.TOPIC),
+                checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.ALTER_CONFIG, Role.Resource.TOPIC),
+                checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.READ, Role.Resource.TOPIC_DATA),
+                checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.CREATE, Role.Resource.TOPIC_DATA),
+                checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.DELETE, Role.Resource.TOPIC_DATA),
+                checkIfClusterAndResourceAllowed(cluster, topic.getName(), Role.Action.READ, Role.Resource.CONSUMER_GROUP)
+            );
+            topic.setPermissions(permissions);
+        });
+
+        return ResultPagedList.of(topicList);
     }
 
     @AKHQSecured(resource = Role.Resource.TOPIC, action = Role.Action.READ)

--- a/src/main/java/org/akhq/models/Topic.java
+++ b/src/main/java/org/akhq/models/Topic.java
@@ -29,6 +29,7 @@ public class Topic {
     @JsonIgnore
     private boolean configStream;
     private final List<Partition> partitions = new ArrayList<>();
+    private TopicPermissions permissions;
 
     public Topic(
         TopicDescription description,
@@ -119,6 +120,14 @@ public class Topic {
         }
 
         throw new NoSuchElementException("Partition '" + partition + "' doesn't exist for topic " + this.name);
+    }
+
+    public void setPermissions(TopicPermissions permission) {
+        this.permissions = permission;
+    }
+
+    public TopicPermissions getPermissions() {
+        return permissions;
     }
 
     public Boolean canDeleteRecords(String clusterId, ConfigRepository configRepository) throws ExecutionException, InterruptedException {

--- a/src/main/java/org/akhq/models/TopicPermissions.java
+++ b/src/main/java/org/akhq/models/TopicPermissions.java
@@ -1,14 +1,21 @@
 package org.akhq.models;
 
-public record TopicPermissions(
-    boolean create,
-    boolean read,
-    boolean update,
-    boolean delete,
-    boolean readConfig,
-    boolean alterConfig,
-    boolean topicDataRead,
-    boolean topicDataCreate,
-    boolean topicDataDelete,
-    boolean consumerGroupRead
-) {}
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class TopicPermissions {
+    private boolean create;
+    private boolean read;
+    private boolean update;
+    private boolean delete;
+    private boolean readConfig;
+    private boolean alterConfig;
+    private boolean topicDataRead;
+    private boolean topicDataCreate;
+    private boolean topicDataDelete;
+    private boolean consumerGroupRead;
+}

--- a/src/main/java/org/akhq/models/TopicPermissions.java
+++ b/src/main/java/org/akhq/models/TopicPermissions.java
@@ -1,6 +1,6 @@
 package org.akhq.models;
 
-public record Permissions(
+public record TopicPermissions(
     boolean create,
     boolean read,
     boolean update,
@@ -9,19 +9,6 @@ public record Permissions(
     boolean alterConfig,
     boolean topicDataRead,
     boolean topicDataCreate,
-    boolean topicDataDelete
-) {
-    public Permissions() {
-        this(
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false
-        );
-    }
-}
+    boolean topicDataDelete,
+    boolean consumerGroupRead
+) {}

--- a/src/main/java/org/akhq/models/TopicPermissions.java
+++ b/src/main/java/org/akhq/models/TopicPermissions.java
@@ -1,0 +1,27 @@
+package org.akhq.models;
+
+public record Permissions(
+    boolean create,
+    boolean read,
+    boolean update,
+    boolean delete,
+    boolean readConfig,
+    boolean alterConfig,
+    boolean topicDataRead,
+    boolean topicDataCreate,
+    boolean topicDataDelete
+) {
+    public Permissions() {
+        this(
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false
+        );
+    }
+}


### PR DESCRIPTION
This is a partial solution to https://github.com/tchiotludo/akhq/issues/1912 and https://github.com/tchiotludo/akhq/issues/2027. It’s partial because it is only implemented for the topic list in the frontend. Implementation for the remaining routes can be done, but I wanted to keep this fairly short and hear your opinions on it.

In this MR, every topic fetched from the backend in the topic list API (`api/local/topic`) will contain the permissions that are applicable for that combination of topic, user, and cluster.

<details><summary>See example response (see <code>permissions</code> property of each topic)</summary>

```json
{
    "results": [
        {
            "name": "json",
            "internal": false,
            "partitions": [
                {
                    "leader": {
                        "id": 0,
                        "host": "kafka",
                        "port": 9092,
                        "leader": true,
                        "inSyncReplicas": true
                    },
                    "id": 0,
                    "topic": "json",
                    "nodes": [
                        {
                            "id": 0,
                            "host": "kafka",
                            "port": 9092,
                            "leader": true,
                            "inSyncReplicas": true
                        }
                    ],
                    "logDir": [
                        {
                            "brokerId": 0,
                            "path": "/var/lib/kafka/data",
                            "topic": "json",
                            "partition": 0,
                            "size": 0,
                            "offsetLag": 0,
                            "future": false
                        }
                    ],
                    "firstOffset": 0,
                    "lastOffset": 0,
                    "logDirSize": 0
                }
            ],
            "permissions": {
                "create": false,
                "read": true,
                "update": false,
                "delete": true,
                "readConfig": true,
                "alterConfig": false,
                "topicDataRead": true,
                "topicDataCreate": false,
                "topicDataDelete": true,
                "consumerGroupRead": false
            },
            "logDir": [
                {
                    "brokerId": 0,
                    "path": "/var/lib/kafka/data",
                    "topic": "json",
                    "partition": 0,
                    "size": 0,
                    "offsetLag": 0,
                    "future": false
                }
            ],
            "size": 1,
            "inSyncReplicaCount": 1,
            "streamTopic": false,
            "internalTopic": false,
            "replicaCount": 1,
            "logDirSize": 122
        },
        {
            "name": "test",
            "internal": false,
            "partitions": [
                {
                    "leader": {
                        "id": 0,
                        "host": "kafka",
                        "port": 9092,
                        "leader": true,
                        "inSyncReplicas": true
                    },
                    "id": 0,
                    "topic": "test",
                    "nodes": [
                        {
                            "id": 0,
                            "host": "kafka",
                            "port": 9092,
                            "leader": true,
                            "inSyncReplicas": true
                        }
                    ],
                    "logDir": [
                        {
                            "brokerId": 0,
                            "path": "/var/lib/kafka/data",
                            "topic": "test",
                            "partition": 0,
                            "size": 0,
                            "offsetLag": 0,
                            "future": false
                        }
                    ],
                    "firstOffset": 0,
                    "lastOffset": 0,
                    "logDirSize": 0
                }
            ],
            "permissions": {
                "create": false,
                "read": true,
                "update": false,
                "delete": false,
                "readConfig": true,
                "alterConfig": false,
                "topicDataRead": false,
                "topicDataCreate": false,
                "topicDataDelete": false,
                "consumerGroupRead": true
            },
            "logDir": [
                {
                    "brokerId": 0,
                    "path": "/var/lib/kafka/data",
                    "topic": "test",
                    "partition": 0,
                    "size": 0,
                    "offsetLag": 0,
                    "future": false
                }
            ],
            "size": 1,
            "inSyncReplicaCount": 1,
            "streamTopic": false,
            "internalTopic": false,
            "replicaCount": 1,
            "logDirSize": 122
        }
    ],
    "page": 1,
    "total": 2,
    "pageSize": 25
}
```

</details>

These permissions are used in the TopicList.jsx component to confirm actions for each row, since `roles` object in session storage is the union of all permissions for all topics.

With the permissions in the response listed above, the topic list looks like this with topic "json" and "test":

![image](https://github.com/user-attachments/assets/8d7f4789-1542-4317-b1c2-22daf1391c64)


Also fixed a minor bug by only adding `TABLE_DETAILS` when roles TOPIC include READ_CONFIG (I got error in data view when I only had TOPIC_DATA).