### PR TITLE
chore(java): update old java 11 references to java 17

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,7 +121,7 @@ services:
       KSQL_KSQL_LOGGING_PROCESSING_TOPIC_REPLICATION_FACTOR: '1'
 
   test-data:
-    image: gradle:8-jdk11
+    image: gradle:8-jdk17
     command: "gradle --no-daemon testInjectData -x installFrontend -x assembleFrontend"
     restart: unless-stopped
     working_dir: /app

--- a/docs/docs/dev.md
+++ b/docs/docs/dev.md
@@ -52,15 +52,14 @@ see [Kafka Getting started guide](https://kafka.apache.org/quickstart). In the n
 git clone https://github.com/tchiotludo/akhq.git
 ```
 
-Open the checked out directory in IntelliJ IDEA. The current version (0.25.0) of AKHQ is built with Java 17. If you
+Open the checked out directory in IntelliJ IDEA. The current version of AKHQ is built with Java 17. If you
 don't have OpenJDK 17 installed already, do the following in IntelliJ IDEA:
 * _File > Project Structure... > Platform Settings >
-SDKs > + > Download JDK... >_ select a vendor of your choice (but make sure it's version 11)
-* download + install. Make sure
-that JDK 11 is set under _Project Settings > Project SDK_
-* language level is Java 11.
-* Now tell Gradle to use Java 11
-as well: _File > Settings > Plugins > Build, Execution, Deployment > Build Tools > Gradle > Gradle JVM_: any JDK 11.
+SDKs > + > Download JDK... >_ select a vendor of your choice (but make sure it's version 17)
+* download + install. Make sure that JDK 17 is set under _Project Settings > Project SDK_
+* language level is Java 17.
+* Now tell Gradle to use Java 17
+as well: _File > Settings > Plugins > Build, Execution, Deployment > Build Tools > Gradle > Gradle JVM_: any JDK 17.
 
 To configure AKHQ for using the Kafka server you set up before, edit `application.yml` by adding the following under `akhq`:
 ```yaml


### PR DESCRIPTION
Hello,

I spoted some old java 11 references, I changed them to be consistant for the whole project.

