### PR TITLE
feat(schema): Add the detail of schemas visible to read-only user (#1821)

### DIFF
--- a/client/src/containers/Schema/SchemaDetail/Schema.jsx
+++ b/client/src/containers/Schema/SchemaDetail/Schema.jsx
@@ -41,10 +41,6 @@ class Schema extends Root {
     const { clusterId, schemaId, roles } = this.state;
     let tabSelected = getSelectedTab(this.props, this.tabs);
 
-    if (!roles.SCHEMA.includes('UPDATE') && tabSelected === 'update') {
-      tabSelected = 'versions';
-    }
-
     schemas = await this.getApi(endpoints.uriSchemaVersions(clusterId, schemaId));
     this.setState(
       {
@@ -97,16 +93,14 @@ class Schema extends Root {
         <Header title={`Schema: ${decodeURIComponent(schemaId)}`} />
         <div className="tabs-container">
           <ul className="nav nav-tabs" role="tablist">
-            {roles.SCHEMA.includes('UPDATE') && (
               <li className="nav-item">
                 <Link
                   to={`/ui/${clusterId}/schema/details/${schemaId}/update`}
                   className={this.tabClassName('update')}
                 >
-                  Update
+                  Details
                 </Link>
               </li>
-            )}
             <li className="nav-item">
               <Link
                 to={`/ui/${clusterId}/schema/details/${schemaId}/versions`}

--- a/client/src/containers/Schema/SchemaDetail/SchemaUpdate/SchemaUpdate.jsx
+++ b/client/src/containers/Schema/SchemaDetail/SchemaUpdate/SchemaUpdate.jsx
@@ -116,7 +116,7 @@ class SchemaUpdate extends Form {
         className="khq-form khq-form-config"
         onSubmit={e => this.handleSubmit(e)}
       >
-        <fieldset>
+        <fieldset disabled={!roles.SCHEMA.includes('UPDATE')}>
           {this.renderInput('subject', 'Subject', 'Subject', undefined, false, '', false, false, {
             disabled: true
           })}


### PR DESCRIPTION
- Deleted the condition that hiddes the tab
- Renamed the tab to "details" instead of "update", it feels weird to me
- Default tab diplayed when clicking on the schema is now always the detail
- Disabled all field when in read-only for better feedback to the user

I tested with admin group : 
![image](https://github.com/user-attachments/assets/f2217773-90e5-4ae5-bec7-ea3fc0b1788c)
with the reader group :
![image](https://github.com/user-attachments/assets/794b5ac4-b744-4f38-ac9e-c0dc4c97bf11)
This is not showing the "update" button

There is no security issue on the backend side, there is still an update check on the update schema route

