### PR TITLE
fix(topicdata): Avoid waiting the poll timeout when there is no data in the topic partition (#2093 #1939 #2002 #1987)

### DIFF
--- a/src/main/java/org/akhq/repositories/RecordRepository.java
+++ b/src/main/java/org/akhq/repositories/RecordRepository.java
@@ -143,7 +143,18 @@ public class RecordRepository extends AbstractRepository {
     private List<Record> consumeOldest(Topic topic, Options options) {
         List<Record> list = new ArrayList<>();
 
-        for (Map.Entry<TopicPartition, Long> partition : getTopicPartitionForSortOldest(topic, options).entrySet()) {
+        getTopicPartitionForSortOldest(topic, options).entrySet().parallelStream()
+            .forEach(partition -> {
+
+            // Skip partition without data
+            if (topic.getPartitions()
+                    .stream()
+                    .filter(partition_ -> partition_.getId() == partition.getKey().partition())
+                    .filter(partition_ -> partition_.getLogDir().stream().anyMatch(logDir -> logDir.getSize() != 0))
+                    .collect(Collectors.toList()).isEmpty()) {
+                return;
+            }
+
             Properties properties = new Properties() {{
                 put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, options.size);
             }};
@@ -171,7 +182,7 @@ public class RecordRepository extends AbstractRepository {
                     }
                 }
             }
-        }
+        });
 
         return list.stream()
             .sorted(Comparator.comparing(Record::getTimestamp))
@@ -268,6 +279,8 @@ public class RecordRepository extends AbstractRepository {
         return topic
             .getPartitions()
             .parallelStream()
+            // Skip partition without data
+            .filter(partition -> partition.getLogDir().stream().anyMatch(logDir -> logDir.getSize() != 0))
             .map(partition -> {
                 KafkaConsumer<byte[], byte[]> consumer =
                     this.kafkaModule.getConsumer(options.clusterId, new Properties() {{


### PR DESCRIPTION
Follow up to #2015.

The goal is to avoid waiting the poll timeout configured by the user when the topic/data get messages from empty partitions.

Example of URLs with the issue:
- http://localhost:4000/ui/local/topic/{topic}/data?sort=Oldest&partition=All
- http://localhost:4000/ui/local/topic/{topic}/data?sort=Newest&partition=All
