### PR TITLE
chore: move com.github.johnrengelman.shadow to new home

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     // micronaut
-    id "com.github.johnrengelman.shadow" version "8.1.1"
+    id "com.gradleup.shadow" version "8.3.5"
     id "io.micronaut.application" version "4.4.5"
 
     // akhq


### PR DESCRIPTION
The package `com.github.johnrengelman.shadow` has not been updated since 2023, because it has [moved](https://github.com/GradleUp/shadow/issues/908) to a new home at [`com.gradleup.shadow`](https://github.com/GradleUp/shadow).

Unfortunately there is no 8.1.1 build under the new home, so this PR both changes the package name _and_ upgrades to the most recent version under major version 8.