### PR TITLE
fix(ui): set pagination to 1 when no data displayed

### DIFF
--- a/client/src/containers/Connect/ConnectList/ConnectList.jsx
+++ b/client/src/containers/Connect/ConnectList/ConnectList.jsx
@@ -122,7 +122,7 @@ class ConnectList extends Root {
         );
       });
     } else {
-      this.setState({ clusterId, tableData: [], totalPageNumber: 0, loading: false });
+      this.setState({ clusterId, tableData: [], loading: false });
     }
   }
 

--- a/client/src/containers/KsqlDB/KsqlDBList/KsqlDBQueries/KsqlDBQueries.jsx
+++ b/client/src/containers/KsqlDB/KsqlDBList/KsqlDBQueries/KsqlDBQueries.jsx
@@ -80,7 +80,7 @@ class KsqlDBQueries extends Root {
         );
       });
     } else {
-      this.setState({ clusterId, tableData: [], totalPageNumber: 0, loading: false });
+      this.setState({ clusterId, tableData: [], loading: false });
     }
   }
 

--- a/client/src/containers/KsqlDB/KsqlDBList/KsqlDBStreams/KsqlDBStreams.jsx
+++ b/client/src/containers/KsqlDB/KsqlDBList/KsqlDBStreams/KsqlDBStreams.jsx
@@ -79,7 +79,7 @@ class KsqlDBStreams extends Root {
         );
       });
     } else {
-      this.setState({ clusterId, tableData: [], totalPageNumber: 0, loading: false });
+      this.setState({ clusterId, tableData: [], loading: false });
     }
   }
 

--- a/client/src/containers/KsqlDB/KsqlDBList/KsqlDBTables/KsqlDBTables.jsx
+++ b/client/src/containers/KsqlDB/KsqlDBList/KsqlDBTables/KsqlDBTables.jsx
@@ -79,7 +79,7 @@ class KsqlDBTables extends Root {
         );
       });
     } else {
-      this.setState({ clusterId, tableData: [], totalPageNumber: 0, loading: false });
+      this.setState({ clusterId, tableData: [], loading: false });
     }
   }
 

--- a/client/src/containers/Schema/SchemaList/SchemaList.jsx
+++ b/client/src/containers/Schema/SchemaList/SchemaList.jsx
@@ -130,7 +130,7 @@ class SchemaList extends Root {
         );
       });
     } else {
-      this.setState({ selectedCluster, schemasRegistry: [], totalPageNumber: 0, loading: false });
+      this.setState({ selectedCluster, schemasRegistry: [], loading: false });
     }
   }
 

--- a/client/src/containers/Topic/TopicList/TopicList.jsx
+++ b/client/src/containers/Topic/TopicList/TopicList.jsx
@@ -247,12 +247,12 @@ class TopicList extends Root {
       }
       this.setState({
         selectedCluster,
-        totalPageNumber: data.page,
+        totalPageNumber: data.page < 1 ? 1 : data.page,
         currentPageSize: data.pageSize,
         loading: false
       });
     } else {
-      this.setState({ topics: [], loading: false, totalPageNumber: 0 });
+      this.setState({ topics: [], loading: false });
     }
   }
 


### PR DESCRIPTION
Hello,

I noticed, that empty queries show 0 in pagination.   
It's a quick fix since the initial object in js is already set with the good value.
Before :
![image](https://github.com/user-attachments/assets/72a327ca-b936-4489-bd81-4110ecb9f36c)
After :
![image](https://github.com/user-attachments/assets/e80ae7c2-70fa-40ca-84da-a40ffe173691)

Here is the list of urls:
http://localhost:4000/ui/local/connect/connect
http://localhost:4000/ui/local/ksqldb/ksqldb/streams
http://localhost:4000/ui/local/ksqldb/ksqldb/tables
http://localhost:4000/ui/local/ksqldb/ksqldb/queries
http://localhost:4000/ui/local/schema
http://localhost:4000/ui/local/topic <- 2 bugs, one coming from the backend, I fixed it in the js since the impact would be much bigger
