### PR TITLE
chore: make tests run on Java 21

### DIFF
--- a/src/test/java/org/akhq/clusters/EmbeddedSingleNodeKafkaCluster.java
+++ b/src/test/java/org/akhq/clusters/EmbeddedSingleNodeKafkaCluster.java
@@ -105,6 +105,7 @@ public class EmbeddedSingleNodeKafkaCluster implements BeforeTestExecutionCallba
         ksqlDbProperties.put("bootstrap.servers", bootstrapServers());
         ksqlDbProperties.put("ksql.schema.registry.url", schemaRegistryUrl());
         ksqlDbProperties.put("listeners", "http://0.0.0.0:" + randomPort());
+        ksqlDbProperties.put("ksql.udf.enable.security.manager", "false");
 
         ksqlDBEmbedded = new KsqlDBEmbedded(ksqlDbProperties);
         log.debug("Kafka KsqlDB is running at {}", ksqlDbUrl());


### PR DESCRIPTION
In my IDE, which runs on Java 21, the running of tests fails with the following exception, and timeout:

```text
java.lang.UnsupportedOperationException: The Security Manager is deprecated and will be removed in a future release
	at java.base/java.lang.System.setSecurityManager(System.java:430)
	at io.confluent.ksql.function.UserFunctionLoader.newInstance(UserFunctionLoader.java:158)
	at org.akhq.clusters.KsqlDBEmbedded.<init>(KsqlDBEmbedded.java:32)
	at org.akhq.clusters.EmbeddedSingleNodeKafkaCluster.start(EmbeddedSingleNodeKafkaCluster.java:109)
	at org.akhq.KafkaTestCluster.<init>(KafkaTestCluster.java:135)
	at org.akhq.KafkaTestCluster.main(KafkaTestCluster.java:80)
```

This PR will instruct KSQL to not do anything with the Java `SecurityManager`. With this change, I am able to run tests in my IDE.