### PR TITLE
fix(log): fix value of content-length always return -1

### DIFF
--- a/application.example.yml
+++ b/application.example.yml
@@ -39,7 +39,7 @@ akhq:
     access-log: # Access log configuration (optional)
       enabled: true # true by default
       name: org.akhq.log.access # Logger name
-      format: "[Date: {}] [Duration: {} ms] [Url: {} {}] [Status: {}] [Ip: {}] [User: {}]" # Logger format
+      format: "[Date: {}] [Duration: {} ms] [Url: {} {}] [Status: {}] [Ip: {}] [User: {}] [Length: {}]" # Logger format
     # Custom HTTP response headers configuration
     customHttpResponseHeaders:
       - name: "Content-Security-Policy"

--- a/src/main/java/org/akhq/middlewares/HttpServerAccessLogFilter.java
+++ b/src/main/java/org/akhq/middlewares/HttpServerAccessLogFilter.java
@@ -127,6 +127,8 @@ public class HttpServerAccessLogFilter implements HttpServerFilter {
         public void subscribe(Subscriber<? super T> actual) {
 
             publisher.subscribe(new Subscriber<T>() {
+                private T response;
+
                 @Override
                 public void onSubscribe(Subscription subscription) {
                     actual.onSubscribe(subscription);
@@ -134,7 +136,7 @@ public class HttpServerAccessLogFilter implements HttpServerFilter {
 
                 @Override
                 public void onNext(T httpResponse) {
-                    log(httpResponse);
+                    this.response = httpResponse;
                     actual.onNext(httpResponse);
                 }
 
@@ -146,6 +148,7 @@ public class HttpServerAccessLogFilter implements HttpServerFilter {
 
                 @Override
                 public void onComplete() {
+                    log(response);
                     actual.onComplete();
                 }
             });


### PR DESCRIPTION
Following #1154, the content-lengh displayed is always -1.
This is because the log is evaluated in the OnNext function and this is not the end of the request.
The real end seems to be in "OnComplete".
This also mean the log is now at the end of the request, it was near the end before, so the request time was a little bit off.

Log before : 
![image](https://github.com/user-attachments/assets/fb01cfee-d990-4818-8407-9920d8d54ad4)

Log After :
![image](https://github.com/user-attachments/assets/4bca4ca7-f602-4735-9a6f-badbbe51a584)

Don't hesitate if i'm being too pushy with all the fix PR, I also can create issues if you want. 
I'm just fixing things as I see/need them.


