### PR TITLE
chore(tests): tell KSQL not to phone home to Confluent

### DIFF
--- a/src/test/java/org/akhq/clusters/EmbeddedSingleNodeKafkaCluster.java
+++ b/src/test/java/org/akhq/clusters/EmbeddedSingleNodeKafkaCluster.java
@@ -106,6 +106,7 @@ public class EmbeddedSingleNodeKafkaCluster implements BeforeTestExecutionCallba
         ksqlDbProperties.put("ksql.schema.registry.url", schemaRegistryUrl());
         ksqlDbProperties.put("listeners", "http://0.0.0.0:" + randomPort());
         ksqlDbProperties.put("ksql.udf.enable.security.manager", "false");
+        ksqlDbProperties.put("confluent.support.metrics.enable", "false");
 
         ksqlDBEmbedded = new KsqlDBEmbedded(ksqlDbProperties);
         log.debug("Kafka KsqlDB is running at {}", ksqlDbUrl());


### PR DESCRIPTION
When building behind a strict firewall, the test log contains several ERROR messages like these:

```text
2025-03-17 06:24:08,602 ERROR eckerAgent i.c.s.m.utils.WebClient    Could not submit metrics to Confluent: version-check.confluent.io: Name or service not known
2025-03-17 06:24:08,603 ERROR eckerAgent c.s.m.s.ConfluentSubmitter Failed to submit metrics via secure endpoint, falling back to insecure endpoint
2025-03-17 06:24:08,604 ERROR eckerAgent i.c.s.m.utils.WebClient    Could not submit metrics to Confluent: version-check.confluent.io
2025-03-17 06:24:08,604 ERROR eckerAgent c.s.m.s.ConfluentSubmitter Failed to submit metrics to Confluent via insecure endpoint=http://version-check.confluent.io/ksql/anon -- giving up
```

This PR instructs KSQL not to send "support metrics" to Confluent.