### PR TITLE
add graceful shutdown for docker

### DIFF
--- a/docker/app/akhq
+++ b/docker/app/akhq
@@ -7,4 +7,4 @@ do
   JAVA_OPTS="${JAVA_OPTS} ${JVM_OPT}"
 done
 
-/opt/java/openjdk/bin/java ${JAVA_OPTS} -cp /app/akhq.jar:${CLASSPATH} org.akhq.App
+exec /opt/java/openjdk/bin/java ${JAVA_OPTS} -cp /app/akhq.jar:${CLASSPATH} org.akhq.App


### PR DESCRIPTION
Execute java process with PID=1 through replacing the existing process with the java process. This is required for docker based execution since docker forwards SIGINT to the process with PID=1. In case the process cannot handle it (which was the case prior to this PR), the signal is ignored and docker forcefully kills the container after a certain grace period leading to an exit code of 137.

This PR fixes: https://github.com/tchiotludo/akhq/issues/2146