### PR TITLE
fix(ui): switch to sort by oldest when specifying timestamp

### DIFF
--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -721,14 +721,13 @@ class TopicData extends Root {
         <Dropdown.Item
           key={option}
           onClick={() => {
-              if (option === 'Newest' && this.state.endDatetime !== '') {
-                toast.warn('Sorting by newest with timestamp in large topics may not show data.');
-              }
-              this.setState({ sortBy: option }, () => {
-                this._searchMessages();
-              })
+            if (option === 'Newest' && this.state.endDatetime !== '') {
+              toast.warn('Sorting by newest with timestamp in large topics may not show data.');
             }
-          }
+            this.setState({ sortBy: option }, () => {
+              this._searchMessages();
+            });
+          }}
         >
           <FontAwesomeIcon icon={faSortNumericDesc} aria-hidden={true} pull={'left'} /> {option}
         </Dropdown.Item>
@@ -1082,7 +1081,7 @@ class TopicData extends Root {
                           showTimeSelect
                           value={endDatetime}
                           onChange={value => {
-                            this.setState({ endDatetime: value, sortBy: "Oldest" }, () => {
+                            this.setState({ endDatetime: value, sortBy: 'Oldest' }, () => {
                               this._searchMessages();
                             });
                           }}
@@ -1444,20 +1443,19 @@ class TopicData extends Root {
     );
   }
 }
-const withRouterInnerRef = (WrappedComponent) => {
-
+const withRouterInnerRef = WrappedComponent => {
   class InnerComponentWithRef extends React.Component {
-      render() {
-          const { forwardRef, ...rest } = this.props;
-          return <WrappedComponent {...rest} ref={forwardRef} />;
-      }
+    render() {
+      const { forwardRef, ...rest } = this.props;
+      return <WrappedComponent {...rest} ref={forwardRef} />;
+    }
   }
 
   const ComponentWithRef = withRouter(InnerComponentWithRef, { withRef: true });
 
   return React.forwardRef((props, ref) => {
-      return <ComponentWithRef {...props} forwardRef={ref} />;
-    });
-}
+    return <ComponentWithRef {...props} forwardRef={ref} />;
+  });
+};
 
 export default withRouterInnerRef(TopicData);

--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -720,10 +720,14 @@ class TopicData extends Root {
       renderedOptions.push(
         <Dropdown.Item
           key={option}
-          onClick={() =>
-            this.setState({ sortBy: option }, () => {
-              this._searchMessages();
-            })
+          onClick={() => {
+              if (option === 'Newest' && this.state.endDatetime !== '') {
+                toast.warn('Sorting by newest with timestamp in large topics may not show data.');
+              }
+              this.setState({ sortBy: option }, () => {
+                this._searchMessages();
+              })
+            }
           }
         >
           <FontAwesomeIcon icon={faSortNumericDesc} aria-hidden={true} pull={'left'} /> {option}
@@ -1078,7 +1082,7 @@ class TopicData extends Root {
                           showTimeSelect
                           value={endDatetime}
                           onChange={value => {
-                            this.setState({ endDatetime: value }, () => {
+                            this.setState({ endDatetime: value, sortBy: "Oldest" }, () => {
                               this._searchMessages();
                             });
                           }}


### PR DESCRIPTION
Kind of fixing https://github.com/tchiotludo/akhq/issues/2047 (kind of because from the user perspective it should work to sort both ways regardless of topic size).

This PR changes the sort order to `Oldest` every time the user specifies an end timestamp, because it is then the problem arises. And if the user changes to `Newest`, they will be warned that this may not show any data:

![image](https://github.com/user-attachments/assets/1f9f73aa-c840-4fbb-a8e3-cf6b69836593)
