### PR TITLE
feat(ui): make datetime input editable

### DIFF
--- a/client/src/components/DatePicker/DatePicker.jsx
+++ b/client/src/components/DatePicker/DatePicker.jsx
@@ -21,25 +21,6 @@ class DatePicker extends Component {
     });
   };
 
-  getDisplayValue = value => {
-    const date = value == '' ? new Date() : value;
-    try {
-      return formatDateTime(
-        {
-          year: date.getFullYear(),
-          monthValue: date.getMonth(),
-          dayOfMonth: date.getDate(),
-          hour: date.getHours(),
-          minute: date.getMinutes(),
-          second: date.getSeconds()
-        },
-        'dd-MM-yyyy HH:mm'
-      );
-    } catch (e) {
-      return '';
-    }
-  };
-
   render = () => {
     const { value } = this.state;
     const { showDateTimeInput, showTimeInput, showTimeSelect, onClear, label } = this.props;
@@ -55,11 +36,14 @@ class DatePicker extends Component {
             }}
           >
             {label && <div style={{ marginRight: 10 }}>{label}</div>}
-            <input
-              value={this.getDisplayValue(value)}
-              className="form-control"
-              readOnly={true}
-              placeholder={this.getDisplayValue(value)}
+            <DateTimePicker
+              popperClassName="display-none"
+              selected={value}
+              onChange={date => {
+                this.onChange(date);
+              }}
+              showTimeSelect={showTimeSelect}
+              dateFormat="dd-MM-yyyy HH:mm"
             />
             {onClear && (
               <button

--- a/client/src/components/DatePicker/styles.scss
+++ b/client/src/components/DatePicker/styles.scss
@@ -5,3 +5,7 @@
 .date-block {
   display: inline-block !important;
 }
+
+.display-none {
+  display: none;
+}


### PR DESCRIPTION
This change makes the date-time input field editable, so you are not limited to the 15-minute intervals of the date picker (we are in need of more granular time picking).

![image](https://github.com/user-attachments/assets/facca80c-9076-4e2c-b13b-e1bb896691b5)

The trick used here is to use two synchronized date pickers, with one of them not displaying the picker.



