### PR TITLE
Fix UI is broken after clicking empty topic button

### DIFF
--- a/client/src/containers/Topic/Topic/Topic.jsx
+++ b/client/src/containers/Topic/Topic/Topic.jsx
@@ -66,7 +66,6 @@ class Topic extends Root {
         topicInternal: this.props.location.internal
       },
       () => {
-        console.log('Topic data current:', this.topicData.current);
         this.getTopicsConfig();
         let uri = `/ui/${clusterId}/topic/${topicId}/${this.state.selectedTab}`;
         if (searchParams) {

--- a/client/src/containers/Topic/Topic/Topic.jsx
+++ b/client/src/containers/Topic/Topic/Topic.jsx
@@ -66,6 +66,7 @@ class Topic extends Root {
         topicInternal: this.props.location.internal
       },
       () => {
+        console.log('Topic data current:', this.topicData.current);
         this.getTopicsConfig();
         let uri = `/ui/${clusterId}/topic/${topicId}/${this.state.selectedTab}`;
         if (searchParams) {

--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -1440,5 +1440,20 @@ class TopicData extends Root {
     );
   }
 }
+const withRouterInnerRef = (WrappedComponent) => {
 
-export default withRouter(TopicData);
+  class InnerComponentWithRef extends React.Component {
+      render() {
+          const { forwardRef, ...rest } = this.props;
+          return <WrappedComponent {...rest} ref={forwardRef} />;
+      }
+  }
+
+  const ComponentWithRef = withRouter(InnerComponentWithRef, { withRef: true });
+
+  return React.forwardRef((props, ref) => {
+      return <ComponentWithRef {...props} forwardRef={ref} />;
+    });
+}
+
+export default withRouterInnerRef(TopicData);


### PR DESCRIPTION
Fix #2043 

The ref to TopicData was returning null because it is a class component wrapped with withRouter, which doesn't forward refs by default. To fix this, the ref-forwarding logic was implemented in Topic.jsx using a wrapper component that passes the ref as a forwardRef prop through withRouter and applies it to the actual component.