### PR TITLE
chore(ui): remove IE10+ specific styling

### DIFF
--- a/client/src/components/Modal/styles.scss
+++ b/client/src/components/Modal/styles.scss
@@ -700,12 +700,6 @@ body.swal2-no-backdrop .swal2-shown.swal2-bottom-right {
   margin: auto;
 }
 
-@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-  .swal2-container .swal2-modal {
-    margin: 0 !important;
-  }
-}
-
 .swal2-container.swal2-fade {
   transition: background-color 0.1s;
 }
@@ -1051,15 +1045,6 @@ body.swal2-no-backdrop .swal2-shown.swal2-bottom-right {
 }
 
 @supports (-ms-accelerator: true) {
-  .swal2-range input {
-    width: 100% !important;
-  }
-  .swal2-range output {
-    display: none;
-  }
-}
-
-@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
   .swal2-range input {
     width: 100% !important;
   }


### PR DESCRIPTION
The CSS code:

```css
@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
  /* IE10+ CSS styles go here */
}
```

is used to target IE10/IE11 browsers, this should not be necessary anymore. In addition, this code creates warnings in the console for some non IE10/IE11 browsers (e.g. Edge), which is why I want this removed. Example of warning:

> [Deprecation] -ms-high-contrast is in the process of being deprecated. Please see https://blogs.windows.com/msedgedev/2024/04/29/deprecating-ms-high-contrast/ for tips on updating to the new Forced Colors Mode standard.