### PR TITLE
 Fix: Support Large Retention Values in Topic Config

### DIFF
--- a/src/main/java/org/akhq/controllers/TopicController.java
+++ b/src/main/java/org/akhq/controllers/TopicController.java
@@ -79,10 +79,10 @@ public class TopicController extends AbstractController {
 
     @Get ("api/topic/defaults-configs")
     @Operation(tags = {"topic"}, summary = "Get default topic configuration")
-    public Map<String,Long> getDefaultConf(){
+    public Map<String,Object> getDefaultConf(){
         return Map.of(
-            "replication", replicationFactor.longValue(),
-            "partition", partitionCount.longValue(),
+            "replication", replicationFactor,
+            "partition", partitionCount,
             "retention", retention
         );
     }

--- a/src/main/java/org/akhq/controllers/TopicController.java
+++ b/src/main/java/org/akhq/controllers/TopicController.java
@@ -73,16 +73,16 @@ public class TopicController extends AbstractController {
     @Value("${akhq.topic.partition}")
     private Integer partitionCount;
     @Value("${akhq.topic.retention}")
-    private Integer retention;
+    private Long retention;
     @Value("${akhq.pagination.page-size}")
     private Integer pageSize;
 
     @Get ("api/topic/defaults-configs")
     @Operation(tags = {"topic"}, summary = "Get default topic configuration")
-    public Map<String,Integer> getDefaultConf(){
+    public Map<String,Long> getDefaultConf(){
         return Map.of(
-            "replication", replicationFactor.intValue(),
-            "partition", partitionCount,
+            "replication", replicationFactor.longValue(),
+            "partition", partitionCount.longValue(),
             "retention", retention
         );
     }

--- a/src/test/java/org/akhq/controllers/TopicControllerTest.java
+++ b/src/test/java/org/akhq/controllers/TopicControllerTest.java
@@ -27,7 +27,7 @@ public class TopicControllerTest extends AbstractTest {
     @Test
     @Order(1)
     void defaultsConfigsApi(){
-        Map<String,Integer> result = this.retrieve(HttpRequest.GET(DEFAULTS_CONFIGS_URL), Map.class);
+        Map<String,Long> result = this.retrieve(HttpRequest.GET(DEFAULTS_CONFIGS_URL), Map.class);
 
         assertEquals(1, result.get("replication"));
         assertEquals(86400000, result.get("retention"));

--- a/src/test/java/org/akhq/controllers/TopicControllerTest.java
+++ b/src/test/java/org/akhq/controllers/TopicControllerTest.java
@@ -27,11 +27,11 @@ public class TopicControllerTest extends AbstractTest {
     @Test
     @Order(1)
     void defaultsConfigsApi(){
-        Map<String,Long> result = this.retrieve(HttpRequest.GET(DEFAULTS_CONFIGS_URL), Map.class);
+        Map<String,Object> result = this.retrieve(HttpRequest.GET(DEFAULTS_CONFIGS_URL), Map.class);
 
-        assertEquals(1, result.get("replication"));
-        assertEquals(86400000, result.get("retention"));
-        assertEquals(1, result.get("partition"));
+        assertEquals(1, ((Number) result.get("replication")).shortValue());
+        assertEquals(86400000L, ((Number) result.get("retention")).longValue());
+        assertEquals(1, ((Number) result.get("partition")).intValue());
     }
 
 


### PR DESCRIPTION
The [Issue:2247](https://github.com/tchiotludo/akhq/issues/2247) was caused because TopicController.retention was defined as an Integer, which has a max value of 2,147,483,647 — too small for realistic retention.ms values like 315576000000 (10 years in milliseconds).

Since Kafka supports this config as a 64-bit long, the field should be updated to use Long instead of Integer.