### PR TITLE
Fix consumer group auth check in topic groups endpoint

### DIFF
--- a/src/main/java/org/akhq/controllers/TopicController.java
+++ b/src/main/java/org/akhq/controllers/TopicController.java
@@ -278,7 +278,7 @@ public class TopicController extends AbstractController {
     public List<ConsumerGroup> groups(String cluster, String topicName,
                                       Optional<TopicRepository.TopicGroupsListView> groupsListView)
         throws ExecutionException, InterruptedException {
-        checkIfClusterAndResourceAllowed(cluster, topicName);
+        checkIfClusterAndResourceAllowed(cluster);
 
         return groupsListView.isPresent() && TopicRepository.TopicGroupsListView.HIDE_EMPTY.equals(groupsListView.get())
             ? this.consumerGroupRepository.findActiveByTopic(cluster, topicName, buildUserBasedResourceFilters(cluster))


### PR DESCRIPTION
Topic name was incorrectly being checked as a consumer group resource.
This PR replaces `checkIfClusterAndResourceAllowed(cluster, topicName)` with `checkIfClusterAllowed(cluster)`.
