### PR TITLE
feat(helm): add configurable targetPort support for sidecars

### DIFF
--- a/helm/akhq/templates/ingress.yaml
+++ b/helm/akhq/templates/ingress.yaml
@@ -49,7 +49,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  name: http
+                  name: {{ .Values.service.targetPort | default "http" }}
               {{ else }}
               serviceName: {{ $fullName }}
               servicePort: http

--- a/helm/akhq/templates/service.yaml
+++ b/helm/akhq/templates/service.yaml
@@ -19,14 +19,14 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: {{ .Values.service.targetPort | default "http" }}
       protocol: TCP
       name: http
       {{- if and (eq "NodePort" .Values.service.type) .Values.service.httpNodePort }}
       nodePort: {{ .Values.service.httpNodePort }}
       {{- end }}
     - port: {{ .Values.service.managementPort }}
-      targetPort: management
+      targetPort: {{ .Values.service.managementTargetPort | default "management" }}
       protocol: TCP
       name: management
       {{- if and (eq "NodePort" .Values.service.type) .Values.service.managementNodePort }}

--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -103,6 +103,11 @@ initContainers: {}
 #      - mountPath: /tmp
 #        name: certs
 
+# When using a sidecar (e.g., initContainer with restartPolicy=Always), 
+# you may want to set service.targetPort to the sidecar port:
+# service:
+#   targetPort: "proxy"  # or 4180
+
 # Configure the Pod Security Context
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 securityContext: {}
@@ -126,6 +131,12 @@ service:
   type: ClusterIP
   port: 80
   managementPort: 28081
+  # Configure target ports for the service - useful when using sidecars
+  # targetPort: "http"  # defaults to "http" (port name)
+  # managementTargetPort: "management"  # defaults to "management" (port name)
+  # Alternative: specify port numbers directly
+  # targetPort: 8080
+  # managementTargetPort: 28081
   #httpNodePort: 32551
   #managementNodePort: 32552
   labels: {}


### PR DESCRIPTION
This PR updates the Helm charts to support a configurable service targetPort. The current implementation has the ingress hardcoded to the `http` named port, and the service will point to an `http` named port in the deployment. K8s sidecars do not support named ports being aggregated under a Service ([ref](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#detailed-behavior)), so having these named ports hardcoded today prevents the ability of deploying/configuring AKHQ to use a reverse proxy sidecar (e.g. when using header-auth in AKHQ). 

- Add configurable service.targetPort and service.managementTargetPort options
- Update service template to support custom target ports with defaults
- Update ingress template to use configurable targetPort