### PR TITLE
fix(ui): correct redirection after oauth2 login

### DIFF
--- a/client/src/utils/AkhqRoutes.jsx
+++ b/client/src/utils/AkhqRoutes.jsx
@@ -108,6 +108,17 @@ class AkhqRoutes extends Root {
     this.setState({ loading: false });
   }
 
+  checkAfterLoginAndHandleRedirect() {
+    const returnTo = sessionStorage.getItem('returnTo');
+
+    if (returnTo && location.pathname !== '/ui/login') {
+      sessionStorage.removeItem('returnTo');
+      return returnTo;
+    }
+
+    return this.handleRedirect();
+  }
+
   handleRedirect() {
     let clusterId = this.state.clusterId;
     const roles = JSON.parse(sessionStorage.getItem('roles'));
@@ -300,7 +311,7 @@ class AkhqRoutes extends Root {
               )}
               <Route exact path="/ui/:clusterId/settings" element={<Settings />} />
               <Route path="/" element={<Navigate to={this.handleRedirect()} />} />
-              <Route path="/ui" element={<Navigate to={this.handleRedirect()} />} />
+              <Route path="/ui" element={<Navigate to={this.checkAfterLoginAndHandleRedirect()} />} />
               <Route path="/ui/401" element={<Navigate to={this.handleRedirect()} />} />
             </Routes>
           </Base>

--- a/client/src/utils/api.jsx
+++ b/client/src/utils/api.jsx
@@ -23,6 +23,7 @@ const handleError = err => {
 
   if (err.response && err.response.status < 500) {
     if (err.response.status === 401 || err.response.status === 403) {
+      sessionStorage.setItem('returnTo', window.location.pathname + (window.location.search || ''));
       localStorage.setItem('toastMessage', error.message);
       location.href = '/ui/login';
     } else {


### PR DESCRIPTION
This fix contains redirection on stored route_path in session storage (key = returnTo).

This is for OAuth2 login flow. After login the page is redirected to '/ui'.
Then using 'returnTo' in client\src\containers\Login\Login.jsx function 'getData' do not works