### PR TITLE
fix(ui): search field submitting form after 'Enter' key pressed

### DIFF
--- a/client/src/components/Form/Form.jsx
+++ b/client/src/components/Form/Form.jsx
@@ -209,7 +209,7 @@ class Form extends Root {
                 <input
                   type="text"
                   name="searchValue"
-                  className="form-control placeholder"
+                  className="form-control"
                   placeholder={name}
                   defaultValue={selectedKeySchema}
                 />
@@ -227,6 +227,11 @@ class Form extends Root {
                     aria-controls="bs-select-1"
                     aria-autocomplete="list"
                     placeholder={'search'}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                      }
+                    }}
                     onChange={onChange}
                     value={searchValue}
                   />


### PR DESCRIPTION
When user use search filed (e.g. in 'Value schema') in topic produce form (/ui/${clusterId}/topic/${topicId}/produce) and press 'Enter' key, then form is submitted.
Changes prevent this case.