### PR TITLE
bugfix: Allow anonymous users to read default topic configuration

### DIFF
--- a/src/main/java/org/akhq/controllers/TopicController.java
+++ b/src/main/java/org/akhq/controllers/TopicController.java
@@ -78,6 +78,7 @@ public class TopicController extends AbstractController {
     private Integer pageSize;
 
     @Get ("api/topic/defaults-configs")
+    @Secured(SecurityRule.IS_ANONYMOUS)
     @Operation(tags = {"topic"}, summary = "Get default topic configuration")
     public Map<String,Object> getDefaultConf(){
         return Map.of(


### PR DESCRIPTION
Previously, in AKHQ 0.24, it was possible to read the default topic configuration when security is enabled and the user is anonymous. Now, it is no longer possible to do so.  That is probably because `@Secured(SecurityRule.IS_AUTHENTICATED)` was added to the outer `TopicController` class as part of the security refactor in AKHQ 0.25.

The problem being fixed here was ultimately preventing anonymous users from creating new topics when security is enabled.  It was not possible to even access the UI form for filling out the new topic information.

The solution is to allow anonymous users to read default topic configuration.

Example configuration that would not work:

```
micronaut:
  security:
    enabled: true
    token.jwt.signatures.secret.generator.secret: "jwtsecrethere"
akhq:
  security:
    default-group: admin
```

then go to the Topics screen, click to create a new topic, and note that you're immediately redirected to the login URL.

This PR fixes #2434.