### PR TITLE
Upgrade to logback 1.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ dependencies {
     implementation("io.micronaut:micronaut-http-server-netty")
     implementation("io.micronaut:micronaut-jackson-databind")
     implementation("io.swagger.core.v3:swagger-annotations")
-    runtimeOnly("ch.qos.logback:logback-classic")
+    runtimeOnly("ch.qos.logback:logback-classic:1.5.18")
     runtimeOnly("org.yaml:snakeyaml")
     implementation("io.micronaut.security:micronaut-security-annotations")
     implementation("io.micronaut.security:micronaut-security-jwt")


### PR DESCRIPTION
logback 1.5 includes the ability to log formatted JSON messages using the new `withFormattedMessage` XML option:
https://logback.qos.ch/manual/encoders.html

This PR upgrades from logback 1.4, which was being implicitly chosen.

Example configuration snippet that outputs formatted JSON log messages using the new logback 1.5 functionality:

```
<!-- Adopted from https://github.com/tchiotludo/akhq/blob/0.26.0/src/main/resources/logback.xml -->
<configuration>
    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
        <immediateFlush>true</immediateFlush>

        <encoder class="ch.qos.logback.classic.encoder.JsonEncoder">
            <withFormattedMessage>true</withFormattedMessage>
            <withMessage>false</withMessage>
            <withArguments>false</withArguments>
        </encoder>
    </appender>

    <root level="info">
        <appender-ref ref="stdout"/>
    </root>

    <logger name="org.apache" level="WARN" />
    <logger name="io.micronaut" level="WARN"/>
    <logger name="io.micronaut.context.DefaultApplicationContext" level="INFO" />
    <logger name="io.micronaut.runtime.Micronaut" level="INFO" />
</configuration>
```

Fixes #2435