### PR TITLE
Put the original OIDC groups mapping back

### DIFF
--- a/docs/docs/configuration/authentifications/oidc.md
+++ b/docs/docs/configuration/authentifications/oidc.md
@@ -20,6 +20,10 @@ micronaut:
 
 OIDC responses will be cached according to the settings under `micronaut.caches.local-security-claim-provider`.
 
+> Depending on the number of groups the user is part of, you may face issues during login. If the groups size is too big, it won't fit into the 4Kb cookie size limit, in which we save the groups the user belongs to.
+>
+> Groups size issue can happen on the AKHQ groups mapping (default behaviour) or the OIDC groups. To let you choose the one you want to use, AKHQ provides the `akhq.providers.<provider_name>.useOidcGroupsInToken`. By setting it to true, only the OIDC groups are saved in the token, and the AKHQ groups mapping is resolved when a request arrives.
+
 To further tell AKHQ to display OIDC options on the login page and customize claim mapping, configure OIDC in the AKHQ config:
 
 ```yaml

--- a/src/main/java/org/akhq/configs/security/Oidc.java
+++ b/src/main/java/org/akhq/configs/security/Oidc.java
@@ -25,6 +25,7 @@ public class Oidc {
         private List<GroupMapping> groups = new ArrayList<>();
         private List<UserMapping> users = new ArrayList<>();
         private boolean useOidcClaim = false;
+        private boolean useOidcGroupsInToken = false;
     }
 
     public Provider getProvider(String key) {

--- a/src/main/java/org/akhq/security/mapper/OidcUserDetailsMapper.java
+++ b/src/main/java/org/akhq/security/mapper/OidcUserDetailsMapper.java
@@ -18,7 +18,10 @@ import io.reactivex.Flowable;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.akhq.configs.security.Oidc;
+import org.akhq.models.security.ClaimProvider;
 import org.akhq.models.security.ClaimProviderType;
+import org.akhq.models.security.ClaimRequest;
+import org.akhq.models.security.ClaimResponse;
 import org.reactivestreams.Publisher;
 
 import java.util.*;
@@ -35,6 +38,9 @@ import java.util.stream.Collectors;
 public class OidcUserDetailsMapper extends DefaultOpenIdAuthenticationMapper {
     @Inject
     private Oidc oidc;
+
+    @Inject
+    private ClaimProvider claimProvider;
 
     public OidcUserDetailsMapper(OpenIdAdditionalClaimsConfiguration openIdAdditionalClaimsConfiguration, AuthenticationModeConfiguration authenticationModeConfiguration) {
         super(openIdAdditionalClaimsConfiguration, authenticationModeConfiguration);
@@ -57,11 +63,38 @@ public class OidcUserDetailsMapper extends DefaultOpenIdAuthenticationMapper {
 
         List<String> oidcGroups = getOidcGroups(provider, openIdClaims);
 
-        Map<String, Object> attributes = new HashMap<>();
-        attributes.put("provider_name", providerName);
-        attributes.put("provider_type", ClaimProviderType.OIDC.name());
-        attributes.put("groups", oidcGroups);
-        return (Flowable.just(AuthenticationResponse.success(oidcUsername, List.of(SecurityRule.IS_AUTHENTICATED), attributes)));
+        // Stores the OIDC groups in the JWT token
+        // Useful is the AKHQ groups mapping size is more than 4Kb. It saves the OIDC groups and resolves the AKHQ
+        // groups for each HTTP request (in the AKHQSecurityRule).
+        if (provider.isUseOidcGroupsInToken()) {
+            Map<String, Object> attributes = new HashMap<>();
+            attributes.put("provider_name", providerName);
+            attributes.put("provider_type", ClaimProviderType.OIDC.name());
+            attributes.put("groups", oidcGroups);
+            return (Flowable.just(
+                AuthenticationResponse.success(oidcUsername, List.of(SecurityRule.IS_AUTHENTICATED), attributes)));
+        }
+        // Stores the AKHQ groups in the JWT token
+        // Default behaviour. The OIDC provider gives the groups, AKHQ resolves the groups mapping and saves it in the token.
+        else {
+            ClaimRequest request = ClaimRequest.builder()
+                .providerType(ClaimProviderType.OIDC)
+                .providerName(providerName)
+                .username(oidcUsername)
+                .groups(oidcGroups)
+                .build();
+
+            try {
+                ClaimResponse claim = claimProvider.generateClaim(request);
+                return (Flowable.just(
+                    AuthenticationResponse.success(oidcUsername, List.of(SecurityRule.IS_AUTHENTICATED),
+                        Map.of("groups", claim.getGroups()))));
+            } catch (Exception e) {
+                String claimProviderClass = claimProvider.getClass().getName();
+                return Flowable.just(new AuthenticationFailed(
+                    "Exception from ClaimProvider " + claimProviderClass + ": " + e.getMessage()));
+            }
+        }
     }
 
     private AuthenticationResponse createDirectClaimAuthenticationResponse(String oidcUsername, OpenIdClaims openIdClaims) {

--- a/src/main/java/org/akhq/security/rule/AKHQSecurityRule.java
+++ b/src/main/java/org/akhq/security/rule/AKHQSecurityRule.java
@@ -115,9 +115,10 @@ public class AKHQSecurityRule extends AbstractSecurityRule<HttpRequest<?>> {
     }
 
     public static Map<String, List<Group>> unrollGroups(Authentication authentication, ClaimProvider claimProvider) {
-        /* For OIDC providers, the "groups" attribute contains a list of group names.
-         * For other providers, the "groups" attribute contains a map of role names to lists of groups.
-         * This method creates a map of role names to lists of groups no matter the origin of the "groups" attribute. */
+        /* For OIDC providers with useOidcGroupsInToken, the "groups" attribute contains a list of group names.
+         * For other providers and OIDC without useOidcGroupsInToken, the "groups" attribute contains a map of role
+         * names to lists of groups. This method creates a map of role names to lists of groups no matter the origin
+         * of the "groups" attribute. */
         Object decompressedGroups = decompressGroups(authentication);
         if (decompressedGroups instanceof Map<?, ?>) {
             return toMapOfGroupLists((Map<String, List<?>>) decompressedGroups);


### PR DESCRIPTION
Fix #2379
Fix #2383

#2125 tried to fix a problem with OIDC and the 4Kb cookie size limit. AKHQ stores in the JWT token the groups mapping (roles/patterns/clusters) in the new RBAC system but it can lead to issue because this groups mapping can be too big to be saved in the token. Instead of storing the groups mapping, this PR saves only the OIDC groups given by the OIDC provider and let AKHQ resolve the permissions by extracting the OIDC groups and doing mapping when a request comes.

This features introduces a regression for people, not facing the 4Kb limit due to the AKHQ groups mapping, for which the OIDC provider gives a lot of groups, exceeding also the 4Kb limit

This PR keeps the 2 behaviours, restoring the original behaviour as the default one and allowing people to choose the OIDC groups storage by using the `useOidcGroupsInToken` property in the OIDC provider configuration