### PR TITLE
Remove inline script to fix CSP issue

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -10,21 +10,6 @@
     <meta name="theme-color" content="#33b5e5" />
     <meta name="html-head" content="replace" />
 
-    <!--
-      The AKHQ_PREFIX_PATH placeholder magic value is replaced during serving by server
-      and set to ${micronaut.server.context-path:} external URL path. It gets prepended to all links back
-      to Prometheus, both for asset loading as well as API accesses.
-    -->
-    <script>
-      const AKHQ_PREFIX_UI = '%BASE_URL%';
-
-      const AKHQ_PREFIX_PATH = (function () {
-        const split = AKHQ_PREFIX_UI.split('/');
-        split.pop();
-        return split.join('/');
-      })();
-    </script>
-
     <meta
       name="description"
       content="Kafka GUI for Apache Kafka to manage topics, topics data, consumers group, schema registry, connect and more..."

--- a/client/src/prefix.jsx
+++ b/client/src/prefix.jsx
@@ -1,14 +1,21 @@
-export default () => {
-  // eslint-disable-next-line no-undef
-  let prefix = AKHQ_PREFIX_PATH;
+function extractPrefixFromUrl() {
+  // Extract prefix from current URL path
+  const path = window.location.pathname;
+  const uiIndex = path.indexOf('/ui');
 
-  // eslint-disable-next-line no-undef
-  if (prefix === undefined) {
-    prefix = '/';
+  if (uiIndex > 0) {
+    return path.substring(0, uiIndex);
   }
 
+  return '';
+}
+
+export default () => {
+  // Use environment variable or detect from window location
+  let prefix = extractPrefixFromUrl() || '/';
+
   if (prefix.endsWith('/')) {
-    prefix = prefix.substr(-1);
+    prefix = prefix.slice(0, -1);
   }
 
   return prefix;

--- a/client/src/prefix.jsx
+++ b/client/src/prefix.jsx
@@ -5,7 +5,7 @@ function extractPrefixFromUrl() {
   const path = window.location.pathname;
   const uiIndex = path.indexOf(UI_PATH);
 
-  if (uiIndex > 0) {
+  if (uiIndex >= 0) {
     return path.substring(0, uiIndex);
   }
 

--- a/client/src/prefix.jsx
+++ b/client/src/prefix.jsx
@@ -1,7 +1,9 @@
+const UI_PATH = '/ui';
+
 function extractPrefixFromUrl() {
   // Extract prefix from current URL path
   const path = window.location.pathname;
-  const uiIndex = path.indexOf('/ui');
+  const uiIndex = path.indexOf(UI_PATH);
 
   if (uiIndex > 0) {
     return path.substring(0, uiIndex);


### PR DESCRIPTION
Fix #1765 

Due to the inline script in index.html, deploying AKHQ in K8S requires to add a configuration-snippet:

```
nginx.ingress.kubernetes.io/configuration-snippet:
   more_set_headers "Content-Security-Policy: script-src 'self' 'unsafe-eval' 'unsafe-inline'";
```

Following the different CVE related to the nginx ingress controller, snippet annotations are now disabled by default from version 1.1.5 and it is recommended to don't use it anymore for security reasons. Not using snippets then require to remove the inline script from the index.html.