### PR TITLE
fix(ui) - issue 1790 - Safari: Handle opaqueredirect - res.status 0

### DIFF
--- a/client/src/containers/Login/Login.jsx
+++ b/client/src/containers/Login/Login.jsx
@@ -42,6 +42,12 @@ class Login extends Form {
       };
 
       login(uriLogin(), body).then(res => {
+        // Safari: Handle opaqueredirect (status 0 means redirect was successful with redirect: 'manual')
+        if (res.type === 'opaqueredirect' || res.status === 0) {
+          this.getData();
+          return;
+        }
+
         // Handle login failed for bearer auth
         if (res.status === 500) {
           toast.error('Wrong Username or Password!');


### PR DESCRIPTION
Fixes #1790 

Tested on Safari and Chrome with modified application-dev.yml


```
micronaut:
  security:
    enabled: true
    token:
      jwt:
        signatures:
          secret:
            generator:
              secret: d74ff0ee8da3b9806b18c877dbf29bbde50b5bd8e4dad7a3a725000feb82e8f1

akhq:
  server:
    access-log:
      enabled: true

  connections:
    local:
      properties:
        bootstrap.servers: "kafka:9092"
      schema-registry:
        url: "http://schema-registry:8085"
      connect:
        - name: "connect"
          url: "http://connect:8083"
      ksqldb:
        - name: "ksqldb"
          url: "http://ksqldb:8088"

  security:
    roles:
      node-admin:
        - resources: [ "NODE" ]
          actions: [ "READ", "READ_CONFIG", "ALTER_CONFIG" ]

    default-group: admin
    groups:
      admin:
        - role: node-admin

    basic-auth:
      - username: user
        password: d74ff0ee8da3b9806b18c877dbf29bbde50b5bd8e4dad7a3a725000feb82e8f1
        groups:
          - admin
```