### PR TITLE
docs(license): clarify Apache 2.0 license section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,14 @@ Many thanks to:
 
 
 ## License
-Apache 2.0 © [tchiotludo](https://github.com/tchiotludo)
+
+AKHQ is licensed under the **Apache License 2.0**.
+
+You are free to **use**, **modify**, and **distribute** this software
+in compliance with the terms of the Apache 2.0 license.
+
+For complete details and legal information,  
+please refer to the [LICENSE](LICENSE) file included in this repository.
+
+Copyright © [tchiotludo](https://github.com/tchiotludo)
+


### PR DESCRIPTION
### Summary
Improved the License section in the README for clarity and markdownlint compliance.

### Changes
- Added detailed description of the Apache 2.0 License
- Fixed markdownlint spacing issues
- Enhanced readability and consistency

### Why
This update makes the License section clearer for users and aligns with standard open-source documentation practices.
