### PR TITLE
chore(deps): Bump micronaut to version from 4.10.0 to 4.10.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-micronautVersion=4.15.0
+micronautVersion=4.10.1
 confluentVersion=8.1.0
 kafkaVersion=4.0.1
 kafkaScalaVersion=2.13

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-micronautVersion=4.10.0
+micronautVersion=4.15.0
 confluentVersion=8.1.0
 kafkaVersion=4.0.1
 kafkaScalaVersion=2.13


### PR DESCRIPTION
A recent Azure change broke SSO logins using Azure Entra ID. See also https://github.com/tchiotludo/akhq/issues/2597. According to [this micronaut](https://github.com/micronaut-projects/micronaut-security/issues/1774) issue, it should be solved in version 4.10.1, where we're currently on version 4.10.0. 

With this PR I've bumped it to version 4.15.0.