### PR TITLE
Fix: default pathType for Ingress to Prefix (#1508)

### DIFF
--- a/helm/akhq/templates/ingress.yaml
+++ b/helm/akhq/templates/ingress.yaml
@@ -42,7 +42,7 @@ spec:
 	{{- range $ingressPaths }}
           - path: {{ . }}
             {{- if eq (include "akhq.ingress.apiVersion" $) "networking.k8s.io/v1" }}
-            pathType: {{ $.Values.ingress.pathType | default "ImplementationSpecific" }}
+            pathType: {{ $.Values.ingress.pathType | default "Prefix" }}
             {{- end }}
             backend:
               {{- if eq (include "akhq.ingress.apiVersion" $) "networking.k8s.io/v1" }}


### PR DESCRIPTION
### Problem
Kubernetes Ingress with pathType `ImplementationSpecific` fails on some ingress controllers.

### Fix
Changed the default pathType to `Prefix` in helm chart, so Ingress works consistently without needing manual override.

### Files Changed
- helm/akhq/templates/ingress.yaml

### Result
Ingress now renders correctly with pathType `Prefix`.
