### PR TITLE
Add topologySpreadConstraints to Helm chart

### DIFF
--- a/helm/akhq/templates/deployment.yaml
+++ b/helm/akhq/templates/deployment.yaml
@@ -129,6 +129,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       volumes:
       {{- if .Values.extraVolumes  }}{{ toYaml .Values.extraVolumes | trim | nindent 6 }}{{ end }}
       {{- if .Values.configuration }}

--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -193,6 +193,8 @@ tolerations: []
 
 affinity: {}
 
+topologySpreadConstraints: []
+
 networkPolicy:
   enabled: true
   labels: {}


### PR DESCRIPTION
It would be nice to be able to set `topologySpreadConstraints` for HA.