### PR TITLE
Enable human bytes label for .bytes config props

### DIFF
--- a/client/src/containers/Node/NodeDetail/NodeConfigs/NodeConfigs.jsx
+++ b/client/src/containers/Node/NodeDetail/NodeConfigs/NodeConfigs.jsx
@@ -83,6 +83,8 @@ class NodeConfigs extends Form {
         return MILLI;
       case '.size':
         return BYTES;
+      case '.bytes':
+        return BYTES;
       default:
         return TEXT;
     }

--- a/client/src/containers/Topic/Topic/TopicConfigs/TopicConfigs.jsx
+++ b/client/src/containers/Topic/Topic/TopicConfigs/TopicConfigs.jsx
@@ -65,6 +65,8 @@ class TopicConfigs extends Form {
         return MILLI;
       case '.size':
         return BYTES;
+      case '.bytes':
+        return BYTES;
       default:
         return TEXT;
     }

--- a/client/src/utils/converters.js
+++ b/client/src/utils/converters.js
@@ -95,7 +95,7 @@ export function showTime(milliseconds) {
  * @returns
  */
 export function showBytes(bytes, decimals = 3) {
-  if (bytes === null || bytes === undefined) return '';
+  if (bytes === null || bytes === undefined || bytes < 0) return '';
   if (bytes === 0) return '0 B';
 
   const kbytes = 1024;


### PR DESCRIPTION
Before:
<img width="1477" height="169" alt="image" src="https://github.com/user-attachments/assets/bbf5ede7-1301-4c30-8437-cb03ecfce50a" />

After:
<img width="1599" height="207" alt="image" src="https://github.com/user-attachments/assets/7e8f205a-df17-4b7a-8ff7-9a5419303fed" />

