### PR TITLE
feat(helm): add startup probe support to deployment template

### DIFF
--- a/helm/akhq/templates/deployment.yaml
+++ b/helm/akhq/templates/deployment.yaml
@@ -115,6 +115,18 @@ spec:
             successThreshold: {{ $.Values.readinessProbe.successThreshold }}
             failureThreshold: {{ $.Values.readinessProbe.failureThreshold }}
           {{- end }}
+          {{- if $.Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.startupProbe.prefix | default "" }}{{ $.Values.startupProbe.path }}
+              port: {{ $.Values.startupProbe.port }}
+              {{- if $.Values.startupProbe.httpGetExtra }}{{ toYaml $.Values.startupProbe.httpGetExtra | trim | nindent 14 }}{{ end }}
+            initialDelaySeconds: {{ $.Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ $.Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ $.Values.startupProbe.timeoutSeconds }}
+            successThreshold: {{ $.Values.startupProbe.successThreshold }}
+            failureThreshold: {{ $.Values.startupProbe.failureThreshold }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -179,6 +179,18 @@ livenessProbe:
   failureThreshold: 3
   httpGetExtra: {}
 
+startupProbe:
+  enabled: false
+  prefix: "" # set same as `micronaut.server.context-path`
+  path: /health
+  port: management
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 30
+  httpGetExtra: {}
+
 resources: {}
   # limits:
   #  cpu: 100m


### PR DESCRIPTION
## Summary

Add a configurable `startupProbe` to the Helm chart deployment template, following the same pattern as the existing `readinessProbe` and `livenessProbe`.

## Motivation

Startup probes are useful for applications that have slow startup times. Unlike liveness probes, the startup probe only runs during initial container startup, preventing Kubernetes from killing pods that are still initializing. This is especially relevant for AKHQ when connecting to large Kafka clusters where the initial health check may take longer.

## Changes

- **`helm/akhq/templates/deployment.yaml`** — Added `startupProbe` block after the `readinessProbe`, with the same configurable fields (`httpGet`, `prefix`, `path`, `port`, `httpGetExtra`, and all timing parameters).
- **`helm/akhq/values.yaml`** — Added default `startupProbe` configuration:
  - **Disabled by default** (`enabled: false`) to avoid breaking existing deployments
  - Uses `/health` endpoint on the `management` port
  - `initialDelaySeconds: 0`, `periodSeconds: 10`, `failureThreshold: 30` — allows up to ~5 minutes for the application to start

## Usage

Enable the startup probe in your values override:

```yaml
startupProbe:
  enabled: true