### PR TITLE
fix: use GroupState API for KIP-848 consumer protocol groups (#2720)

### DIFF
--- a/src/main/java/org/akhq/models/ConsumerGroup.java
+++ b/src/main/java/org/akhq/models/ConsumerGroup.java
@@ -7,7 +7,7 @@ import lombok.ToString;
 import org.apache.kafka.clients.admin.ConsumerGroupDescription;
 import org.apache.kafka.clients.admin.MemberDescription;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.common.ConsumerGroupState;
+import org.apache.kafka.common.GroupState;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -20,7 +20,7 @@ public class ConsumerGroup {
     private String id;
     private boolean simpleConsumerGroup;
     private String partitionAssignor;
-    private ConsumerGroupState state;
+    private GroupState state;
     private Node coordinator;
     private final ArrayList<Consumer> members = new ArrayList<>();
     private final ArrayList<TopicPartition.ConsumerGroupOffset> offsets = new ArrayList<>();
@@ -33,7 +33,7 @@ public class ConsumerGroup {
         this.id = groupDescription.groupId();
         this.simpleConsumerGroup = groupDescription.isSimpleConsumerGroup();
         this.partitionAssignor = groupDescription.partitionAssignor();
-        this.state = groupDescription.state();
+        this.state = groupDescription.groupState();
         this.coordinator = new Node(groupDescription.coordinator());
 
         for (MemberDescription member : groupDescription.members()) {


### PR DESCRIPTION
## Summary
- Migrated `ConsumerGroup.java` from deprecated `ConsumerGroupState`/`.state()` to `GroupState`/`.groupState()`
- Fixes consumer groups using KIP-848 consumer protocol showing state `DEAD` instead of actual state (`Stable`, `Assigning`, etc.)

## Root Cause
The deprecated `ConsumerGroupState`/`.state()` API relies on the classic `DescribeGroups` RPC which has no knowledge of KIP-848 consumer protocol groups, returning `DEAD`. The new `GroupState`/`.groupState()` API uses the `ConsumerGroupDescribe` RPC which correctly handles both classic and consumer protocol groups.


Fixes #2720