### PR TITLE
fix: include null keys in NOT_CONTAINS filter results

### DIFF
--- a/src/main/java/org/akhq/repositories/RecordRepository.java
+++ b/src/main/java/org/akhq/repositories/RecordRepository.java
@@ -874,8 +874,7 @@ public class RecordRepository extends AbstractRepository {
         }
 
         return in.parallelStream()
-            .filter(Objects::nonNull)
-            .anyMatch(s -> extractSearchPatterns(search)
+            .anyMatch(s -> s == null || extractSearchPatterns(search)
                 .stream()
                 .noneMatch(s.toLowerCase()::contains));
     }


### PR DESCRIPTION
Fixes #2775

Hey, I looked into this and managed to reproduce it,
I created a topic with 4 partitions and produced some messages 
with null keys, Without any filter all 4 partitions show up fine. 
But as soon as I apply a NOT_CONTAINS key filter, all the null-key 
records just disappear from the results.

The issue is in 'notContainsAll' there's a 
'.filter(Objects::nonNull)' call that silently drops null values 
before the filter even runs. So when a record has a null key, 
the stream is empty and 'anyMatch' just returns false, meaning 
the record gets excluded even though null obviously doesn't 
contain anything.

Fix is pretty simple, removed the null filter and added 
's == null' check directly in the 'anyMatch' lambda, so If the key 
is null it just passes through, which is the correct behaviour.

Tested before and after, null-key records now show up correctly 
with NOT_CONTAINS filter applied.