### PR TITLE
fix(topicdata): use beginningOffset as lower bound in getLastRecord seek

### DIFF
--- a/src/main/java/org/akhq/repositories/RecordRepository.java
+++ b/src/main/java/org/akhq/repositories/RecordRepository.java
@@ -106,10 +106,12 @@ public class RecordRepository extends AbstractRepository {
         try (KafkaConsumer<byte[], byte[]> consumer = kafkaModule.getConsumer(clusterId)) {
             consumer.assign(topicPartitions);
 
+            Map<TopicPartition, Long> beginOffsets = consumer.beginningOffsets(consumer.assignment());
             consumer
                 .endOffsets(consumer.assignment())
                 .forEach((topicPartition, offset) -> {
-                    consumer.seek(topicPartition, Math.max(0, offset - 2));
+                    long beginOffset = beginOffsets.getOrDefault(topicPartition, 0L);
+                    consumer.seek(topicPartition, Math.max(beginOffset, offset - 2));
                 });
 
             this.poll(consumer)


### PR DESCRIPTION
Fixes #2490

Hey, I reproduced this by producing 10 records to a topic then 
deleting the first 9, leaving a single record at offset 9.

The issue is in getLastRecord method, it seeks to Math.max(0, endOffset - 2)  which protects against negative offsets but not against going below , the actual first available offset. With the record at offset 9, it seeks to offset 8 which no longer exists, so thats why the poll returns nothing
Fix: fetch the beginning offsets first and use Math.max(beginOffset, 
endOffset - 2) instead, This makes sure we never seek below the first 
available record regardless of how many records were deleted or 
compacted away.

i tested this before and after, empty {} with a single high-offset record 
now correctly returns that record.