### PR TITLE
fix(build): preserve git.properties to show the right version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -316,6 +316,9 @@ task startTestKafkaCluster(type: com.github.psxpaul.task.JavaExecFork) {
 shadowJar {
     mergeServiceFiles()
     zip64 = true
+    transform(com.github.jengelman.gradle.plugins.shadow.transformers.PreserveFirstFoundResourceTransformer) {
+        include('git.properties')
+    }
 }
 
 processResources.dependsOn ":client:installFrontend"


### PR DESCRIPTION
Fix #2853 

After upgrading the shadow plugin, our git.properties file that contains the AKHQ version (in the `git.tags` property) displayed in the UI was overwrited by some third-party libraries.
It ended up by showing "Snapshot" as the AKHQ version instead of the actual version.
This fix preserves our git.properties in the fat jar, allowing to show the right version