### PR TITLE
fix: return 403 instead of 307 for unauthorized API requests

### DIFF
--- a/src/main/java/org/akhq/controllers/ErrorController.java
+++ b/src/main/java/org/akhq/controllers/ErrorController.java
@@ -2,8 +2,6 @@ package org.akhq.controllers;
 
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.micrometer.core.instrument.util.StringUtils;
-import io.micronaut.core.annotation.AnnotationValue;
-import io.micronaut.http.BasicHttpAttributes;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
@@ -14,10 +12,8 @@ import io.micronaut.http.hateoas.Link;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.authentication.AuthorizationException;
 import io.micronaut.security.rules.SecurityRule;
-import io.micronaut.web.router.UriRouteMatch;
 import lombok.extern.slf4j.Slf4j;
 import org.akhq.modules.InvalidClusterException;
-import org.akhq.security.annotation.AKHQSecured;
 import org.apache.kafka.common.errors.ApiException;
 import org.sourcelab.kafka.connect.apiclient.rest.exceptions.ConcurrentConfigModificationException;
 import org.sourcelab.kafka.connect.apiclient.rest.exceptions.InvalidRequestException;
@@ -84,16 +80,12 @@ public class ErrorController extends AbstractController {
     public HttpResponse<?> error(HttpRequest<?> request, AuthorizationException e) throws URISyntaxException {
         if (request.getUri().toString().startsWith("/api")) {
             if (e.isForbidden()) {
-                if (BasicHttpAttributes.getRouteMatchInfo(request).isPresent() &&
-                    ((UriRouteMatch<?, ?>) BasicHttpAttributes.getRouteMatchInfo(request).get()).hasAnnotation(AKHQSecured.class)) {
-                    AnnotationValue<AKHQSecured> annotation =
-                        ((UriRouteMatch<?, ?>) BasicHttpAttributes.getRouteMatchInfo(request).get()).getAnnotation(AKHQSecured.class);
-
-                    return HttpResponse.status(HttpStatus.FORBIDDEN)
-                        .body(new JsonError(String.format("Unauthorized: missing permission on resource %s and action %s",
-                            annotation.getValues().get("resource"),
-                            annotation.getValues().get("action"))));
-                }
+                String resource = request.getAttribute("akhq.rejected.resource", String.class).orElse(null);
+                String action = request.getAttribute("akhq.rejected.action", String.class).orElse(null);
+                String message = resource != null && action != null
+                    ? String.format("Unauthorized: missing permission on resource %s and action %s", resource, action)
+                    : "Forbidden: insufficient permissions";
+                return HttpResponse.status(HttpStatus.FORBIDDEN).body(new JsonError(message));
             } else {
                 return HttpResponse.unauthorized().body(new JsonError("User not authenticated or token expired"));
             }

--- a/src/main/java/org/akhq/controllers/ErrorController.java
+++ b/src/main/java/org/akhq/controllers/ErrorController.java
@@ -14,6 +14,7 @@ import io.micronaut.security.authentication.AuthorizationException;
 import io.micronaut.security.rules.SecurityRule;
 import lombok.extern.slf4j.Slf4j;
 import org.akhq.modules.InvalidClusterException;
+import org.akhq.security.rule.AKHQSecurityRule;
 import org.apache.kafka.common.errors.ApiException;
 import org.sourcelab.kafka.connect.apiclient.rest.exceptions.ConcurrentConfigModificationException;
 import org.sourcelab.kafka.connect.apiclient.rest.exceptions.InvalidRequestException;
@@ -80,8 +81,8 @@ public class ErrorController extends AbstractController {
     public HttpResponse<?> error(HttpRequest<?> request, AuthorizationException e) throws URISyntaxException {
         if (request.getUri().toString().startsWith("/api")) {
             if (e.isForbidden()) {
-                String resource = request.getAttribute("akhq.rejected.resource", String.class).orElse(null);
-                String action = request.getAttribute("akhq.rejected.action", String.class).orElse(null);
+                String resource = request.getAttribute(AKHQSecurityRule.REJECTED_RESOURCE, String.class).orElse(null);
+                String action = request.getAttribute(AKHQSecurityRule.REJECTED_ACTION, String.class).orElse(null);
                 String message = resource != null && action != null
                     ? String.format("Unauthorized: missing permission on resource %s and action %s", resource, action)
                     : "Forbidden: insufficient permissions";

--- a/src/main/java/org/akhq/security/rule/AKHQSecurityRule.java
+++ b/src/main/java/org/akhq/security/rule/AKHQSecurityRule.java
@@ -108,8 +108,10 @@ public class AKHQSecurityRule extends AbstractSecurityRule<HttpRequest<?>> {
 
         if (allowed)
             return Flowable.just(SecurityRuleResult.ALLOWED);
-        else
-            return Flowable.just(SecurityRuleResult.REJECTED);
+
+        request.setAttribute("akhq.rejected.resource", optionalResource.get().toString());
+        request.setAttribute("akhq.rejected.action", optionalAction.get().toString());
+        return Flowable.just(SecurityRuleResult.REJECTED);
     }
 
     public static Map<String, List<Group>> unrollGroups(Authentication authentication, ClaimProvider claimProvider) {

--- a/src/main/java/org/akhq/security/rule/AKHQSecurityRule.java
+++ b/src/main/java/org/akhq/security/rule/AKHQSecurityRule.java
@@ -31,6 +31,9 @@ import java.util.stream.Collectors;
 @Slf4j
 @Singleton
 public class AKHQSecurityRule extends AbstractSecurityRule<HttpRequest<?>> {
+    public static final String REJECTED_RESOURCE = "akhq.rejected.resource";
+    public static final String REJECTED_ACTION = "akhq.rejected.action";
+
     private static final ObjectMapper mapper = new ObjectMapper();
     private static final GzipCompressionAlgorithm gzip = new GzipCompressionAlgorithm();
 
@@ -109,8 +112,8 @@ public class AKHQSecurityRule extends AbstractSecurityRule<HttpRequest<?>> {
         if (allowed)
             return Flowable.just(SecurityRuleResult.ALLOWED);
 
-        request.setAttribute("akhq.rejected.resource", optionalResource.get().toString());
-        request.setAttribute("akhq.rejected.action", optionalAction.get().toString());
+        request.setAttribute(REJECTED_RESOURCE, optionalResource.get().toString());
+        request.setAttribute(REJECTED_ACTION, optionalAction.get().toString());
         return Flowable.just(SecurityRuleResult.REJECTED);
     }
 


### PR DESCRIPTION
When an AuthorizationException was thrown for an request the ErrorController attempted to look up the original matched route via `BasicHttpAttributes.getRouteMatchInfo()` to read `@AKHQSecured` annotation values for a detailed 403 response. But by the time the global error handler runs, the route match info is no longer present on the request (possibly due to changes in newer Micronaut version) so the lookup always returned empty. This caused the handler to fall through and return a 307 Redirect instead of a proper 403 forbidden.

**Changes:**
- `AKHQSecurityRule` now stores the rejected resource and action as request attributes before returning REJECTED
- `ErrorController` reads those attributes to build a 403 response body, removing the broken route match lookup

Fixes #2854 #2405