### PR TITLE
fix(deps): force kafka-group-coordinator version to fix NoClassDefFoundError on internal topics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,8 @@ configurations.all {
         force("org.apache.kafka:kafka-metadata:" + kafkaVersion)
         force("org.apache.kafka:kafka-server:" + kafkaVersion)
         force("org.apache.kafka:kafka-raft:" + kafkaVersion)
+        force("org.apache.kafka:kafka-group-coordinator:" + kafkaVersion)
+        force("org.apache.kafka:kafka-group-coordinator-api:" + kafkaVersion)
         force("com.fasterxml.jackson.core:jackson-databind:" + jacksonVersion)
         force("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:" + jacksonVersion)
         force("com.fasterxml.jackson.module:jackson-module-scala_" + kafkaScalaVersion + ":" + jacksonVersion)


### PR DESCRIPTION
Fix the following NoClassDefFoundError when trying to list internal topics or see their content.
This is due to a dependency version conflict on `org.apache.kafka:kafka-group-coordinator`

```
java.lang.NoClassDefFoundError: null
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:483)
	at java.base/java.util.concurrent.ForkJoinTask.getException(ForkJoinTask.java:561)
	at java.base/java.util.concurrent.ForkJoinTask.reportException(ForkJoinTask.java:577)
	at java.base/java.util.concurrent.ForkJoinTask.join(ForkJoinTask.java:667)
	at java.base/java.util.concurrent.ForkJoinTask.invoke(ForkJoinTask.java:681)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateParallel(ForEachOps.java:162)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateParallel(ForEachOps.java:176)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:264)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:632)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:806)
	at org.akhq.repositories.RecordRepository.consumeOldest(RecordRepository.java:149)
	at org.akhq.repositories.RecordRepository.lambda$consume$0(RecordRepository.java:139)
	at org.akhq.utils.Debug.call(Debug.java:67)
	at org.akhq.repositories.RecordRepository.consume(RecordRepository.java:135)
	at org.akhq.controllers.TopicController.data(TopicController.java:238)
	at org.akhq.controllers.$TopicController$Definition$Exec.dispatch(Unknown Source)
	at io.micronaut.context.AbstractExecutableMethodsDefinition$DispatchedExecutableMethod.invokeUnsafe(AbstractExecutableMethodsDefinition.java:461)
	at io.micronaut.context.DefaultBeanContext$BeanContextUnsafeExecutionHandle.invokeUnsafe(DefaultBeanContext.java:4454)
	at io.micronaut.web.router.AbstractRouteMatch.execute(AbstractRouteMatch.java:272)
	at io.micronaut.web.router.DefaultUriRouteMatch.execute(DefaultUriRouteMatch.java:38)
	at io.micronaut.http.server.RouteExecutor.executeRouteAndConvertBody(RouteExecutor.java:466)
	at io.micronaut.http.server.RouteExecutor.lambda$callRoute$5(RouteExecutor.java:443)
	at io.micronaut.core.execution.ExecutionFlow.lambda$async$0(ExecutionFlow.java:92)
	at io.micronaut.core.propagation.PropagatedContext.lambda$wrap$3(PropagatedContext.java:232)
	at java.base/java.util.concurrent.ThreadPerTaskExecutor$TaskRunner.run(ThreadPerTaskExecutor.java:291)
	at java.base/java.lang.VirtualThread.run(VirtualThread.java:456)
Caused by: java.lang.NoClassDefFoundError: org/apache/kafka/common/protocol/MessageContext
	at org.apache.kafka.coordinator.group.generated.OffsetCommitValue.<init>(OffsetCommitValue.java:106)
	at kafka.coordinator.group.GroupMetadataManager$.readOffsetMessageValue(GroupMetadataManager.scala:1173)
	at kafka.coordinator.group.GroupMetadataManager.readOffsetMessageValue(GroupMetadataManager.scala)
	at org.akhq.models.Record.convertToString(Record.java:244)
	at org.akhq.models.Record.getValue(Record.java:176)
	at org.akhq.repositories.RecordRepository.filterMessageLength(RecordRepository.java:1387)
	at org.akhq.repositories.RecordRepository.lambda$consumeOldest$0(RecordRepository.java:172)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:186)
	at java.base/java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1859)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
	at java.base/java.util.stream.ForEachOps$ForEachTask.compute(ForEachOps.java:293)
	at java.base/java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:759)
	at java.base/java.util.concurrent.ForkJoinTask.doExec$$$capture(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
Caused by: java.lang.ClassNotFoundException: org.apache.kafka.common.protocol.MessageContext
	... 17 common frames omitted
```