### PR TITLE
feat(cicd): remove legacy helm release action and PAT references

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - dev
-    tags:
-      - '*'
+  release:
+    types: [released]
 
 jobs:
   check:
@@ -40,15 +40,15 @@ jobs:
           cp LICENSE helm/akhq/LICENSE
           cp README.md helm/akhq/README.md
 
-      # Helm charts - only release on tag push
+      # Helm charts - only release on GitHub release creation
       - name: Configure Git
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'release'
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'release'
         uses: helm/chart-releaser-action@v1
         with:
           charts_dir: helm

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,11 +4,15 @@ on:
   push:
     branches:
       - dev
+    tags:
+      - '*'
 
 jobs:
   check:
     name: Docs
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v6
@@ -36,12 +40,21 @@ jobs:
           cp LICENSE helm/akhq/LICENSE
           cp README.md helm/akhq/README.md
 
-      # Helm charts
-      - uses: J12934/helm-gh-pages-action@master
+      # Helm charts - only release on tag push
+      - name: Configure Git
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: helm/chart-releaser-action@v1
         with:
-          access-token: ${{ secrets.GITHUB_PERSONAL_TOKEN }}
-          charts-folder: "helm"
-          deploy-branch: helm
+          charts_dir: helm
+          pages_branch: helm
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       # Clone helm charts
       - name: Clone helm charts
@@ -60,7 +73,7 @@ jobs:
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
         with:
-          personal_token: ${{ secrets.GITHUB_PERSONAL_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/.vuepress/dist/
 
       # Slack

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           charts_dir: helm
           pages_branch: helm
+          mark_as_latest: false
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/helm/akhq/Chart.yaml
+++ b/helm/akhq/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "0.27.0"
 description: Kafka GUI for Apache Kafka to manage topics, topics data, consumers group, schema registry, connect and more...
 name: akhq

--- a/helm/akhq/Chart.yaml
+++ b/helm/akhq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "0.27.0"
-description: Kafka GUI for Apache Kafka to manage topics, topics data, consumers group, schema registry, connect and more...
+description: Helm chart for AKHQ, the Kafka GUI for Apache Kafka to manage topics, topics data, consumers group, schema registry, connect and more...
 name: akhq
 version: 0.27.0
 keywords:


### PR DESCRIPTION
- Remove the legacy J12934/helm-gh-pages-action action
  * Use helm/chart-releaser-action instead
  * Trigger only after release
  * Set mark_as_latest to false to always highlight the AKHQ release (and not the chart release)
- Remove references to the GITHUB_PERSONAL_TOKEN personal access token