### PR TITLE
feat(helm): add support for HTTPRoute and GKE HealthCheckPolicy

### DIFF
--- a/helm/akhq/templates/healthcheckpolicy.yaml
+++ b/helm/akhq/templates/healthcheckpolicy.yaml
@@ -11,18 +11,18 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   default:
-    checkIntervalSec: 5
+    checkIntervalSec: {{ .Values.gke.healthCheckPolicy.checkIntervalSec }}
     config:
       httpHealthCheck:
         port: {{ .Values.service.managementPort }}
         portSpecification: USE_FIXED_PORT
         requestPath: /health
       type: HTTP
-    healthyThreshold: 1
+    healthyThreshold: {{ .Values.gke.healthCheckPolicy.healthyThreshold }}
     logConfig:
       enabled: true
-    timeoutSec: 5
-    unhealthyThreshold: 2
+    timeoutSec: {{ .Values.gke.healthCheckPolicy.timeoutSec }}
+    unhealthyThreshold: {{ .Values.gke.healthCheckPolicy.unhealthyThreshold }}
   targetRef:
     group: ""
     kind: Service

--- a/helm/akhq/templates/healthcheckpolicy.yaml
+++ b/helm/akhq/templates/healthcheckpolicy.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.gke .Values.gke.healthCheckPolicy.enabled }}
+{{- $fullName := include "akhq.fullname" . -}}
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "akhq.name" . }}
+    helm.sh/chart: {{ include "akhq.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  default:
+    checkIntervalSec: 5
+    config:
+      httpHealthCheck:
+        port: {{ .Values.service.managementPort }}
+        portSpecification: USE_FIXED_PORT
+        requestPath: /health
+      type: HTTP
+    healthyThreshold: 1
+    logConfig:
+      enabled: true
+    timeoutSec: 5
+    unhealthyThreshold: 2
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ $fullName }}
+{{- end }}

--- a/helm/akhq/templates/httproute.yaml
+++ b/helm/akhq/templates/httproute.yaml
@@ -1,0 +1,46 @@
+{{- if and .Values.httpRoute.enabled .Values.service.enabled -}}
+{{- $fullName := include "akhq.fullname" . -}}
+{{- $httpRoutePaths := .Values.httpRoute.paths -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "akhq.name" . }}
+    helm.sh/chart: {{ include "akhq.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- range $key, $value := .Values.httpRoute.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.httpRoute.hostnames }}
+  hostnames:
+  {{- range .Values.httpRoute.hostnames }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  parentRefs:
+  {{- toYaml .Values.httpRoute.parentRefs | nindent 2 }}
+  rules:
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: {{ $fullName }}
+      port: {{ .Values.service.port }}
+      weight: 100
+    {{- if .Values.httpRoute.filters }}
+    filters:
+    {{- toYaml .Values.httpRoute.filters | nindent 4 }}
+    {{- end }}
+    matches:
+    {{- range $httpRoutePaths }}
+    - path:
+        type: {{ $.Values.httpRoute.pathType | default "PathPrefix" }}
+        value: {{ . }}
+    {{- end }}
+{{- end }}

--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -222,3 +222,7 @@ networkPolicy:
 gke:
   healthCheckPolicy:
     enabled: false
+    checkIntervalSec: 5
+    timeoutSec: 5
+    healthyThreshold: 1
+    unhealthyThreshold: 2

--- a/helm/akhq/values.yaml
+++ b/helm/akhq/values.yaml
@@ -153,6 +153,28 @@ ingress:
   #    hosts:
   #      - akhq.demo.com
 
+httpRoute:
+  enabled: false
+  annotations: {}
+  labels: {}
+  paths:
+    - /
+  pathType: "PathPrefix"
+  hostnames:
+    - akhq.demo.com
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-name
+      namespace: gateway-namespace
+  filters: []
+  # Example filters:
+  # - type: RequestHeaderModifier
+  #   requestHeaderModifier:
+  #     add:
+  #       - name: X-Custom-Header
+  #         value: custom-value
+
 ### Readiness / Liveness probe config.
 ### ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
 readinessProbe:
@@ -196,3 +218,7 @@ affinity: {}
 networkPolicy:
   enabled: true
   labels: {}
+
+gke:
+  healthCheckPolicy:
+    enabled: false


### PR DESCRIPTION
This PR introduces two significant enhancements to the AKHQ Helm chart, improving traffic routing and health check management for Kubernetes deployments:

**1. Kubernetes Gateway API HTTPRoute Support:**
*   Adds a new `helm/akhq/templates/httproute.yaml` template to enable the creation of `HTTPRoute` resources.
*   `HTTPRoute` is part of the Kubernetes Gateway API, offering a more powerful, extensible, and vendor-agnostic way to manage ingress traffic compared to the older Ingress API.
*   This feature allows users to define advanced routing rules, traffic splitting, and more granular control over external access to AKHQ.
*   **Configuration:** Configurable via the new `httpRoute` section in `values.yaml`.
*   **Status:** Disabled by default (`httpRoute.enabled: false`).

**2. GKE-specific HealthCheckPolicy Support:**
*   Adds a new `helm/akhq/templates/healthcheckpolicy.yaml` template for Google Kubernetes Engine (GKE) users.
*   This feature allows for the creation of a `HealthCheckPolicy` resource (`networking.gke.io/v1`), providing native GKE health check configurations for improved reliability and
integration with GKE's load balancers.
*   **Configuration:** Configurable via the new `gke.healthCheckPolicy` section in `values.yaml`.
*   **Status:** Disabled by default (`gke.healthCheckPolicy.enabled: false`).

**Motivation:**
These additions provide more modern and flexible options for deploying and operating AKHQ in Kubernetes environments, especially for users leveraging the Gateway API or running on GKE. By
keeping them disabled by default, we ensure no breaking changes for existing deployments.

**Chart Versioning:**
I have not bumped the Helm chart version in this PR. I would appreciate guidance from the maintainers on the appropriate version increment (e.g., patch or minor) given these new features.
Please let me know your preference in the PR discussion.

**Checklist for Reviewers:**
*   Review `helm/akhq/templates/httproute.yaml` for correct `HTTPRoute` implementation.
*   Review `helm/akhq/templates/healthcheckpolicy.yaml` for correct `HealthCheckPolicy` implementation.
*   Review `helm/akhq/values.yaml` for the new `httpRoute` and `gke.healthCheckPolicy` configuration options and their default values.