### PR TITLE
feat(topic): add per-cluster topic aliases

### DIFF
--- a/application.example.yml
+++ b/application.example.yml
@@ -113,6 +113,9 @@ akhq:
         topic-data:
           sort: NEWEST # default sort order (OLDEST, NEWEST) (default: OLDEST).  Overrides default
           date-time-format: ISO # format of message timestamps (RELATIVE, ISO) (default: RELATIVE)
+        topic-aliases: # optional human-readable display names for technical topic names
+          org.company.billing.events.v2: "Billing Events"
+          1de5cb5d-9f92-4ff8-bda2-084158c0cd06: "Payment Transactions"
 
     my-cluster-ssl:
       properties:

--- a/client/src/containers/Topic/TopicList/TopicList.jsx
+++ b/client/src/containers/Topic/TopicList/TopicList.jsx
@@ -268,9 +268,11 @@ class TopicList extends Root {
     };
 
     topics.forEach(topic => {
+      const displayName = topic.alias?.trim() || topic.name;
       tableTopics[topic.name] = {
         id: topic.name,
-        name: topic.name,
+        name: displayName,
+        realName: displayName !== topic.name ? topic.name : null,
         count: topic.size,
         lastWrite: undefined,
         size: showBytes(topic.logDirSize),
@@ -402,7 +404,13 @@ class TopicList extends Root {
         id: 'name',
         accessor: 'name',
         colName: 'Name',
-        type: 'text'
+        type: 'text',
+        cell: (obj, col) => (
+          <span>
+            {obj[col.accessor]}
+            {obj.realName && <><br /><small className="text-muted">{obj.realName}</small></>}
+          </span>
+        )
       },
       {
         id: 'count',

--- a/client/src/containers/Topic/TopicList/TopicList.test.jsx
+++ b/client/src/containers/Topic/TopicList/TopicList.test.jsx
@@ -1,0 +1,108 @@
+/*eslint-disable*/
+import React from 'react';
+import { describe, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import TopicList from './TopicList';
+
+// vi.hoisted ensures the mock reference is available inside the vi.mock factory
+const mockGet = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../prefix', () => ({ default: () => '' }));
+
+vi.mock('react-router-dom', () => ({
+  useLocation: vi.fn(() => ({ search: '', pathname: '/ui/test/topic' })),
+  useNavigate: vi.fn(() => vi.fn()),
+  useNavigationType: vi.fn(() => 'PUSH'),
+  useParams: () => ({ clusterId: 'test-cluster' }),
+  Link: ({ children }) => children
+}));
+
+vi.mock('axios', async importActual => {
+  const mod = await importActual();
+  return {
+    ...mod,
+    default: {
+      ...mod.default,
+      isCancel: () => true,
+      CancelToken: { source: () => ({ token: 'mock-token', cancel: vi.fn() }) }
+    }
+  };
+});
+
+// Skip consumer groups and last record to avoid extra API calls in tests
+vi.mock('../../../utils/functions', () => ({
+  getClusterUIOptions: vi.fn().mockResolvedValue({
+    topic: { skipConsumerGroups: true, skipLastRecord: true },
+    topicData: {}
+  })
+}));
+
+vi.mock('../../../utils/api', () => ({
+  get: mockGet,
+  put: vi.fn(),
+  post: vi.fn(),
+  remove: vi.fn()
+}));
+
+const ALIASED_TOPIC = {
+  name: 'technical.topic.name',
+  alias: 'Human Readable',
+  size: 0,
+  logDirSize: null,
+  partitions: [],
+  replicaCount: 1,
+  inSyncReplicaCount: 1,
+  internal: false
+};
+
+const PLAIN_TOPIC = {
+  name: 'plain-topic',
+  alias: null,
+  size: 0,
+  logDirSize: null,
+  partitions: [],
+  replicaCount: 1,
+  inSyncReplicaCount: 1,
+  internal: false
+};
+
+function makeTopicsResponse(topics) {
+  return { data: { results: topics, page: 1, pageSize: 25 } };
+}
+
+describe('TopicList alias rendering', () => {
+  beforeEach(() => {
+    sessionStorage.setItem('roles', JSON.stringify({ TOPIC: ['READ'], TOPIC_DATA: [] }));
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('shows alias as primary name and real name as secondary when alias is set', async ({ expect }) => {
+    mockGet.mockResolvedValue(makeTopicsResponse([ALIASED_TOPIC]));
+
+    render(<TopicList />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Human Readable')).toBeTruthy();
+      expect(screen.getByText('technical.topic.name', { selector: 'small' })).toBeTruthy();
+    }, { timeout: 3000 });
+  });
+
+  it('shows only the real topic name when no alias is configured', async ({ expect }) => {
+    mockGet.mockResolvedValue(makeTopicsResponse([PLAIN_TOPIC]));
+
+    render(<TopicList />);
+
+    await waitFor(() => {
+      expect(screen.getByText('plain-topic')).toBeTruthy();
+    }, { timeout: 3000 });
+
+    expect(screen.queryByRole('cell', { name: /plain-topic/i })).toBeTruthy();
+    // No <small> elements should appear for topics without an alias
+    const smalls = screen.queryAllByText('plain-topic', { selector: 'small' });
+    expect(smalls.length).toBe(0);
+  });
+});

--- a/docs/docs/configuration/akhq.md
+++ b/docs/docs/configuration/akhq.md
@@ -32,6 +32,19 @@ These parameters are the default values used in the topic creation page.
 * `akhq.ui-options.topic.show-all-consumer-groups` expand lists of consumer groups on topic list
 * `akhq.ui-options.topic.groups-default-view` is the default consumer groups list view on topic screen/consumer groups tab (ALL, HIDE_EMPTY) (default: ALL). HIDE_EMPTY increases performance, especially on cluster with a lot of consumer groups
 
+### Topic Aliases
+* `akhq.connections.<cluster>.ui-options.topic-aliases` is a per-cluster map of Kafka topic name to human-readable alias. The alias is shown as the primary name in the topic list, with the real topic name displayed below in muted text. Search works on both the alias and the real topic name.
+
+```yaml
+akhq:
+  connections:
+    my-cluster:
+      ui-options:
+        topic-aliases:
+          org.company.billing.events.v2: "Billing Events"
+          1de5cb5d-9f92-4ff8-bda2-084158c0cd06: "Payment Transactions"
+```
+
 ### Topic Data
 * `akhq.ui-options.topic-data.sort`: default sort order (OLDEST, NEWEST) (default: OLDEST)
 

--- a/docs/docs/configuration/brokers.md
+++ b/docs/docs/configuration/brokers.md
@@ -22,6 +22,8 @@
     * `url`: ksqlDB url
     * `basic-auth-username`: ksqlDB basic auth username
     * `basic-auth-password`: ksqlDB basic auth password
+  * `ui-options`: *(optional)* per-cluster UI overrides
+    * `topic-aliases`: *(optional)* map of Kafka topic name to human-readable alias, see [Topic Aliases](akhq.md#topic-aliases)
 
 ## Basic cluster with plain auth
 

--- a/src/main/java/org/akhq/configs/Connection.java
+++ b/src/main/java/org/akhq/configs/Connection.java
@@ -10,6 +10,7 @@ import lombok.Data;
 import lombok.Getter;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -68,6 +69,9 @@ public class Connection extends AbstractProperties {
 
         @ConfigurationBuilder(configurationPrefix = "topic-data")
         private UiOptionsTopicData topicData = new UiOptionsTopicData();
+
+        @MapFormat(transformation = MapFormat.MapTransformation.FLAT)
+        private Map<String, String> topicAliases = new HashMap<>();
     }
 
     public UiOptions mergeOptions(UIOptions defaultOptions) {
@@ -85,6 +89,8 @@ public class Connection extends AbstractProperties {
             StringUtils.isNotEmpty(this.uiOptions.topicData.getSort()) ? this.uiOptions.topicData.getSort() : defaultOptions.getTopicData().getSort(),
             this.uiOptions.topicData.getDateTimeFormat()
         );
+
+        options.topicAliases = this.uiOptions.topicAliases;
 
         return options;
     }

--- a/src/main/java/org/akhq/models/Topic.java
+++ b/src/main/java/org/akhq/models/Topic.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 public class Topic {
     private String name;
+    private String alias;
     private boolean internal;
     @JsonIgnore
     private boolean configInternal;
@@ -35,10 +36,12 @@ public class Topic {
         List<LogDir> logDirs,
         List<Partition.Offsets> offsets,
         boolean configInternal,
-        boolean configStream
+        boolean configStream,
+        String alias
     ) {
         this.name = description.name();
         this.internal = description.isInternal();
+        this.alias = alias;
 
         this.configInternal = configInternal;
         this.configStream = configStream;

--- a/src/main/java/org/akhq/repositories/TopicRepository.java
+++ b/src/main/java/org/akhq/repositories/TopicRepository.java
@@ -11,6 +11,8 @@ import org.akhq.modules.AbstractKafkaWrapper;
 import org.akhq.utils.PagedList;
 import org.akhq.utils.Pagination;
 
+import org.akhq.configs.Connection;
+
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.*;
@@ -32,6 +34,9 @@ public class TopicRepository extends AbstractRepository {
 
     @Inject
     private ApplicationContext applicationContext;
+
+    @Inject
+    private List<Connection> connections;
 
     @Value("${akhq.topic.internal-regexps}")
     protected List<String> internalRegexps;
@@ -61,7 +66,7 @@ public class TopicRepository extends AbstractRepository {
         return kafkaWrapper.listTopics(clusterId)
             .stream()
             .map(TopicListing::name)
-            .filter(name -> isSearchMatch(search, name) && isMatchRegex(filters, name))
+            .filter(name -> (isSearchMatch(search, name) || isSearchMatch(search, getAlias(clusterId, name).orElse(""))) && isMatchRegex(filters, name))
             .filter(name -> isListViewMatch(view, name))
             .sorted(Comparator.comparing(String::toLowerCase))
             .collect(Collectors.toList());
@@ -99,7 +104,8 @@ public class TopicRepository extends AbstractRepository {
                         logDirRepository.findByTopic(clusterId, description.getValue().name()),
                         topicOffsets.get(description.getValue().name()),
                         isInternal(description.getValue().name()),
-                        isStream(description.getValue().name())
+                        isStream(description.getValue().name()),
+                        getAlias(clusterId, description.getValue().name()).orElse(null)
                     )
                 );
         }
@@ -139,5 +145,12 @@ public class TopicRepository extends AbstractRepository {
         }, delay = "${akhq.topic.retry.topic-exists.delay:3s}")
     void checkIfTopicExists(String clusterId, String name) throws ExecutionException {
         kafkaWrapper.describeTopics(clusterId, Collections.singletonList(name));
+    }
+
+    private Optional<String> getAlias(String clusterId, String topicName) {
+        return connections.stream()
+            .filter(c -> c.getName().equals(clusterId))
+            .findFirst()
+            .map(c -> c.getUiOptions().getTopicAliases().get(topicName));
     }
 }

--- a/src/test/java/org/akhq/repositories/TopicRepositoryTest.java
+++ b/src/test/java/org/akhq/repositories/TopicRepositoryTest.java
@@ -23,6 +23,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
+import com.google.common.collect.ImmutableMap;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -32,11 +34,25 @@ import java.util.function.Predicate;
 
 import static org.akhq.controllers.TopicControllerTest.CREATE_TOPIC_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(KafkaClusterExtension.class)
 class TopicRepositoryTest extends AbstractTest {
+
+    static final String TOPIC_RANDOM_ALIAS = "Random Topic Alias";
+
+    @Override
+    public Map<String, String> getProperties() {
+        return ImmutableMap.<String, String>builder()
+            .putAll(super.getProperties())
+            .put(
+                "akhq.connections." + KafkaTestCluster.CLUSTER_ID + ".ui-options.topic-aliases." + KafkaTestCluster.TOPIC_RANDOM,
+                TOPIC_RANDOM_ALIAS
+            )
+            .build();
+    }
 
     @Inject
     @InjectMocks
@@ -210,6 +226,32 @@ class TopicRepositoryTest extends AbstractTest {
                 // Ignore if topic doesn't exist
             }
         }
+    }
+
+    @Test
+    void aliasIsEnrichedOnTopic() throws ExecutionException, InterruptedException {
+        Topic topic = topicRepository.findByName(KafkaTestCluster.CLUSTER_ID, KafkaTestCluster.TOPIC_RANDOM);
+        assertEquals(TOPIC_RANDOM_ALIAS, topic.getAlias());
+    }
+
+    @Test
+    void aliasIsNullWhenNotConfigured() throws ExecutionException, InterruptedException {
+        Topic topic = topicRepository.findByName(KafkaTestCluster.CLUSTER_ID, KafkaTestCluster.TOPIC_COMPACTED);
+        assertNull(topic.getAlias());
+    }
+
+    @Test
+    void searchByAlias() throws ExecutionException, InterruptedException {
+        // "Alias" only appears in the configured alias, not in any real topic name,
+        // so this search can only match via the alias path.
+        List<String> results = topicRepository.all(
+            KafkaTestCluster.CLUSTER_ID,
+            TopicRepository.TopicListView.ALL,
+            Optional.of("Alias"),
+            List.of()
+        );
+        assertEquals(1, results.size());
+        assertEquals(KafkaTestCluster.TOPIC_RANDOM, results.get(0));
     }
 
     private void mockApplicationContext() {

--- a/src/test/java/org/akhq/utils/MaskerTestHelper.java
+++ b/src/test/java/org/akhq/utils/MaskerTestHelper.java
@@ -18,7 +18,8 @@ class MaskerTestHelper {
                 List.of(),
                 List.of(),
                 true,
-                true
+                true,
+                null
             )
         );
         record.setKey(key);


### PR DESCRIPTION
## Summary

Adds support for configuring human-readable display names (aliases) for Kafka topic names on a per-cluster basis.
<img width="334" height="216" alt="topic-alias" src="https://github.com/user-attachments/assets/53cbc58c-c2d1-4a6f-a0e8-1eac6fc453df" />


- Aliases are configured under `akhq.connections.<cluster>.ui-options.topic-aliases` as a flat map of topic name → alias
- In the topic list, the alias is shown as the primary name with the real topic name displayed below in muted text
- Search works on both the alias and the real topic name
- Useful when topic names are UUIDs or overly technical internal identifiers

## Configuration

```yaml
akhq:
  connections:
    my-cluster:
      ui-options:
        topic-aliases:
          org.company.billing.events.v2: "Billing Events"
          1de5cb5d-9f92-4ff8-bda2-084158c0cd06: "Payment Transactions"
```

## Changes

- `Connection.java`: added `topicAliases` map to `UiOptions` with `@MapFormat(FLAT)` to preserve dots in topic names as literal key characters
- `Topic.java`: added `alias` as a constructor parameter
- `TopicRepository.java`: enriches each topic with its alias; alias is also matched during search
- `TopicList.jsx`: renders alias as primary name with real name below in `<small>` muted text
- Docs updated in `docs/docs/configuration/akhq.md` and `docs/docs/configuration/brokers.md`