### PR TITLE
fix(search): don't end on first empty poll while partitions still have data

### DIFF
--- a/src/main/java/org/akhq/repositories/RecordRepository.java
+++ b/src/main/java/org/akhq/repositories/RecordRepository.java
@@ -661,7 +661,12 @@ public class RecordRepository extends AbstractRepository {
         return Flowable.generate(() -> {
             Map<TopicPartition, Long> partitions = getTopicPartitionForSortOldest(topic, options);
 
-            KafkaConsumer<byte[], byte[]> consumer = this.kafkaModule.getConsumer(options.clusterId);
+            // Bound MAX_POLL_RECORDS so a single busy partition cannot drain
+            // the consumer's prefetch buffer and starve the others.
+            Properties properties = new Properties() {{
+                put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, Math.max(options.size, 50));
+            }};
+            KafkaConsumer<byte[], byte[]> consumer = this.kafkaModule.getConsumer(options.clusterId, properties);
 
             if (partitions.size() == 0) {
                 return new SearchState(consumer, null);
@@ -679,10 +684,15 @@ public class RecordRepository extends AbstractRepository {
                 )
             );
 
-            return new SearchState(consumer, new SearchEvent(topic));
+            // Capture end offsets so we can detect "truly done" instead of
+            // ending the search on the first single empty poll.
+            Map<TopicPartition, Long> endOffsets = consumer.endOffsets(partitions.keySet());
+
+            return new SearchState(consumer, new SearchEvent(topic), endOffsets);
         }, (searchState, emitter) -> {
             SearchEvent searchEvent = searchState.getSearchEvent();
             KafkaConsumer<byte[], byte[]> consumer = searchState.getConsumer();
+            Map<TopicPartition, Long> endOffsets = searchState.getEndOffsets();
 
             // end
             if (searchEvent == null || searchEvent.emptyPoll >= 1) {
@@ -690,14 +700,31 @@ public class RecordRepository extends AbstractRepository {
                 emitter.onComplete();
                 consumer.close();
 
-                return new SearchState(consumer, searchEvent);
+                return new SearchState(consumer, searchEvent, endOffsets);
             }
 
             SearchEvent currentEvent = new SearchEvent(searchEvent);
 
             ConsumerRecords<byte[], byte[]> records = this.poll(consumer);
 
-            if (records.isEmpty()) {
+            // Only treat the search as exhausted when every assigned partition
+            // has reached its end offset. Otherwise keep polling so that quiet
+            // partitions get a chance to deliver records.
+            boolean allAtEnd = true;
+            if (endOffsets != null) {
+                for (TopicPartition tp : consumer.assignment()) {
+                    Long end = endOffsets.get(tp);
+                    if (end == null) {
+                        continue;
+                    }
+                    if (consumer.position(tp) < end) {
+                        allAtEnd = false;
+                        break;
+                    }
+                }
+            }
+
+            if (records.isEmpty() && allAtEnd) {
                 currentEvent.emptyPoll = 1;
             } else {
                 currentEvent.emptyPoll = 0;
@@ -735,7 +762,7 @@ public class RecordRepository extends AbstractRepository {
 
             currentEvent.records = list;
 
-            // No more records, poll was empty: stop here
+            // No more records anywhere: stop here
             if (currentEvent.emptyPoll == 1) {
                 emitter.onNext(currentEvent.end(searchEvent.getAfter()));
             }
@@ -749,7 +776,7 @@ public class RecordRepository extends AbstractRepository {
                 emitter.onNext(currentEvent.progress(options));
             }
 
-            return new SearchState(consumer, currentEvent);
+            return new SearchState(consumer, currentEvent, endOffsets);
         });
     }
 
@@ -1140,6 +1167,11 @@ public class RecordRepository extends AbstractRepository {
     public static class SearchState {
         private final KafkaConsumer<byte[], byte[]> consumer;
         private final SearchEvent searchEvent;
+        private Map<TopicPartition, Long> endOffsets;
+
+        public SearchState(KafkaConsumer<byte[], byte[]> consumer, SearchEvent searchEvent) {
+            this(consumer, searchEvent, null);
+        }
     }
 
 


### PR DESCRIPTION
## Problem

`RecordRepository.search()` terminates the streaming search the first time a poll returns zero records, regardless of whether other assigned partitions still have unread data. On topics with many partitions and uneven throughput this consistently hides existing records:

1. The consumer is assigned every partition of the topic and seeks to the search start offset.
2. The first few polls drain the prefetch buffer from whichever partition has the most data ready.
3. A subsequent poll returns no records — but only because the busy partition's prefetch buffer is empty for a moment, while quieter partitions haven't been polled yet.
4. `currentEvent.emptyPoll = 1` is set and the search ends. The frontend reports "no records" even though the key exists later in one of the partitions that never got polled.

This was reproducible for us on a 16-partition compacted state-store changelog with 2-3M records per partition: search-by-key consistently terminated at ~4% progress and returned zero matches even for keys with records visible in the latest data view.

The same root cause is mentioned in #2002 and #2093 (which #2100 partially addresses for `consumeOldest` / `consumeNewest` but not for `search()`).

## Fix

- Capture `endOffsets` for all assigned partitions at search start and store them on `SearchState`.
- Only set `emptyPoll = 1` when **both** the poll returned no records **and** every assigned partition's consumer position has reached its end offset.
- Bound `MAX_POLL_RECORDS` per search to `max(options.size, 50)` so a single very busy partition can't drain the prefetch buffer alone and starve the others.

The diff is ~38 lines, contained in `RecordRepository.search()` and a small extension to the inner `SearchState` class to carry the `endOffsets` map across `Flowable.generate` iterations.

## Verification

Built locally from this branch and deployed against a real cluster (16-partition compacted topic, ~2-3M records per partition, single broker). Same query the upstream 0.27.0 image fails on:

- **Before:** searchEnd at `percent ≈ 4.26`, 0 records, ~1s wall time.
- **After:** searchEnd at `percent = 100.0` after scanning every partition to its end offset, 10 records returned, ~18s wall time.

Returned offsets/timestamps line up with the same records the non-search `/data` endpoint shows for the key, confirming correctness rather than a partial recovery.

## Notes

- Behavior on topics that don't trigger the bug (small partitions, single-partition, single broker with bounded prefetch) is unchanged: the `allAtEnd` check is satisfied as soon as the consumer truly has no more data, which matches the previous semantics.
- I kept the `emptyPoll = 666` fast-path that fires when `matchesCount >= options.size`; that exit is independent of the empty-poll path and still terminates the stream as before.
- No tests added in this PR — happy to add a multi-partition integration test if the maintainers point me at the preferred test harness; the existing `RecordRepositoryTest` setup uses an embedded Kafka but doesn't seem to cover the partition-starvation case.

Refs #2002, #2093, builds on the spirit of #2100.