### PR TITLE
fix(deps): exclude log4j-core and confluent-log4j2-extensions to resolve NonUniqueBeanException

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ configurations.all {
     exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j2-impl'
     exclude group: 'org.apache.logging.log4j', module: 'log4j-to-slf4j'
     exclude group: 'org.slf4j', module: 'slf4j-reload4j'
+    exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
+    exclude group: 'org.apache.logging.log4j', module: 'log4j-1.2-api'
+    exclude group: 'io.confluent', module: 'confluent-log4j2-extensions'
     // Exclude legacy org.lz4 provider so we can consistently use the relocated at.yawk.lz4
     exclude group: 'org.lz4', module: 'lz4-java'
     // Explicitly exclude missing Confluent telemetry modules from all configurations


### PR DESCRIPTION
Fixes #3008 

## Problem
Calling /loggers endpoint returns HTTP 500:
NonUniqueBeanException: Multiple possible bean candidates found:
[LogbackLoggingSystem, Log4jLoggingSystem]

## Root Cause
io.confluent:confluent-log4j2-extensions:8.1.1 transitively pulls 
log4j-core onto the classpath, activating Log4jLoggingSystem bean 
alongside LogbackLoggingSystem causing the conflict.

## Fix
Exclude confluent-log4j2-extensions, log4j-core and log4j-1.2-api 
from configurations.all in build.gradle

## Tested
- Dependency tree shows log4j-core no longer present
- Server starts cleanly with no NonUniqueBeanException