### PR TITLE
chore(deps): force vulnerable transitive deps to patched versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,19 @@ configurations.all {
         force("com.fasterxml.jackson.core:jackson-databind:" + jacksonVersion)
         force("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:" + jacksonVersion)
         force("com.fasterxml.jackson.module:jackson-module-scala_" + kafkaScalaVersion + ":" + jacksonVersion)
+
+        // Security CVE fixes (forced transitive bumps)
+        force("ch.qos.logback:logback-core:1.5.25")
+        force("ch.qos.logback:logback-classic:1.5.25")
+        force("io.netty:netty-codec-http:4.2.11.Final")
+        force("io.netty:netty-codec-http2:4.2.11.Final")
+        force("io.vertx:vertx-core:4.5.24")
+        force("org.apache.logging.log4j:log4j-core:2.25.4")
+        force("org.apache.logging.log4j:log4j-1.2-api:2.25.4")
+        force("org.codehaus.plexus:plexus-utils:3.6.1")
+        force("commons-beanutils:commons-beanutils:1.11.0")
+        force("org.eclipse.jetty:jetty-http:12.1.7")
+        force("org.eclipse.jetty:jetty-server:12.1.7")
     }
 }
 


### PR DESCRIPTION
## Summary

  Forces 11 transitive dependencies to versions that resolve published CVEs.
  All bumps are within-major patch/minor; no public API or behavior changes.

  | Dependency | Current (transitive) | Bumped to | CVE(s) |
  |---|---|---|---|
  | `ch.qos.logback:logback-core` / `logback-classic` | 1.5.19 | 1.5.25 | CVE-2026-1225 |
  | `io.netty:netty-codec-http` | 4.2.9.Final | 4.2.11.Final | CVE-2026-33870 |
  | `io.vertx:vertx-core` | 4.5.22 | 4.5.24 | CVE-2026-1002 | 
  | `org.apache.logging.log4j:log4j-core` | 2.25.2 | 2.25.4 | CVE-2025-68161, CVE-2026-34477/8/80 |
  | `org.apache.logging.log4j:log4j-1.2-api` | 2.25.2 | 2.25.4 | CVE-2026-34479 |
  | `org.codehaus.plexus:plexus-utils` | 3.5.1 | 3.6.1 | CVE-2025-67030 |
  | `commons-beanutils:commons-beanutils` | 1.9.4 | 1.11.0 | CVE-2025-48734 |
  | `org.eclipse.jetty:jetty-http` | 12.1.2 | 12.1.7 | CVE-2025-11143, CVE-2026-2332 |
  | `org.eclipse.jetty:jetty-server` | 12.1.2 | 12.1.7 | CVE-2026-1605 |
  
  
  ## Out of scope
  
  - `jackson-core` 2.20.0 → 2.21.1 (GHSA-72hv-8253-57qq, async JSON parser
    DoS) is intentionally **not** included — bumping it broke JSON serialization
    in the UI in local testing, likely needing a coordinated Micronaut
    upgrade. Worth a separate PR.
    
  ## Test plan
  
  - [x] `./gradlew check` passes — 286 tests, 0 failures, 0 errors, 5 skipped
  - [x] Runtime smoke test: backend boots, connects to Kafka, serves API
  - [ ] CI green
