### PR TITLE
fix(auth): move blocking claim provider call off Netty event loop in HeaderAuthenticationFetcher

### DIFF
--- a/src/main/java/org/akhq/security/authentication/HeaderAuthenticationFetcher.java
+++ b/src/main/java/org/akhq/security/authentication/HeaderAuthenticationFetcher.java
@@ -11,6 +11,7 @@ import io.micronaut.security.filters.AuthenticationFetcher;
 import io.micronaut.security.rules.SecurityRule;
 import io.micronaut.security.token.config.TokenConfiguration;
 import io.reactivex.Flowable;
+import io.reactivex.schedulers.Schedulers;
 import lombok.extern.slf4j.Slf4j;
 import org.akhq.configs.security.HeaderAuth;
 import org.akhq.models.security.ClaimRequest;
@@ -109,6 +110,7 @@ public class HeaderAuthenticationFetcher implements AuthenticationFetcher<HttpRe
                 return Optional.of(claimProvider.generateClaim(claim));
 
             })
+            .subscribeOn(Schedulers.io())
             .switchMap(t -> {
                 if (t.isPresent()) {
                     return Flowable.just(new ServerAuthentication(


### PR DESCRIPTION
## Problem

When using `akhq.security.rest` (REST API claim provider) with header authentication, every request causes a 500 error:

```
java.lang.IllegalStateException: block()/blockFirst()/blockLast() are blocking, which is not supported in thread default-eventLoopGroup-2-1
```

## Root Cause

`HeaderAuthenticationFetcher.fetchAuthentication()` wraps the `claimProvider.generateClaim()` call in `Flowable.fromCallable()`, which executes on the subscribing thread — the Netty event loop. When `RestApiClaimProvider` is active, the interceptor chain calls `Mono.block()` (via `HttpClientIntroductionAdvice.handleBlockingCall`), which Reactor 3.6+ rejects on `NonBlocking` threads.

## Fix

Add `.subscribeOn(Schedulers.io())` after the `fromCallable()` to move the blocking call to an IO thread. This matches the pattern already used in `BasicAuthAuthenticationProvider` (line 62-66).

## Testing

- Verified this fixes the 500 error in production with AKHQ 0.27.1 + Micronaut 4.10.7
- `BasicAuthAuthenticationProvider` already uses this exact pattern successfully