### PR TITLE
fix(auth): preserve return route after session expiry

### DIFF
--- a/client/src/components/Root/Root.jsx
+++ b/client/src/components/Root/Root.jsx
@@ -1,4 +1,5 @@
 import { Component } from 'react';
+import { basePath } from '../../utils/endpoints';
 import axios from 'axios';
 import { get, put, post, remove } from '../../utils/api';
 
@@ -10,17 +11,17 @@ class Root extends Component {
     const pathname = this.props.location?.pathname;
 
     if (pathname && pathname !== '/ui/login') {
-      sessionStorage.setItem('returnTo', pathname + (window.location.search || ''));
+      sessionStorage.setItem('returnTo', basePath + pathname + (window.location.search || ''));
     }
 
     this.cancelAxiosRequests();
   }
 
   saveReturnToOnSessionExpiry() {
-    const pathname = window.location.pathname;
+    const pathname = this.props.location?.pathname;
 
     if (pathname && pathname.startsWith('/ui/') && pathname !== '/ui/login') {
-      sessionStorage.setItem('returnTo', pathname + (window.location.search || ''));
+      sessionStorage.setItem('returnTo', basePath + pathname + (window.location.search || ''));
     }
   }
 

--- a/client/src/components/Root/Root.jsx
+++ b/client/src/components/Root/Root.jsx
@@ -16,6 +16,14 @@ class Root extends Component {
     this.cancelAxiosRequests();
   }
 
+  saveReturnToOnSessionExpiry() {
+    const pathname = window.location.pathname;
+
+    if (pathname && pathname.startsWith('/ui/') && pathname !== '/ui/login') {
+      sessionStorage.setItem('returnTo', pathname + (window.location.search || ''));
+    }
+  }
+
   cancelAxiosRequests() {
     if (this.cancel !== undefined) {
       this.cancel.cancel('cancel all');

--- a/client/src/containers/Login/Login.jsx
+++ b/client/src/containers/Login/Login.jsx
@@ -85,7 +85,7 @@ class Login extends Form {
         const returnTo = sessionStorage.getItem('returnTo');
         sessionStorage.removeItem('returnTo');
 
-        window.location.replace(basePath + (returnTo || '/ui'));
+        window.location.replace((returnTo || basePath + '/ui'));
       } else {
         toast.error('User logged in but no roles assigned');
       }

--- a/client/src/utils/AkhqRoutes.jsx
+++ b/client/src/utils/AkhqRoutes.jsx
@@ -32,6 +32,7 @@ import Root from '../components/Root';
 import KsqlDBList from '../containers/KsqlDB/KsqlDBList/KsqlDBList';
 import KsqlDBStatement from '../containers/KsqlDB/KsqlDBStatement';
 import KsqlDBQuery from '../containers/KsqlDB/KsqlDBQuery';
+import { withRouter } from './withRouter';
 
 class AkhqRoutes extends Root {
   state = {
@@ -332,4 +333,4 @@ class AkhqRoutes extends Root {
   }
 }
 
-export default AkhqRoutes;
+export default withRouter(AkhqRoutes);

--- a/client/src/utils/AkhqRoutes.jsx
+++ b/client/src/utils/AkhqRoutes.jsx
@@ -93,6 +93,7 @@ class AkhqRoutes extends Root {
       sessionStorage.setItem('roles', organizeRoles(currentUserData.roles));
       this.setState({ user: currentUserData.username });
     } else {
+      this.saveReturnToOnSessionExpiry();
       sessionStorage.setItem('login', false);
       if (currentUserData.roles) {
         sessionStorage.setItem('user', 'default');


### PR DESCRIPTION
Fixes #3029.

This change preserves the current UI route when a user's session expires and they are redirected back to the login page.

Previously, when the JWT/session was lost, the app redirected to login but did not always save the route the user was on. After logging back in, the user could be sent to the default page instead of returning to their previous page.

This adds a session-expiry-specific return route save, while keeping the existing component unmount/logout return behavior unchanged.

Following review feedback, the saved returnTo route now includes basePath so the redirect remains consistent for context-path setups. The login redirect now uses the saved returnTo directly, or falls back to basePath + '/ui' when no return route exists.

I also wrapped AkhqRoutes with the existing withRouter helper so Root can access this.props.location?.pathname when saving the return route.

Tested locally by:

enabling basic auth
navigating to a protected page
deleting the JWT cookie
refreshing the page
confirming returnTo is saved without duplicate /ui
logging in again
confirming the app returns to the previous route and clears returnTo

Please let me know if this matches the expected behavior for the session-expiry flow, or if you would prefer the route-saving logic handled differently.