### PR TITLE
feat(ui): add opt-in server refresh for ui options

### DIFF
--- a/application.example.yml
+++ b/application.example.yml
@@ -177,6 +177,7 @@ akhq:
 
   # Ui Global Options (optional)
   ui-options:
+    refresh-from-server: false # Always refresh UI options from server instead of using local browser settings
     topic:
       default-view: ALL  # default list view (ALL, HIDE_INTERNAL, HIDE_INTERNAL_STREAM, HIDE_STREAM). Overrides default
       skip-consumer-groups: false # Skip loading consumer group information when showing topics. Overrides default

--- a/client/src/utils/functions.jsx
+++ b/client/src/utils/functions.jsx
@@ -10,17 +10,23 @@ export const getSelectedTab = (props, tabs) => {
 
 export async function getClusterUIOptions(clusterId) {
   const uiOptions = getUIOptions(clusterId);
-  if (!uiOptions && clusterId) {
-    try {
-      const resOptions = await get(uriUIOptions(clusterId));
-      setUIOptions(clusterId, resOptions.data);
-      return resOptions.data;
-    } catch (err) {
-      console.error('Error:', err);
-      return {};
-    }
-  } else {
+  if (!clusterId) {
     return uiOptions;
+  }
+
+  try {
+    const resOptions = await get(uriUIOptions(clusterId));
+    const serverOptions = resOptions.data;
+
+    if (!uiOptions || serverOptions.refreshFromServer) {
+      setUIOptions(clusterId, serverOptions);
+      return serverOptions;
+    }
+
+    return uiOptions;
+  } catch (err) {
+    console.error('Error:', err);
+    return uiOptions ?? {};
   }
 }
 

--- a/client/src/utils/functions.test.js
+++ b/client/src/utils/functions.test.js
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getClusterUIOptions } from './functions.jsx';
+import { get } from './api';
+import { setUIOptions } from './localstorage.jsx';
+
+vi.mock('./api', () => ({
+  get: vi.fn()
+}));
+
+describe('getClusterUIOptions()', () => {
+  const clusterId = 'local';
+  const serverOptions = {
+    topic: {
+      defaultView: 'ALL',
+      skipLastRecord: true
+    }
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('returns cached options without calling server when clusterId is missing', async () => {
+    await expect(getClusterUIOptions(undefined)).resolves.toBeNull();
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('stores server options when there are no cached options', async () => {
+    get.mockResolvedValue({ data: serverOptions });
+
+    await expect(getClusterUIOptions(clusterId)).resolves.toEqual(serverOptions);
+    expect(JSON.parse(localStorage.getItem('uiOptions'))).toEqual({ [clusterId]: serverOptions });
+  });
+
+  it('keeps local user options by default', async () => {
+    const localOptions = {
+      topic: {
+        defaultView: 'HIDE_INTERNAL',
+        skipLastRecord: false
+      }
+    };
+    setUIOptions(clusterId, localOptions);
+    get.mockResolvedValue({ data: serverOptions });
+
+    await expect(getClusterUIOptions(clusterId)).resolves.toEqual(localOptions);
+    expect(JSON.parse(localStorage.getItem('uiOptions'))).toEqual({ [clusterId]: localOptions });
+  });
+
+  it('refreshes local options when server refresh is enabled', async () => {
+    const localOptions = {
+      topic: {
+        defaultView: 'HIDE_INTERNAL',
+        skipLastRecord: false
+      }
+    };
+    const refreshingServerOptions = {
+      ...serverOptions,
+      refreshFromServer: true
+    };
+    setUIOptions(clusterId, localOptions);
+    get.mockResolvedValue({ data: refreshingServerOptions });
+
+    await expect(getClusterUIOptions(clusterId)).resolves.toEqual(refreshingServerOptions);
+    expect(JSON.parse(localStorage.getItem('uiOptions'))).toEqual({
+      [clusterId]: refreshingServerOptions
+    });
+  });
+
+  it('falls back to cached local options when fetching server options fails', async () => {
+    setUIOptions(clusterId, serverOptions);
+    get.mockRejectedValue(new Error('network error'));
+
+    await expect(getClusterUIOptions(clusterId)).resolves.toEqual(serverOptions);
+  });
+});

--- a/docs/docs/configuration/akhq.md
+++ b/docs/docs/configuration/akhq.md
@@ -25,6 +25,8 @@ These parameters are the default values used in the topic creation page.
 * `akhq.topic-data.kafka-max-message-length`: Max message length allowed to send to UI when retrieving a list of records (dafault: 1000000 bytes).
 
 ## Ui Settings
+* `akhq.ui-options.refresh-from-server` when true, always refresh UI settings from the server instead of using cached browser settings. Server-provided options take precedence on every load and overwrite user-level customizations made via the Settings page (default: false)
+
 ### Topics
 * `akhq.ui-options.topic.default-view` is default list view (ALL, HIDE_INTERNAL, HIDE_INTERNAL_STREAM, HIDE_STREAM) (default: HIDE_INTERNAL)
 * `akhq.ui-options.topic.skip-consumer-groups` hide consumer groups columns on topic list

--- a/src/main/java/org/akhq/configs/Connection.java
+++ b/src/main/java/org/akhq/configs/Connection.java
@@ -63,6 +63,8 @@ public class Connection extends AbstractProperties {
     @Data
     @ConfigurationProperties("ui-options")
     public static class UiOptions {
+        Boolean refreshFromServer;
+
         @ConfigurationBuilder(configurationPrefix = "topic")
         private UiOptionsTopic topic = new UiOptionsTopic();
 
@@ -72,6 +74,8 @@ public class Connection extends AbstractProperties {
 
     public UiOptions mergeOptions(UIOptions defaultOptions) {
         UiOptions options = new UiOptions();
+
+        options.refreshFromServer = (this.uiOptions.refreshFromServer != null) ? this.uiOptions.refreshFromServer : defaultOptions.getRefreshFromServer();
 
         options.topic = new UiOptionsTopic(
             StringUtils.isNotEmpty(this.uiOptions.topic.getDefaultView()) ? this.uiOptions.topic.getDefaultView() : defaultOptions.getTopic().getDefaultView(),
@@ -89,4 +93,3 @@ public class Connection extends AbstractProperties {
         return options;
     }
 }
-

--- a/src/main/java/org/akhq/configs/UIOptions.java
+++ b/src/main/java/org/akhq/configs/UIOptions.java
@@ -7,6 +7,8 @@ import lombok.Data;
 @Data
 @ConfigurationProperties("akhq.ui-options")
 public class UIOptions {
+    private Boolean refreshFromServer = false;
+
     @ConfigurationBuilder(configurationPrefix = "topic")
     private UiOptionsTopic topic = new UiOptionsTopic();
 


### PR DESCRIPTION
## Summary

Adds an opt-in `akhq.ui-options.refresh-from-server` setting.

The default is `false`, so existing behavior is preserved: once UI options are stored in browser localStorage, those local settings continue to win. When set to `true`, AKHQ refreshes the cached UI options from the server on each load.

## Motivation

This should improve the user experience for managed AKHQ deployments by letting operators roll out UI option changes without requiring each user to clear their local browser storage.

Related issues:

- https://github.com/tchiotludo/akhq/issues/904
- https://github.com/tchiotludo/akhq/issues/994

## Changes

- Add global `akhq.ui-options.refresh-from-server`
- Add per-connection `akhq.connections.<cluster>.ui-options.refresh-from-server`
- Refresh local UI options from the server when `refreshFromServer` is true
- Add unit tests for `getClusterUIOptions` cache/server precedence
