### PR TITLE
[JAVA-457] Ignore gradle-wrapper 9.6.0 in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,11 @@ updates:
     labels:
       - "dependency-upgrade"
     open-pull-requests-limit: 50
+    ignore:
+      # Holding off on gradle-wrapper 9.6.0 for now. See JAVA-457.
+      - dependency-name: gradle-wrapper
+        versions:
+          - 9.6.0
 
   # Maintain dependencies for Npm modules
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Summary
- Add an ignore entry for gradle-wrapper 9.6.0 to the gradle ecosystem block(s) in .github/dependabot.yml.
- We are holding off on adopting gradle-wrapper 9.6.0 for now; this stops Dependabot re-raising the bump.

Jira: JAVA-457

## Context
The open gradle-wrapper 9.6.0 bump PRs were closed because we are not upgrading yet. Closing alone does not stop Dependabot reopening them, so this adds the explicit ignore. Applied to running Gradle services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)