### PR TITLE
fix(ui): solve several redirect issues

### DIFF
--- a/client/src/containers/ConsumerGroup/ConsumerGroupList/ConsumerGroupList.jsx
+++ b/client/src/containers/ConsumerGroup/ConsumerGroupList/ConsumerGroupList.jsx
@@ -29,69 +29,70 @@ class ConsumerGroupList extends Root {
     loading: true
   };
 
-  componentDidMount() {
-    const { clusterId } = this.props.params;
-    const { search, pageNumber } = this.state;
+  getSearchAndPageFromLocation = () => {
     const query = new URLSearchParams(this.props.location.search);
+    return {
+      search: query.get('search') ?? '',
+      pageNumber: query.get('page') ? parseInt(query.get('page')) : 1
+    };
+  };
+
+  navigateWithQuery = (search, pageNumber, replace = false) => {
+    const { clusterId } = this.props.params;
+    this.props.router.navigate(
+      {
+        pathname: `/ui/${clusterId}/group`,
+        search: `search=${search || ''}&page=${pageNumber}`
+      },
+      { replace }
+    );
+  };
+
+  syncStateFromLocation = callback => {
+    const { clusterId } = this.props.params;
+    const { search, pageNumber } = this.getSearchAndPageFromLocation();
 
     this.setState(
       {
         selectedCluster: clusterId,
-        search: query.get('search') ? query.get('search') : search,
-        pageNumber: query.get('page') ? parseInt(query.get('page')) : parseInt(pageNumber)
+        search,
+        pageNumber
       },
-      () => {
-        this.getConsumerGroup();
-      }
+      callback
     );
+  };
+
+  componentDidMount() {
+    this.syncStateFromLocation(() => {
+      this.getConsumerGroup();
+    });
   }
 
-  componentDidUpdate(prevProps, prevState, snapshot) {
-    if (this.props.location.search !== prevProps.location.search) {
-      // Handle back navigation
-      if (this.props.router.navigationType === 'POP') {
-        let { clusterId } = this.props.params;
-        const { search, pageNumber } = this.state;
-        const query = new URLSearchParams(this.props.location.search);
-        this.setState(
-          {
-            selectedCluster: clusterId,
-            search: query.get('search'),
-            pageNumber: query.get('page') ? parseInt(query.get('page')) : parseInt(pageNumber)
-          },
-          () => {
-            this.getConsumerGroup(false);
-          }
-        );
-      } else if (this.props.location.search === '') {
-        // Handle sidebar click on schema registry from the component
-        this.setState(
-          {
-            searchData: { search: '' },
-            pageNumber: 1
-          },
-          () => {
-            this.getConsumerGroup(false);
-          }
-        );
-      }
+  componentDidUpdate(prevProps) {
+    const pathnameChanged = this.props.location.pathname !== prevProps.location.pathname;
+    const searchChanged = this.props.location.search !== prevProps.location.search;
+
+    if (pathnameChanged || searchChanged) {
+      this.cancelAxiosRequests();
+      this.renewCancelToken();
+
+      this.syncStateFromLocation(() => {
+        this.getConsumerGroup();
+      });
     }
   }
 
   handleSearch = data => {
-    this.setState({ pageNumber: 1, search: data.searchData.search }, () => {
-      this.getConsumerGroup(false);
-    });
+    const nextSearch = data.searchData.search || '';
+    this.navigateWithQuery(nextSearch, 1, false);
   };
 
   handlePageChangeSubmission = (value, replaceInNavigation) => {
     let pageNumber = getPageNumber(value, this.state.totalPageNumber);
-    this.setState({ pageNumber: pageNumber }, () => {
-      this.getConsumerGroup(replaceInNavigation);
-    });
+    this.navigateWithQuery(this.state.search, pageNumber, replaceInNavigation);
   };
 
-  async getConsumerGroup(replaceInNavigation = true) {
+  async getConsumerGroup() {
     const { selectedCluster, pageNumber, search } = this.state;
     this.setState({ loading: true });
 
@@ -99,15 +100,7 @@ class ConsumerGroupList extends Root {
     response = response.data;
     if (response.results) {
       this.handleConsumerGroup(response.results);
-      this.setState({ selectedCluster, totalPageNumber: response.page }, () =>
-        this.props.router.navigate(
-          {
-            pathname: `/ui/${this.state.selectedCluster}/group`,
-            search: `search=${this.state.search}&page=${pageNumber}`
-          },
-          { replace: replaceInNavigation }
-        )
-      );
+      this.setState({ selectedCluster, totalPageNumber: response.page });
     } else {
       this.setState({ selectedCluster, consumerGroups: [], totalPageNumber: 1, loading: false });
     }

--- a/client/src/containers/ConsumerGroup/ConsumerGroupList/ConsumerGroupList.jsx
+++ b/client/src/containers/ConsumerGroup/ConsumerGroupList/ConsumerGroupList.jsx
@@ -39,10 +39,13 @@ class ConsumerGroupList extends Root {
 
   navigateWithQuery = (search, pageNumber, replace = false) => {
     const { clusterId } = this.props.params;
+    const searchParams = new URLSearchParams();
+    searchParams.set('search', search || '');
+    searchParams.set('page', pageNumber);
     this.props.router.navigate(
       {
         pathname: `/ui/${clusterId}/group`,
-        search: `search=${search || ''}&page=${pageNumber}`
+        search: searchParams.toString()
       },
       { replace }
     );

--- a/client/src/containers/Schema/SchemaList/SchemaList.jsx
+++ b/client/src/containers/Schema/SchemaList/SchemaList.jsx
@@ -36,75 +36,70 @@ class SchemaList extends Root {
     loading: true
   };
 
-  componentDidMount() {
-    let { clusterId } = this.props.params;
-    const { searchData, pageNumber } = this.state;
+  getSearchAndPageFromLocation = () => {
     const query = new URLSearchParams(this.props.location.search);
+    return {
+      search: query.get('search') ?? '',
+      pageNumber: query.get('page') ? parseInt(query.get('page')) : 1
+    };
+  };
+
+  navigateWithQuery = (search, pageNumber, replace = false) => {
+    const { clusterId } = this.props.params;
+    this.props.router.navigate(
+      {
+        pathname: `/ui/${clusterId}/schema`,
+        search: `search=${search || ''}&page=${pageNumber}`
+      },
+      { replace }
+    );
+  };
+
+  syncStateFromLocation = callback => {
+    const { clusterId } = this.props.params;
+    const { search, pageNumber } = this.getSearchAndPageFromLocation();
 
     this.setState(
       {
         selectedCluster: clusterId,
-        searchData: { search: query.get('search') ? query.get('search') : searchData.search },
-        pageNumber: query.get('page') ? parseInt(query.get('page')) : parseInt(pageNumber)
+        searchData: { search },
+        pageNumber
       },
-      () => {
-        this.getSchemaRegistry(true);
-      }
+      callback
     );
+  };
+
+  componentDidMount() {
+    this.syncStateFromLocation(() => {
+      this.getSchemaRegistry();
+    });
   }
 
-  componentDidUpdate(prevProps, prevState, snapshot) {
-    if (this.props.location.search !== prevProps.location.search) {
-      // Handle back navigation
-      if (this.props.router.navigationType === 'POP') {
-        let { clusterId } = this.props.params;
-        const { searchData, pageNumber } = this.state;
-        const query = new URLSearchParams(this.props.location.search);
-        this.setState(
-          {
-            selectedCluster: clusterId,
-            searchData: { search: query.get('search') },
-            pageNumber: query.get('page') ? parseInt(query.get('page')) : parseInt(pageNumber)
-          },
-          () => {
-            this.getSchemaRegistry(false);
-          }
-        );
-      } else if (this.props.location.search === '') {
-        // Handle sidebar click on schema registry from the component
-        this.setState(
-          {
-            searchData: { search: '' },
-            pageNumber: 1
-          },
-          () => {
-            this.getSchemaRegistry(false);
-          }
-        );
-      }
+  componentDidUpdate(prevProps) {
+    const pathnameChanged = this.props.location.pathname !== prevProps.location.pathname;
+    const searchChanged = this.props.location.search !== prevProps.location.search;
+
+    if (pathnameChanged || searchChanged) {
+      this.cancelAxiosRequests();
+      this.renewCancelToken();
+
+      this.syncStateFromLocation(() => {
+        this.getSchemaRegistry();
+      });
     }
   }
 
   handleSearch = data => {
     const { searchData } = data;
-
-    // Cancel previous requests is there are some to prevent UI issues
-    this.cancelAxiosRequests();
-    this.renewCancelToken();
-
-    this.setState({ pageNumber: 1, searchData }, () => {
-      this.getSchemaRegistry(false);
-    });
+    this.navigateWithQuery(searchData.search || '', 1, false);
   };
 
   handlePageChangeSubmission = (value, replaceInNavigation) => {
     let pageNumber = parseInt(getPageNumber(value, this.state.totalPageNumber));
-    this.setState({ pageNumber: pageNumber }, () => {
-      this.getSchemaRegistry(replaceInNavigation);
-    });
+    this.navigateWithQuery(this.state.searchData.search, pageNumber, replaceInNavigation);
   };
 
-  async getSchemaRegistry(replaceInNavigation = true) {
+  async getSchemaRegistry() {
     const { selectedCluster, pageNumber } = this.state;
     const { search } = this.state.searchData;
 
@@ -117,15 +112,7 @@ class SchemaList extends Root {
     let data = response.data;
     if (data.results) {
       this.handleSchemaRegistry(data.results);
-      this.setState({ selectedCluster, totalPageNumber: data.page }, () => {
-        this.props.router.navigate(
-          {
-            pathname: `/ui/${this.state.selectedCluster}/schema`,
-            search: `search=${this.state.searchData.search}&page=${pageNumber}`
-          },
-          { replace: replaceInNavigation }
-        );
-      });
+      this.setState({ selectedCluster, totalPageNumber: data.page });
     } else {
       this.setState({ selectedCluster, schemasRegistry: [], loading: false });
     }

--- a/client/src/containers/Schema/SchemaList/SchemaList.jsx
+++ b/client/src/containers/Schema/SchemaList/SchemaList.jsx
@@ -46,10 +46,13 @@ class SchemaList extends Root {
 
   navigateWithQuery = (search, pageNumber, replace = false) => {
     const { clusterId } = this.props.params;
+    const searchParams = new URLSearchParams();
+    searchParams.set('search', search || '');
+    searchParams.set('page', pageNumber);
     this.props.router.navigate(
       {
         pathname: `/ui/${clusterId}/schema`,
-        search: `search=${search || ''}&page=${pageNumber}`
+        search: searchParams.toString()
       },
       { replace }
     );

--- a/client/src/containers/SideBar/Sidebar.jsx
+++ b/client/src/containers/SideBar/Sidebar.jsx
@@ -265,27 +265,13 @@ class Sidebar extends Component {
       >
         <NavIcon>
           {' '}
-          <Link
-            to={`/ui/${selectedCluster}/${tab}`}
-            onClick={e => {
-              this.setState({ selectedTab: tab });
-              e.preventDefault();
-            }}
-          >
+          <span>
             <FontAwesomeIcon icon={icon} aria-hidden={true} />
-          </Link>
+          </span>
         </NavIcon>
         <NavText>
           {' '}
-          <Link
-            to={`/ui/${selectedCluster}/${tab}`}
-            onClick={e => {
-              this.setState({ selectedTab: tab });
-              e.preventDefault();
-            }}
-          >
-            {label}
-          </Link>
+          <span>{label}</span>
         </NavText>
       </NavItem>
     );

--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -108,33 +108,20 @@ class TopicData extends Root {
   }
 
   componentDidMount = () => {
-    this._checkProps();
+    this._syncStateFromLocationAndLoad();
   };
 
   componentDidUpdate(prevProps, prevState, snapshot) {
-    // Handle back navigation
-    if (
-      this.props.location.search !== prevProps.location.search &&
-      this.props.router.navigationType === 'POP'
-    ) {
-      const { clusterId, topicId } = this.props.params;
-      const query = new URLSearchParams(this.props.location.search);
+    const pathnameChanged = this.props.location.pathname !== prevProps.location.pathname;
+    const searchChanged = this.props.location.search !== prevProps.location.search;
 
-      this.setState(
-        {
-          selectedCluster: clusterId,
-          selectedTopic: topicId,
-          sortBy: query.get('sort'),
-          partition: query.get('partition'),
-          datetime: query.get('timestamp') ? new Date(query.get('timestamp')) : '',
-          endDatetime: query.get('endTimestamp') ? new Date(query.get('endTimestamp')) : '',
-          offsetsSearch: query.get('after'),
-          search: this._buildSearchFromQueryString(query)
-        },
-        () => {
-          this._searchMessages(false, true);
-        }
-      );
+    if (pathnameChanged || searchChanged) {
+      if (!this.props.location.pathname.endsWith('/data')) {
+        return;
+      }
+
+      this._stopEventSource(false);
+      this._syncStateFromLocationAndLoad();
     }
   }
 
@@ -143,10 +130,11 @@ class TopicData extends Root {
     this._stopEventSource();
   };
 
-  async _checkProps() {
+  async _syncStateFromLocationAndLoad() {
     const { clusterId, topicId } = this.props.params;
     const query = new URLSearchParams(this.props.location.search);
     const uiOptions = await getClusterUIOptions(clusterId);
+
     this.setState(
       prevState => ({
         selectedCluster: clusterId,
@@ -175,20 +163,35 @@ class TopicData extends Root {
             : prevState.dateTimeFormat
       }),
       () => {
-        if (query.get('single') !== null) {
-          this._getSingleMessage(query.get('partition'), query.get('offset'));
-          this.setState({ canDownload: true });
-        } else if (Object.keys(this.state.offsets).length) {
-          this._getMessages(false, true);
-        } else {
-          this._searchMessages(false, true);
-        }
+        this._loadFromCurrentLocation(query);
       }
     );
   }
 
+  _loadFromCurrentLocation = query => {
+    if (query.get('single') !== null) {
+      this._getSingleMessage(query.get('partition'), query.get('offset'));
+      this.setState({ canDownload: true });
+    } else if (Object.keys(this.state.offsets).length) {
+      this.setState({ canDownload: false }, () => {
+        this._getMessages(false);
+      });
+    } else {
+      this.setState({ canDownload: false }, () => {
+        this._searchMessages(false);
+      });
+    }
+  };
+
   _buildSearchFromQueryString(query) {
-    const { search } = this.state;
+    const search = {
+      key: { text: '', type: 'C' },
+      value: { text: '', type: 'C' },
+      headerKey: { text: '', type: 'C' },
+      headerValue: { text: '', type: 'C' },
+      keySubject: { text: '', type: 'C' },
+      valueSubject: { text: '', type: 'C' }
+    };
 
     Object.keys(search).forEach(value => {
       const searchFilter = query.get(`searchBy${capitalizeTxt(value)}`);
@@ -204,7 +207,7 @@ class TopicData extends Root {
     return search;
   }
 
-  _startEventSource = (changePage, replaceInNavigation = false) => {
+  _startEventSource = changePage => {
     let { selectedCluster, selectedTopic, nextPage } = this.state;
 
     let lastPercentVal = 0.0;
@@ -215,11 +218,6 @@ class TopicData extends Root {
       { messages: [], pageNumber: 1, percent: 0, isSearching: true, recordCount: 0 },
       () => {
         const filters = this._buildFilters();
-        if (changePage) {
-          this._setUrlHistory(filters + '&after=' + nextPage, replaceInNavigation);
-        } else {
-          this._setUrlHistory(filters, replaceInNavigation);
-        }
         this.eventSource = new EventSourcePolyfill(
           uriTopicDataSearch(
             selectedCluster,
@@ -282,7 +280,7 @@ class TopicData extends Root {
     );
   };
 
-  _stopEventSource = () => {
+  _stopEventSource = (resetLoading = true) => {
     if (this.eventSource) {
       this.eventSource.close();
     }
@@ -290,7 +288,7 @@ class TopicData extends Root {
     this.cancelAxiosRequests();
     this.renewCancelToken();
 
-    this.setState({ isSearching: false, loading: false });
+    this.setState({ isSearching: false, ...(resetLoading ? { loading: false } : {}) });
   };
 
   _clearSearch = () => {
@@ -306,7 +304,7 @@ class TopicData extends Root {
         }
       },
       () => {
-        this._searchMessages();
+        this._navigateWithCurrentFilters(false);
       }
     );
   };
@@ -362,18 +360,20 @@ class TopicData extends Root {
     }
   }
 
-  _searchMessages(changePage = false, replaceInNavigation = false) {
-    this._stopEventSource();
+  _searchMessages(changePage = false) {
+    this._stopEventSource(false);
     this.setState({ loading: true });
     if (this._hasAnyFilterFilled()) {
-      this._startEventSource(changePage, replaceInNavigation);
+      this._startEventSource(changePage);
     } else {
-      this._getMessages(changePage, replaceInNavigation);
+      this._getMessages(changePage);
     }
   }
 
   _getSingleMessage(partition, offset) {
     const { selectedCluster, selectedTopic } = this.state;
+
+    this.setState({ loading: true });
 
     const requests = [
       this.getApi(uriTopicDataSingleRecord(selectedCluster, selectedTopic, partition, offset)),
@@ -383,8 +383,10 @@ class TopicData extends Root {
     this._fetchMessages(requests);
   }
 
-  _getMessages = (changePage = false, replaceInNavigation = false) => {
+  _getMessages = (changePage = false) => {
     const { selectedCluster, selectedTopic, nextPage } = this.state;
+
+    this.setState({ loading: true });
 
     const filters = this._buildFilters();
     const requests = [
@@ -395,15 +397,6 @@ class TopicData extends Root {
     ];
 
     this._fetchMessages(requests, changePage);
-
-    if (changePage) {
-      this._setUrlHistory(
-        nextPage.substring(nextPage.indexOf('?') + 1, nextPage.length),
-        replaceInNavigation
-      );
-    } else {
-      this._setUrlHistory(filters, replaceInNavigation);
-    }
   };
 
   _fetchMessages(requests, changePage = false) {
@@ -690,6 +683,27 @@ class TopicData extends Root {
     );
   }
 
+  _navigateWithCurrentFilters = (replaceInNavigation = false) => {
+    this.setState({ loading: true }, () => {
+      this._setUrlHistory(this._buildFilters(), replaceInNavigation);
+    });
+  };
+
+  _navigateToNextPage = (replaceInNavigation = false) => {
+    const { nextPage } = this.state;
+
+    if (!nextPage) {
+      return;
+    }
+
+    this.setState({ loading: true }, () => {
+      this._setUrlHistory(
+        nextPage.substring(nextPage.indexOf('?') + 1, nextPage.length),
+        replaceInNavigation
+      );
+    });
+  };
+
   _redirectToSchema(id) {
     const { selectedCluster, selectedTopic } = this.state;
 
@@ -699,8 +713,7 @@ class TopicData extends Root {
           {
             pathname: `/ui/${selectedCluster}/schema/details/${response.data.subject}`,
             schemaId: response.data.subject
-          },
-          { replace: true }
+          }
         );
       } else {
         toast.warn(`Unable to find the registry schema with id  ${id} !`);
@@ -721,7 +734,7 @@ class TopicData extends Root {
               toast.warn('Sorting by newest with timestamp in large topics may not show data.');
             }
             this.setState({ sortBy: option }, () => {
-              this._searchMessages();
+              this._navigateWithCurrentFilters(false);
             });
           }}
         >
@@ -742,7 +755,7 @@ class TopicData extends Root {
           key={option}
           onClick={() =>
             this.setState({ partition: option }, () => {
-              this._searchMessages();
+              this._navigateWithCurrentFilters(false);
             })
           }
         >
@@ -855,7 +868,7 @@ class TopicData extends Root {
           <button
             className="btn btn-primary inline-block search"
             type="button"
-            onClick={() => this._searchMessages()}
+            onClick={() => this._navigateWithCurrentFilters(false)}
           >
             {isSearching ? (
               <FontAwesomeIcon icon={faSpinner} spin={true} />
@@ -982,7 +995,7 @@ class TopicData extends Root {
                       pageNumber: pageNumber + 1
                     },
                     () => {
-                      this._searchMessages(true);
+                      this._navigateToNextPage(false);
                     }
                   );
                 }}
@@ -1052,7 +1065,7 @@ class TopicData extends Root {
                           label="Start"
                           onClear={() => {
                             this.setState({ datetime: '' }, () => {
-                              this._searchMessages();
+                              this._navigateWithCurrentFilters(false);
                             });
                           }}
                           showDateTimeInput
@@ -1060,7 +1073,7 @@ class TopicData extends Root {
                           value={datetime}
                           onChange={value => {
                             this.setState({ datetime: value }, () => {
-                              this._searchMessages();
+                              this._navigateWithCurrentFilters(false);
                             });
                           }}
                         />
@@ -1070,7 +1083,7 @@ class TopicData extends Root {
                           label="End"
                           onClear={() => {
                             this.setState({ endDatetime: '' }, () => {
-                              this._searchMessages();
+                              this._navigateWithCurrentFilters(false);
                             });
                           }}
                           showDateTimeInput
@@ -1078,7 +1091,7 @@ class TopicData extends Root {
                           value={endDatetime}
                           onChange={value => {
                             this.setState({ endDatetime: value, sortBy: 'Oldest' }, () => {
-                              this._searchMessages();
+                              this._navigateWithCurrentFilters(false);
                             });
                           }}
                         />
@@ -1119,7 +1132,7 @@ class TopicData extends Root {
                                 }
                               }
                               this.setState({ offsetsSearch }, () => {
-                                this._searchMessages();
+                                this._navigateWithCurrentFilters(false);
                               });
                             }}
                           >

--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -172,12 +172,9 @@ class TopicData extends Root {
     if (query.get('single') !== null) {
       this._getSingleMessage(query.get('partition'), query.get('offset'));
       this.setState({ canDownload: true });
-    } else if (Object.keys(this.state.offsets).length) {
-      this.setState({ canDownload: false }, () => {
-        this._getMessages(false);
-      });
     } else {
       this.setState({ canDownload: false }, () => {
+        // Delegate mode selection to _searchMessages so active filters always use /data/search.
         this._searchMessages(false);
       });
     }
@@ -671,7 +668,7 @@ class TopicData extends Root {
     return offsetsOptions;
   };
 
-  _setUrlHistory(filters, replaceInNavigation = true) {
+  _navigateWithFilters(filters, replaceInNavigation = true) {
     const { selectedCluster, selectedTopic } = this.state;
 
     this.props.router.navigate(
@@ -685,7 +682,7 @@ class TopicData extends Root {
 
   _navigateWithCurrentFilters = (replaceInNavigation = false) => {
     this.setState({ loading: true }, () => {
-      this._setUrlHistory(this._buildFilters(), replaceInNavigation);
+      this._navigateWithFilters(this._buildFilters(), replaceInNavigation);
     });
   };
 
@@ -697,10 +694,16 @@ class TopicData extends Root {
     }
 
     this.setState({ loading: true }, () => {
-      this._setUrlHistory(
-        nextPage.substring(nextPage.indexOf('?') + 1, nextPage.length),
-        replaceInNavigation
-      );
+      const currentParams = new URLSearchParams(this.props.location.search);
+
+      if (nextPage.includes('?')) {
+        const nextQuery = nextPage.substring(nextPage.indexOf('?') + 1);
+        this._navigateWithFilters(nextQuery, replaceInNavigation);
+      } else {
+        // EventSource search returns token-only `after` values (e.g. 0-106_1-55).
+        currentParams.set('after', nextPage);
+        this._navigateWithFilters(currentParams.toString(), replaceInNavigation);
+      }
     });
   };
 

--- a/client/src/containers/Topic/TopicList/TopicList.jsx
+++ b/client/src/containers/Topic/TopicList/TopicList.jsx
@@ -58,54 +58,37 @@ class TopicList extends Root {
   componentDidMount() {
     this._initializeVars(() => {
       this.getTopics();
-      this.props.router.navigate(
-        {
-          pathname: `/ui/${this.state.selectedCluster}/topic`,
-          search: this.props.location.search
-        },
-        { replace: true }
-      );
     });
   }
 
+  navigateWithQuery = (searchData, pageNumber, currentPageSize, replace = false) => {
+    const { clusterId } = this.props.params;
+    const searchParams = new URLSearchParams();
+    searchParams.set('search', searchData.search || '');
+    searchParams.set('topicListView', searchData.topicListView || '');
+    searchParams.set('page', pageNumber);
+    searchParams.set('uiPageSize', currentPageSize);
+
+    this.props.router.navigate(
+      {
+        pathname: `/ui/${clusterId}/topic`,
+        search: searchParams.toString()
+      },
+      { replace }
+    );
+  };
+
   componentDidUpdate(prevProps) {
-    if (this.props.location.pathname !== prevProps.location.pathname) {
+    const pathnameChanged = this.props.location.pathname !== prevProps.location.pathname;
+    const searchChanged = this.props.location.search !== prevProps.location.search;
+
+    if (pathnameChanged || searchChanged) {
       this.cancelAxiosRequests();
       this.renewCancelToken();
 
-      this.setState({ pageNumber: 1 }, () => {
-        this._initializeVars(this.getTopics);
+      this._initializeVars(() => {
+        this.getTopics();
       });
-    }
-
-    if (this.props.location.search !== prevProps.location.search) {
-      const { searchData } = this.state;
-      // Handle back navigation
-      if (this.props.router.navigationType === 'POP') {
-        let { clusterId } = this.props.params;
-        const query = new URLSearchParams(this.props.location.search);
-        this.setState(
-          {
-            selectedCluster: clusterId,
-            searchData: { ...searchData, search: query.get('search') ? query.get('search') : '' },
-            pageNumber: query.get('page') ? parseInt(query.get('page')) : 1
-          },
-          () => {
-            this.getTopics();
-          }
-        );
-      } else if (this.props.location.search === '') {
-        // Handle sidebar click on topics from the component
-        this.setState(
-          {
-            pageNumber: 1,
-            searchData: { ...searchData, search: '' }
-          },
-          () => {
-            this._initializeVars(this.getTopics);
-          }
-        );
-      }
     }
   }
 
@@ -183,50 +166,19 @@ class TopicList extends Root {
   handleSearch = data => {
     const { searchData } = data;
 
-    // Cancel previous requests if there are some to prevent UI issues
-    this.cancelAxiosRequests();
-    this.renewCancelToken();
-
     this.setState({ pageNumber: 1, searchData }, () => {
-      const { topicListView } = this.state.searchData;
-      this.getTopics();
       this.handleKeepSearchChange(data.keepSearch);
-      this.props.router.navigate({
-        pathname: `/ui/${this.state.selectedCluster}/topic`,
-        search: `search=${searchData.search}&topicListView=${topicListView}&page=${this.state.pageNumber}`
-      });
+      this.navigateWithQuery(this.state.searchData, this.state.pageNumber, this.state.currentPageSize, false);
     });
   };
 
   handlePageChangeSubmission = (value, replaceInNavigation = true) => {
     let pageNumber = getPageNumber(value, this.state.totalPageNumber);
-
-    this.setState({ pageNumber: pageNumber }, () => {
-      const { search, topicListView } = this.state.searchData;
-      this.getTopics();
-      this.props.router.navigate(
-        {
-          pathname: `/ui/${this.state.selectedCluster}/topic`,
-          search: `search=${search}&topicListView=${topicListView}&page=${pageNumber}`
-        },
-        { replace: replaceInNavigation }
-      );
-    });
+    this.navigateWithQuery(this.state.searchData, pageNumber, this.state.currentPageSize, replaceInNavigation);
   };
 
   handlePageSizeChangeSubmission = value => {
-    let pageNumber = 1;
-    this.setState({ currentPageSize: value, pageNumber: pageNumber }, () => {
-      const { search, topicListView } = this.state.searchData;
-      this.getTopics();
-      this.props.router.navigate(
-        {
-          pathname: `/ui/${this.state.selectedCluster}/topic`,
-          search: `search=${search}&topicListView=${topicListView}&uiPageSize=${value}`
-        },
-        { replace: true }
-      );
-    });
+    this.navigateWithQuery(this.state.searchData, 1, value, true);
   };
 
   async getTopics() {


### PR DESCRIPTION
Fix frontend routing feedback loops causing duplicate API calls and history/back navigation issues

## Context

This PR fixes multiple frontend regressions where a single user navigation triggered duplicate backend calls (often with one call canceled), plus inconsistent back-navigation behavior.

## What Changed
- List screens moved to URL-driven loading (user action -> navigate -> location change -> sync state -> fetch)
- Sidebar navigation cleanup (Removed redundant connect navigation path to avoid double-routing from one click.)
- Topic list/details transition fix (Prevented TopicList from re-fetching when leaving the list route (e.g. clicking topic details))