### PR TITLE
Add audit events for message produce, record delete and empty topic

### DIFF
--- a/docs/docs/configuration/audit.md
+++ b/docs/docs/configuration/audit.md
@@ -7,6 +7,10 @@ akhq can be configured to emit audit event to a kafka cluster for the following 
   - Topic configuration change
   - Topic partition increase
   - Topic deletion
+- Topic data level
+  - Produce records to a topic
+  - Delete a record
+  - Empty a topic
 - Consumer group level
   - Update offsets
   - Delete offsets

--- a/src/main/java/org/akhq/models/audit/AuditEvent.java
+++ b/src/main/java/org/akhq/models/audit/AuditEvent.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
 @JsonSubTypes({
     @JsonSubTypes.Type(value = TopicAuditEvent.class, name = "TOPIC"),
+    @JsonSubTypes.Type(value = RecordAuditEvent.class, name = "RECORD"),
     @JsonSubTypes.Type(value = ConsumerGroupAuditEvent.class, name = "CONSUMER_GROUP"),
     @JsonSubTypes.Type(value = SchemaAuditEvent.class, name = "SCHEMA"),
     @JsonSubTypes.Type(value = ConnectAuditEvent.class, name = "CONNECT")
@@ -27,6 +28,9 @@ public abstract class AuditEvent {
         TOPIC_CONFIG_CHANGE,
         TOPIC_INCREASE_PARTITION,
         TOPIC_DELETE,
+        RECORD_PRODUCE,
+        RECORD_DELETE,
+        RECORD_EMPTY,
         SCHEMA_CREATE,
         SCHEMA_UPDATE,
         SCHEMA_COMPATIBILITY_UPDATE,

--- a/src/main/java/org/akhq/models/audit/RecordAuditEvent.java
+++ b/src/main/java/org/akhq/models/audit/RecordAuditEvent.java
@@ -1,0 +1,36 @@
+package org.akhq.models.audit;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RecordAuditEvent extends AuditEvent {
+
+    private ActionType actionType;
+    private String clusterId;
+    private String topicName;
+    private Integer partition;
+    private Integer recordCount;
+
+    public static RecordAuditEvent produce(String clusterId, String topicName, Integer recordCount) {
+        return new RecordAuditEvent(ActionType.RECORD_PRODUCE, clusterId, topicName, null, recordCount);
+    }
+
+    public static RecordAuditEvent delete(String clusterId, String topicName, Integer partition) {
+        return new RecordAuditEvent(ActionType.RECORD_DELETE, clusterId, topicName, partition, null);
+    }
+
+    public static RecordAuditEvent empty(String clusterId, String topicName) {
+        return new RecordAuditEvent(ActionType.RECORD_EMPTY, clusterId, topicName, null, null);
+    }
+
+    @Override
+    public String getType() {
+        return "RECORD";
+    }
+}

--- a/src/main/java/org/akhq/repositories/RecordRepository.java
+++ b/src/main/java/org/akhq/repositories/RecordRepository.java
@@ -20,6 +20,8 @@ import org.akhq.models.Partition;
 import org.akhq.models.Record;
 import org.akhq.models.Topic;
 import org.akhq.models.Schema;
+import org.akhq.models.audit.RecordAuditEvent;
+import org.akhq.modules.AuditModule;
 import org.akhq.modules.KafkaModule;
 import org.akhq.modules.schemaregistry.SchemaSerializer;
 import org.akhq.modules.schemaregistry.RecordWithSchemaSerializerFactory;
@@ -57,6 +59,9 @@ public class RecordRepository extends AbstractRepository {
     public static final String SEARCH_SPLIT_REGEX = " (?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)";
     @Inject
     private KafkaModule kafkaModule;
+
+    @Inject
+    private AuditModule auditModule;
 
     @Inject
     private ConfigRepository configRepository;
@@ -519,6 +524,7 @@ public class RecordRepository extends AbstractRepository {
             produceResults.add(
                 produce(clusterId, topic, value, headers, key, partition, timestamp, keySchema, valueSchema));
         }
+        auditModule.save(RecordAuditEvent.produce(clusterId, topic, produceResults.size()));
         return produceResults;
     }
 
@@ -575,6 +581,7 @@ public class RecordRepository extends AbstractRepository {
                     RecordsToDelete.beforeOffset(partition.getLastOffset()));
         });
         deleteRecords(clusterId, recordsToDelete);
+        auditModule.save(RecordAuditEvent.empty(clusterId, topicName));
     }
 
     public void emptyTopicByTimestamp(String clusterId,
@@ -593,7 +600,7 @@ public class RecordRepository extends AbstractRepository {
             recordsToDelete.put(topicPartition, RecordsToDelete.beforeOffset(offsetAndTimestamp.offset()));
         });
         deleteRecords(clusterId, recordsToDelete);
-
+        auditModule.save(RecordAuditEvent.empty(clusterId, topicName));
     }
 
     private void deleteRecords(String clusterId, Map<TopicPartition, RecordsToDelete> recordsToDelete) throws InterruptedException, ExecutionException {
@@ -647,12 +654,14 @@ public class RecordRepository extends AbstractRepository {
     }
 
     public RecordMetadata delete(String clusterId, String topic, Integer partition, byte[] key) throws ExecutionException, InterruptedException {
-        return kafkaModule.getProducer(clusterId).send(new ProducerRecord<>(
+        RecordMetadata recordMetadata = kafkaModule.getProducer(clusterId).send(new ProducerRecord<>(
             topic,
             partition,
             key,
             null
         )).get();
+        auditModule.save(RecordAuditEvent.delete(clusterId, topic, partition));
+        return recordMetadata;
     }
 
     public Flux<Event<SearchEvent>> search(Topic topic, Options options) throws ExecutionException, InterruptedException {

--- a/src/test/java/org/akhq/modules/audit/KafkaAuditModuleTest.java
+++ b/src/test/java/org/akhq/modules/audit/KafkaAuditModuleTest.java
@@ -1,6 +1,7 @@
 package org.akhq.modules.audit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
@@ -10,6 +11,7 @@ import org.akhq.KafkaTestCluster;
 import org.akhq.models.Config;
 import org.akhq.models.audit.AuditEvent;
 import org.akhq.models.audit.ConsumerGroupAuditEvent;
+import org.akhq.models.audit.RecordAuditEvent;
 import org.akhq.models.audit.TopicAuditEvent;
 import org.akhq.modules.KafkaModule;
 import org.akhq.repositories.*;
@@ -29,6 +31,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 
@@ -154,6 +157,91 @@ class KafkaAuditModuleTest extends AbstractTest {
 
     }
 
+    @Test
+    void recordAudit() throws ExecutionException, InterruptedException, IOException, RestClientException {
+        String generatedString = generateRandomString();
+
+        topicRepository.create(KafkaTestCluster.CLUSTER_ID, generatedString, 1, (short) 1, Collections.emptyList());
+
+        // Single produce event tests
+        recordRepository.produce(
+            KafkaTestCluster.CLUSTER_ID,
+            generatedString,
+            Optional.of("value"),
+            Collections.emptyList(),
+            Optional.of("key"),
+            Optional.of(0),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            false,
+            Optional.empty()
+        );
+
+        var produceEvent = (RecordAuditEvent) searchAuditEvent(AuditEvent.ActionType.RECORD_PRODUCE, generatedString);
+
+        assertNotNull(produceEvent);
+        assertEquals(generatedString, produceEvent.getTopicName());
+        assertEquals(KafkaTestCluster.CLUSTER_ID, produceEvent.getClusterId());
+        // The produce event records the action, not a per-record partition (records may span partitions)
+        assertNull(produceEvent.getPartition());
+        assertEquals(1, produceEvent.getRecordCount());
+
+        // Record delete event tests
+        recordRepository.delete(KafkaTestCluster.CLUSTER_ID, generatedString, 0, "key".getBytes());
+
+        var deleteEvent = (RecordAuditEvent) searchAuditEvent(AuditEvent.ActionType.RECORD_DELETE, generatedString);
+
+        assertNotNull(deleteEvent);
+        assertEquals(generatedString, deleteEvent.getTopicName());
+        assertEquals(KafkaTestCluster.CLUSTER_ID, deleteEvent.getClusterId());
+        assertEquals(0, deleteEvent.getPartition());
+
+        // Empty topic event tests
+        recordRepository.emptyTopic(KafkaTestCluster.CLUSTER_ID, generatedString);
+
+        var emptyEvent = (RecordAuditEvent) searchAuditEvent(AuditEvent.ActionType.RECORD_EMPTY, generatedString);
+
+        assertNotNull(emptyEvent);
+        assertEquals(generatedString, emptyEvent.getTopicName());
+        assertEquals(KafkaTestCluster.CLUSTER_ID, emptyEvent.getClusterId());
+
+        // A second topic to cover the multi-message produce and empty-by-timestamp paths
+        String multiTopic = generateRandomString();
+        topicRepository.create(KafkaTestCluster.CLUSTER_ID, multiTopic, 1, (short) 1, Collections.emptyList());
+
+        // Multi-message produce: recordCount must equal the number of split key/value pairs
+        recordRepository.produce(
+            KafkaTestCluster.CLUSTER_ID,
+            multiTopic,
+            Optional.of("key1=value1\nkey2=value2"),
+            Collections.emptyList(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            true,
+            Optional.of("=")
+        );
+
+        var multiProduceEvent = (RecordAuditEvent) searchAuditEvent(AuditEvent.ActionType.RECORD_PRODUCE, multiTopic);
+
+        assertNotNull(multiProduceEvent);
+        assertEquals(multiTopic, multiProduceEvent.getTopicName());
+        assertNull(multiProduceEvent.getPartition());
+        assertEquals(2, multiProduceEvent.getRecordCount());
+
+        // Empty by timestamp must also emit a RECORD_EMPTY event
+        recordRepository.emptyTopicByTimestamp(KafkaTestCluster.CLUSTER_ID, multiTopic, 0L);
+
+        var emptyByTimestampEvent = (RecordAuditEvent) searchAuditEvent(AuditEvent.ActionType.RECORD_EMPTY, multiTopic);
+
+        assertNotNull(emptyByTimestampEvent);
+        assertEquals(multiTopic, emptyByTimestampEvent.getTopicName());
+        assertEquals(KafkaTestCluster.CLUSTER_ID, emptyByTimestampEvent.getClusterId());
+    }
+
     private AuditEvent searchAuditEvent(AuditEvent.ActionType actionType, String topicName) throws IOException {
         var consumer = kafkaModule.getConsumer(KafkaTestCluster.CLUSTER_ID);
         consumer.assign(List.of(new TopicPartition(AUDIT_TOPIC_NAME, 0)));
@@ -173,6 +261,12 @@ class KafkaAuditModuleTest extends AbstractTest {
 
                 if (payload.getType().equals("TOPIC")) {
                     var event = (TopicAuditEvent) payload;
+                    if (event.getTopicName().equals(topicName) && event.getActionType().equals(actionType)) {
+                        consumer.close();
+                        return payload;
+                    }
+                } else if (payload.getType().equals("RECORD")) {
+                    var event = (RecordAuditEvent) payload;
                     if (event.getTopicName().equals(topicName) && event.getActionType().equals(actionType)) {
                         consumer.close();
                         return payload;


### PR DESCRIPTION
## What this does

Adds audit events for three topic-data actions that weren't audited yet: producing records, deleting a record, and emptying a topic.

## How

- New `RecordAuditEvent` (type `RECORD`), following the same pattern as `TopicAuditEvent` and the other audit events, and registered in `AuditEvent`'s `@JsonSubTypes`.
- Three new `ActionType` values: `RECORD_PRODUCE`, `RECORD_DELETE`, `RECORD_EMPTY`.
- `RecordRepository` emits the event after the Kafka operation succeeds, in `produce`, `delete`, `emptyTopic` and `emptyTopicByTimestamp`.
- Updated `docs/docs/configuration/audit.md`.

## A couple of choices worth flagging

Record keys and values are not logged, to keep payload data out of the audit topic. Only metadata goes in: cluster, topic, record count, and partition for deletes.

The produce event stores how many records were produced rather than a partition, since a multi-message produce can span partitions and the requested partition is usually empty. If you'd prefer per-record partition/offset there, I'm happy to add it.

## Tests

Extended `KafkaAuditModuleTest` to cover all four call sites against the embedded cluster: single produce, multi-message produce (checks the count), delete, `emptyTopic`, and `emptyTopicByTimestamp`. The audit tests pass.