### PR TITLE
feature: add per-connection topic discovery allowlist

### DIFF
--- a/application.example.yml
+++ b/application.example.yml
@@ -58,6 +58,19 @@ akhq:
     my-cluster-plain-text: # url friendly name for the cluster (letter, number, _, -, ... dot are not allowed here)
       properties: # standard kafka properties (optional)
         bootstrap.servers: "kafka:9092"
+      # Optional per-connection topic discovery allowlist. When absent or empty,
+      # AKHQ keeps requesting the complete topic list from Kafka.
+      #
+      # Values are exact topic names only: regex, wildcard and prefix matching
+      # are not supported. With a non-empty allowlist, full topic listing is
+      # skipped and missing topics are ignored with a warning.
+      #
+      # This is a discovery/performance option, not an authorization rule.
+      # Use AKHQ security group patterns to restrict access.
+      topic-discovery:
+        allowlist:
+          - "topic-a"
+          - "topic-b"
       schema-registry:
         url: "http://schema-registry:8085" # schema registry url (optional)
         type: "confluent" # schema registry type (optional). Supported types are "confluent" (default) or "tibco"
@@ -188,7 +201,7 @@ akhq:
     cluster:
       order: # Cluster display order (optional). Controls sidebar cluster ordering
         - "my-cluster-plain-text"
-        - "my-cluster-ssl" 
+        - "my-cluster-ssl"
         - "my-cluster-sasl"
 
   # Auth & Roles (optional)

--- a/docs/docs/configuration/brokers.md
+++ b/docs/docs/configuration/brokers.md
@@ -2,6 +2,8 @@
 * `akhq.connections` is a key value configuration with :
   * `key`: must be an url friendly (letter, number, _, -, ... dot are not allowed here)  string to identify your cluster (`my-cluster-1` and `my-cluster-2` is the example above)
   * `properties`: all the configurations found on [Kafka consumer documentation](https://kafka.apache.org/documentation/#consumerconfigs). Most important is `bootstrap.servers` that is a list of host:port of your Kafka brokers.
+  * `topic-discovery`: *(optional)* per-connection topic discovery options
+    * `allowlist`: exact topic names to use for topic discovery instead of requesting the complete topic list from Kafka. Omit it or leave it empty to keep the default full discovery behavior. Regex, wildcard and prefix matching are not supported. Missing topics are ignored with a warning. This is a discovery/performance option, not an authorization rule; use AKHQ security group patterns to restrict access.
   * `schema-registry`: *(optional)*
     * `url`: the schema registry url
     * `type`: the type of schema registry used, either 'confluent' or 'tibco'
@@ -31,6 +33,10 @@ akhq:
     local:
       properties:
         bootstrap.servers: "local:9092"
+      topic-discovery:
+        allowlist:
+          - "topic-a"
+          - "topic-b"
       schema-registry:
         url: "http://schema-registry:8085"
       connect:
@@ -124,7 +130,6 @@ akhq:
         sasl.mechanism: OAUTHBEARER
 ```
 I put oauth.ssl.endpoint_identification_algorithm = "" for testing or my certificates did not match the FQDN. In a production, you have to remove it.
-
 
 
 

--- a/src/main/java/org/akhq/configs/Connection.java
+++ b/src/main/java/org/akhq/configs/Connection.java
@@ -20,10 +20,17 @@ public class Connection extends AbstractProperties {
     List<Connect> connect;
     List<KsqlDb> ksqldb;
     Deserialization deserialization = new Deserialization();
+    TopicDiscovery topicDiscovery = new TopicDiscovery();
     UiOptions uiOptions = new UiOptions();
 
     public Connection(@Parameter String name) {
         super(name);
+    }
+
+    @Data
+    @ConfigurationProperties("topic-discovery")
+    public static class TopicDiscovery {
+        List<String> allowlist = new ArrayList<>();
     }
 
     @Getter
@@ -89,4 +96,3 @@ public class Connection extends AbstractProperties {
         return options;
     }
 }
-

--- a/src/main/java/org/akhq/modules/AbstractKafkaWrapper.java
+++ b/src/main/java/org/akhq/modules/AbstractKafkaWrapper.java
@@ -2,6 +2,7 @@ package org.akhq.modules;
 
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.kafka.common.KafkaFuture;
 import org.akhq.models.Partition;
 import org.akhq.models.audit.ConsumerGroupAuditEvent;
 import org.akhq.models.audit.TopicAuditEvent;
@@ -20,6 +21,7 @@ import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.SecurityDisabledException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 
 import java.util.*;
@@ -84,6 +86,45 @@ abstract public class AbstractKafkaWrapper {
                 topics
             );
 
+            this.describeTopics.get(clusterId).putAll(description);
+        }
+
+        return this.describeTopics
+            .get(clusterId)
+            .entrySet()
+            .stream()
+            .filter(e -> topics.contains(e.getKey()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    public Map<String, TopicDescription> describeExistingTopics(String clusterId, List<String> topics) throws ExecutionException, InterruptedException {
+        describeTopics.computeIfAbsent(clusterId, s -> new HashMap<>());
+
+        List<String> list = new ArrayList<>(topics);
+
+        if (!list.isEmpty()) {
+            Map<String, KafkaFuture<TopicDescription>> topicNameValues = Logger.call(
+                () -> kafkaModule.getAdminClient(clusterId)
+                    .describeTopics(list)
+                    .topicNameValues(),
+                "Describe Existing Topics {}",
+                topics
+            );
+
+            Map<String, TopicDescription> description = new HashMap<>();
+            for (Map.Entry<String, KafkaFuture<TopicDescription>> entry : topicNameValues.entrySet()) {
+                try {
+                    description.put(entry.getKey(), entry.getValue().get());
+                } catch (ExecutionException e) {
+                    if (e.getCause() instanceof UnknownTopicOrPartitionException) {
+                        continue;
+                    }
+
+                    throw e;
+                }
+            }
+
+            list.forEach(topic -> this.describeTopics.get(clusterId).remove(topic));
             this.describeTopics.get(clusterId).putAll(description);
         }
 

--- a/src/main/java/org/akhq/repositories/TopicRepository.java
+++ b/src/main/java/org/akhq/repositories/TopicRepository.java
@@ -3,11 +3,14 @@ package org.akhq.repositories;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Value;
 import io.micronaut.retry.annotation.Retryable;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.admin.TopicListing;
+import org.akhq.configs.Connection;
 import org.akhq.models.Partition;
 import org.akhq.models.Topic;
 import org.akhq.modules.AbstractKafkaWrapper;
+import org.akhq.modules.KafkaModule;
 import org.akhq.utils.PagedList;
 import org.akhq.utils.Pagination;
 
@@ -19,9 +22,13 @@ import java.util.stream.Collectors;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 
 @Singleton
+@Slf4j
 public class TopicRepository extends AbstractRepository {
     @Inject
     private AbstractKafkaWrapper kafkaWrapper;
+
+    @Inject
+    private KafkaModule kafkaModule;
 
     @Inject
     private LogDirRepository logDirRepository;
@@ -52,18 +59,65 @@ public class TopicRepository extends AbstractRepository {
     }
 
     public PagedList<Topic> list(String clusterId, Pagination pagination, TopicListView view, Optional<String> search, List<String> filters) throws ExecutionException, InterruptedException {
-        List<String> all = all(clusterId, view, search, filters);
+        TopicCandidates candidates = topicCandidates(clusterId, view, search, filters);
 
-        return PagedList.of(all, pagination, topicList -> this.findByName(clusterId, topicList));
+        if (candidates.allowlistActive()) {
+            AllowlistedTopicDescriptions descriptions = describeExistingAllowlistedTopics(clusterId, candidates.names());
+
+            return PagedList.of(
+                descriptions.names(),
+                pagination,
+                topicList -> this.findAllowlistedTopics(clusterId, topicList, descriptions.descriptions())
+            );
+        }
+
+        return PagedList.of(candidates.names(), pagination, topicList -> this.findByName(clusterId, topicList));
     }
 
     public List<String> all(String clusterId, TopicListView view, Optional<String> search, List<String> filters) throws ExecutionException, InterruptedException {
-        return kafkaWrapper.listTopics(clusterId)
+        TopicCandidates candidates = topicCandidates(clusterId, view, search, filters);
+
+        if (candidates.allowlistActive()) {
+            return describeExistingAllowlistedTopics(clusterId, candidates.names()).names();
+        }
+
+        return candidates.names();
+    }
+
+    private TopicCandidates topicCandidates(String clusterId, TopicListView view, Optional<String> search, List<String> filters) throws ExecutionException {
+        List<String> topicDiscoveryAllowlist = topicDiscoveryAllowlist(clusterId);
+
+        List<String> names = topicDiscoveryAllowlist.isEmpty() ?
+            kafkaWrapper.listTopics(clusterId)
+                .stream()
+                .map(TopicListing::name)
+                .collect(Collectors.toList()) :
+            topicDiscoveryAllowlist;
+
+        return new TopicCandidates(
+            !topicDiscoveryAllowlist.isEmpty(),
+            names
+                .stream()
+                .filter(name -> isSearchMatch(search, name) && isMatchRegex(filters, name))
+                .filter(name -> isListViewMatch(view, name))
+                .sorted(Comparator.comparing(String::toLowerCase))
+                .collect(Collectors.toList())
+        );
+    }
+
+    private List<String> topicDiscoveryAllowlist(String clusterId) {
+        Connection.TopicDiscovery topicDiscovery = kafkaModule.getConnection(clusterId).getTopicDiscovery();
+
+        if (topicDiscovery == null || topicDiscovery.getAllowlist() == null) {
+            return Collections.emptyList();
+        }
+
+        return topicDiscovery.getAllowlist()
             .stream()
-            .map(TopicListing::name)
-            .filter(name -> isSearchMatch(search, name) && isMatchRegex(filters, name))
-            .filter(name -> isListViewMatch(view, name))
-            .sorted(Comparator.comparing(String::toLowerCase))
+            .filter(Objects::nonNull)
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .distinct()
             .collect(Collectors.toList());
     }
 
@@ -88,25 +142,98 @@ public class TopicRepository extends AbstractRepository {
     }
 
     public List<Topic> findByName(String clusterId, List<String> topics) throws ExecutionException, InterruptedException {
-        ArrayList<Topic> list = new ArrayList<>();
         Set<Map.Entry<String, TopicDescription>> topicDescriptions = kafkaWrapper.describeTopics(clusterId, topics).entrySet();
         Map<String, List<Partition.Offsets>> topicOffsets = kafkaWrapper.describeTopicsOffsets(clusterId, topics);
 
+        return buildTopics(clusterId, topicDescriptions, topicOffsets);
+    }
+
+    private List<Topic> findAllowlistedTopics(String clusterId, List<String> topics, Map<String, TopicDescription> topicDescriptions) throws ExecutionException, InterruptedException {
+        List<String> existingTopics = topics.stream()
+            .filter(topicDescriptions::containsKey)
+            .collect(Collectors.toList());
+        Map<String, List<Partition.Offsets>> topicOffsets = existingTopics.isEmpty() ?
+            Collections.emptyMap() :
+            kafkaWrapper.describeTopicsOffsets(clusterId, existingTopics);
+        Set<Map.Entry<String, TopicDescription>> descriptions = existingTopics.stream()
+            .map(topic -> new AbstractMap.SimpleEntry<>(topic, topicDescriptions.get(topic)))
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        return buildTopics(clusterId, descriptions, topicOffsets);
+    }
+
+    private AllowlistedTopicDescriptions describeExistingAllowlistedTopics(String clusterId, List<String> topics) throws ExecutionException, InterruptedException {
+        Map<String, TopicDescription> topicDescriptions = kafkaWrapper.describeExistingTopics(clusterId, topics);
+
+        topics.stream()
+            .filter(topic -> !topicDescriptions.containsKey(topic))
+            .forEach(topic -> log.warn("Topic configured in topic-discovery.allowlist does not exist for cluster {}: {}", clusterId, topic));
+
+        List<String> existingNames = topics.stream()
+            .filter(topicDescriptions::containsKey)
+            .collect(Collectors.toList());
+
+        return new AllowlistedTopicDescriptions(existingNames, topicDescriptions);
+    }
+
+    private List<Topic> buildTopics(
+        String clusterId,
+        Set<Map.Entry<String, TopicDescription>> topicDescriptions,
+        Map<String, List<Partition.Offsets>> topicOffsets
+    ) throws ExecutionException, InterruptedException {
+        ArrayList<Topic> list = new ArrayList<>();
+
         for (Map.Entry<String, TopicDescription> description : topicDescriptions) {
-                list.add(
-                    new Topic(
-                        description.getValue(),
-                        logDirRepository.findByTopic(clusterId, description.getValue().name()),
-                        topicOffsets.get(description.getValue().name()),
-                        isInternal(description.getValue().name()),
-                        isStream(description.getValue().name())
-                    )
-                );
+            list.add(
+                new Topic(
+                    description.getValue(),
+                    logDirRepository.findByTopic(clusterId, description.getValue().name()),
+                    topicOffsets.get(description.getValue().name()),
+                    isInternal(description.getValue().name()),
+                    isStream(description.getValue().name())
+                )
+            );
         }
 
         list.sort(Comparator.comparing(Topic::getName));
 
         return list;
+    }
+
+    private static class TopicCandidates {
+        private final boolean allowlistActive;
+        private final List<String> names;
+
+        private TopicCandidates(boolean allowlistActive, List<String> names) {
+            this.allowlistActive = allowlistActive;
+            this.names = names;
+        }
+
+        private boolean allowlistActive() {
+            return allowlistActive;
+        }
+
+        private List<String> names() {
+            return names;
+        }
+    }
+
+    private static class AllowlistedTopicDescriptions {
+        private final List<String> names;
+        private final Map<String, TopicDescription> descriptions;
+
+        private AllowlistedTopicDescriptions(List<String> names, Map<String, TopicDescription> descriptions) {
+            this.names = names;
+            this.descriptions = descriptions;
+        }
+
+        private List<String> names() {
+            return names;
+        }
+
+        private Map<String, TopicDescription> descriptions() {
+            return descriptions;
+        }
     }
 
     private boolean isInternal(String name) {

--- a/src/test/java/org/akhq/configs/ConnectionTest.java
+++ b/src/test/java/org/akhq/configs/ConnectionTest.java
@@ -1,0 +1,37 @@
+package org.akhq.configs;
+
+import io.micronaut.context.ApplicationContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConnectionTest {
+    @Test
+    void topicDiscoveryAllowlistBindsPerConnection() {
+        try (ApplicationContext applicationContext = ApplicationContext.run(Map.of(
+            "akhq.connections.cluster-a.properties.bootstrap.servers", "localhost:9092",
+            "akhq.connections.cluster-a.topic-discovery.allowlist[0]", "topic-a",
+            "akhq.connections.cluster-a.topic-discovery.allowlist[1]", "topic-b",
+            "akhq.connections.cluster-b.properties.bootstrap.servers", "localhost:9093"
+        ))) {
+            Collection<Connection> connections = applicationContext.getBeansOfType(Connection.class);
+            Connection clusterA = connection(connections, "cluster-a");
+            Connection clusterB = connection(connections, "cluster-b");
+
+            assertEquals(List.of("topic-a", "topic-b"), clusterA.getTopicDiscovery().getAllowlist());
+            assertTrue(clusterB.getTopicDiscovery().getAllowlist().isEmpty());
+        }
+    }
+
+    private Connection connection(Collection<Connection> connections, String name) {
+        return connections.stream()
+            .filter(connection -> name.equals(connection.getName()))
+            .findFirst()
+            .orElseThrow();
+    }
+}

--- a/src/test/java/org/akhq/modules/AbstractKafkaWrapperTest.java
+++ b/src/test/java/org/akhq/modules/AbstractKafkaWrapperTest.java
@@ -1,0 +1,206 @@
+package org.akhq.modules;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractKafkaWrapperTest {
+    private static final String CLUSTER_ID = "cluster-a";
+
+    @Mock
+    private KafkaModule kafkaModule;
+
+    @Mock
+    private AdminClient adminClient;
+
+    @Mock
+    private DescribeTopicsResult describeTopicsResult;
+
+    private TestKafkaWrapper kafkaWrapper;
+
+    @BeforeEach
+    void beforeEach() throws Exception {
+        kafkaWrapper = new TestKafkaWrapper();
+
+        Field kafkaModuleField = AbstractKafkaWrapper.class.getDeclaredField("kafkaModule");
+        kafkaModuleField.setAccessible(true);
+        kafkaModuleField.set(kafkaWrapper, kafkaModule);
+    }
+
+    @Test
+    void describeExistingTopicsOmitsUnknownTopicFromSingleBatch() throws Exception {
+        KafkaFuture<TopicDescription> existingFuture = successfulFuture(
+            new TopicDescription("topic-existing", false, List.of())
+        );
+        KafkaFuture<TopicDescription> missingFuture = failedFuture(
+            new UnknownTopicOrPartitionException("missing")
+        );
+
+        when(kafkaModule.getAdminClient(CLUSTER_ID)).thenReturn(adminClient);
+        when(adminClient.describeTopics(List.of("topic-existing", "topic-missing"))).thenReturn(describeTopicsResult);
+        when(describeTopicsResult.topicNameValues()).thenReturn(Map.of(
+            "topic-existing", existingFuture,
+            "topic-missing", missingFuture
+        ));
+
+        Map<String, TopicDescription> descriptions = kafkaWrapper.describeExistingTopics(CLUSTER_ID, List.of(
+            "topic-existing",
+            "topic-missing"
+        ));
+
+        assertEquals(List.of("topic-existing"), descriptions.keySet().stream().toList());
+        verify(adminClient).describeTopics(List.of("topic-existing", "topic-missing"));
+    }
+
+    @Test
+    void describeExistingTopicsRefreshesPreviouslyCachedMissingTopic() throws Exception {
+        DescribeTopicsResult firstDescribeTopicsResult = mock(DescribeTopicsResult.class);
+        DescribeTopicsResult secondDescribeTopicsResult = mock(DescribeTopicsResult.class);
+
+        KafkaFuture<TopicDescription> existingFuture = successfulFuture(
+            new TopicDescription("topic-a", false, List.of())
+        );
+        KafkaFuture<TopicDescription> missingFuture = failedFuture(
+            new UnknownTopicOrPartitionException("missing")
+        );
+
+        when(kafkaModule.getAdminClient(CLUSTER_ID)).thenReturn(adminClient);
+        when(adminClient.describeTopics(List.of("topic-a"))).thenReturn(firstDescribeTopicsResult, secondDescribeTopicsResult);
+        when(firstDescribeTopicsResult.topicNameValues()).thenReturn(Map.of(
+            "topic-a", existingFuture
+        ));
+        when(secondDescribeTopicsResult.topicNameValues()).thenReturn(Map.of(
+            "topic-a", missingFuture
+        ));
+
+        Map<String, TopicDescription> firstDescriptions = kafkaWrapper.describeExistingTopics(CLUSTER_ID, List.of("topic-a"));
+        Map<String, TopicDescription> secondDescriptions = kafkaWrapper.describeExistingTopics(CLUSTER_ID, List.of("topic-a"));
+
+        assertEquals(Set.of("topic-a"), firstDescriptions.keySet());
+        assertTrue(secondDescriptions.isEmpty());
+        verify(adminClient, times(2)).describeTopics(List.of("topic-a"));
+    }
+
+    @Test
+    void describeExistingTopicsDoesNotSwallowUnrelatedKafkaErrors() throws Exception {
+        KafkaFuture<TopicDescription> timeoutFuture = failedFuture(new TimeoutException("timeout"));
+
+        when(kafkaModule.getAdminClient(CLUSTER_ID)).thenReturn(adminClient);
+        when(adminClient.describeTopics(List.of("topic-a"))).thenReturn(describeTopicsResult);
+        when(describeTopicsResult.topicNameValues()).thenReturn(Map.of(
+            "topic-a", timeoutFuture
+        ));
+
+        ExecutionException exception = assertThrows(
+            ExecutionException.class,
+            () -> kafkaWrapper.describeExistingTopics(CLUSTER_ID, List.of("topic-a"))
+        );
+
+        assertInstanceOf(TimeoutException.class, exception.getCause());
+    }
+
+    @Test
+    void describeExistingTopicsOnlyOmitsUnknownTopicFromExecutionExceptionCause() throws Exception {
+        KafkaFuture<TopicDescription> future = mockFuture();
+        when(future.get()).thenThrow(new UnknownTopicOrPartitionException("missing"));
+
+        when(kafkaModule.getAdminClient(CLUSTER_ID)).thenReturn(adminClient);
+        when(adminClient.describeTopics(List.of("topic-a"))).thenReturn(describeTopicsResult);
+        when(describeTopicsResult.topicNameValues()).thenReturn(Map.of(
+            "topic-a", future
+        ));
+
+        assertThrows(
+            UnknownTopicOrPartitionException.class,
+            () -> kafkaWrapper.describeExistingTopics(CLUSTER_ID, List.of("topic-a"))
+        );
+    }
+
+    @Test
+    void describeExistingTopicsRefreshesRequestedCacheEntriesWithoutClearingUnrelatedTopics() throws Exception {
+        DescribeTopicsResult initialDescribeTopicsResult = mock(DescribeTopicsResult.class);
+        DescribeTopicsResult refreshDescribeTopicsResult = mock(DescribeTopicsResult.class);
+
+        KafkaFuture<TopicDescription> initialTopicAFuture = successfulFuture(
+            new TopicDescription("topic-a", false, List.of())
+        );
+        KafkaFuture<TopicDescription> unrelatedTopicFuture = successfulFuture(
+            new TopicDescription("unrelated-topic", false, List.of())
+        );
+        KafkaFuture<TopicDescription> missingTopicAFuture = failedFuture(
+            new UnknownTopicOrPartitionException("missing")
+        );
+        KafkaFuture<TopicDescription> topicBFuture = successfulFuture(
+            new TopicDescription("topic-b", false, List.of())
+        );
+
+        when(kafkaModule.getAdminClient(CLUSTER_ID)).thenReturn(adminClient);
+        when(adminClient.describeTopics(List.of("topic-a", "unrelated-topic"))).thenReturn(initialDescribeTopicsResult);
+        when(initialDescribeTopicsResult.topicNameValues()).thenReturn(Map.of(
+            "topic-a", initialTopicAFuture,
+            "unrelated-topic", unrelatedTopicFuture
+        ));
+
+        kafkaWrapper.describeExistingTopics(CLUSTER_ID, List.of("topic-a", "unrelated-topic"));
+
+        when(adminClient.describeTopics(List.of("topic-a", "topic-b"))).thenReturn(refreshDescribeTopicsResult);
+        when(refreshDescribeTopicsResult.topicNameValues()).thenReturn(Map.of(
+            "topic-a", missingTopicAFuture,
+            "topic-b", topicBFuture
+        ));
+
+        Map<String, TopicDescription> descriptions = kafkaWrapper.describeExistingTopics(CLUSTER_ID, List.of("topic-a", "topic-b"));
+        Map<String, TopicDescription> unrelatedDescription = kafkaWrapper.describeTopics(CLUSTER_ID, List.of("unrelated-topic"));
+
+        assertEquals(Set.of("topic-b"), descriptions.keySet());
+        assertEquals(Set.of("unrelated-topic"), unrelatedDescription.keySet());
+        verify(adminClient).describeTopics(List.of("topic-a", "unrelated-topic"));
+        verify(adminClient).describeTopics(List.of("topic-a", "topic-b"));
+        verify(adminClient, never()).describeTopics(List.of("unrelated-topic"));
+    }
+
+    private KafkaFuture<TopicDescription> successfulFuture(TopicDescription description) throws ExecutionException, InterruptedException {
+        KafkaFuture<TopicDescription> future = mockFuture();
+        when(future.get()).thenReturn(description);
+        return future;
+    }
+
+    private KafkaFuture<TopicDescription> failedFuture(Throwable throwable) throws ExecutionException, InterruptedException {
+        KafkaFuture<TopicDescription> future = mockFuture();
+        when(future.get()).thenThrow(new ExecutionException(throwable));
+        return future;
+    }
+
+    @SuppressWarnings("unchecked")
+    private KafkaFuture<TopicDescription> mockFuture() {
+        return mock(KafkaFuture.class);
+    }
+
+    private static class TestKafkaWrapper extends AbstractKafkaWrapper {
+    }
+}

--- a/src/test/java/org/akhq/repositories/TopicRepositoryTopicDiscoveryAllowlistTest.java
+++ b/src/test/java/org/akhq/repositories/TopicRepositoryTopicDiscoveryAllowlistTest.java
@@ -1,0 +1,543 @@
+package org.akhq.repositories;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.admin.TopicListing;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.akhq.configs.Connection;
+import org.akhq.models.Partition;
+import org.akhq.models.Topic;
+import org.akhq.modules.AbstractKafkaWrapper;
+import org.akhq.modules.KafkaModule;
+import org.akhq.utils.PagedList;
+import org.akhq.utils.Pagination;
+import org.codehaus.httpcache4j.uri.URIBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TopicRepositoryTopicDiscoveryAllowlistTest {
+    private static final String CLUSTER_A = "cluster-a";
+    private static final String CLUSTER_B = "cluster-b";
+
+    @Mock
+    private AbstractKafkaWrapper kafkaWrapper;
+
+    @Mock
+    private KafkaModule kafkaModule;
+
+    @Mock
+    private LogDirRepository logDirRepository;
+
+    private TopicRepository topicRepository;
+
+    @BeforeEach
+    void beforeEach() throws Exception {
+        topicRepository = new TopicRepository();
+        topicRepository.internalRegexps = List.of("^_.*$");
+        topicRepository.streamRegexps = List.of("^.*-changelog$", "^.*-repartition$", "^.*-rekey$");
+
+        setField("kafkaWrapper", kafkaWrapper);
+        setField("kafkaModule", kafkaModule);
+        setField("logDirRepository", logDirRepository);
+
+        lenient().when(logDirRepository.findByTopic(anyString(), anyString())).thenReturn(Collections.emptyList());
+    }
+
+    @Test
+    void absentTopicDiscoveryAllowlistUsesFullTopicDiscovery() throws ExecutionException, InterruptedException {
+        configureConnection(CLUSTER_A, null);
+        mockListTopics(CLUSTER_A, "topic-a", "topic-b");
+        mockTopicDetails(CLUSTER_A);
+
+        PagedList<Topic> topics = topicRepository.list(
+            CLUSTER_A,
+            new Pagination(10, URIBuilder.empty(), 1),
+            TopicRepository.TopicListView.ALL,
+            java.util.Optional.empty(),
+            List.of()
+        );
+
+        assertEquals(List.of("topic-a", "topic-b"), names(topics));
+        verify(kafkaWrapper).listTopics(CLUSTER_A);
+        verify(kafkaWrapper, never()).describeExistingTopics(eq(CLUSTER_A), anyList());
+    }
+
+    @Test
+    void emptyTopicDiscoveryAllowlistUsesFullTopicDiscovery() throws ExecutionException, InterruptedException {
+        configureConnection(CLUSTER_A, List.of());
+        mockListTopics(CLUSTER_A, "topic-a");
+        mockTopicDetails(CLUSTER_A);
+
+        PagedList<Topic> topics = topicRepository.list(
+            CLUSTER_A,
+            new Pagination(10, URIBuilder.empty(), 1),
+            TopicRepository.TopicListView.ALL,
+            java.util.Optional.empty(),
+            List.of()
+        );
+
+        assertEquals(List.of("topic-a"), names(topics));
+        verify(kafkaWrapper).listTopics(CLUSTER_A);
+        verify(kafkaWrapper, never()).describeExistingTopics(eq(CLUSTER_A), anyList());
+    }
+
+    @Test
+    void blankTopicDiscoveryAllowlistUsesFullTopicDiscovery() throws ExecutionException, InterruptedException {
+        configureConnection(CLUSTER_A, List.of("", "   "));
+        mockListTopics(CLUSTER_A, "topic-a");
+        mockTopicDetails(CLUSTER_A);
+
+        PagedList<Topic> topics = topicRepository.list(
+            CLUSTER_A,
+            new Pagination(10, URIBuilder.empty(), 1),
+            TopicRepository.TopicListView.ALL,
+            java.util.Optional.empty(),
+            List.of()
+        );
+
+        assertEquals(List.of("topic-a"), names(topics));
+        verify(kafkaWrapper).listTopics(CLUSTER_A);
+        verify(kafkaWrapper, never()).describeExistingTopics(eq(CLUSTER_A), anyList());
+    }
+
+    @Test
+    void activeTopicDiscoveryAllowlistSkipsFullTopicDiscoveryAndSortsCandidates() throws ExecutionException, InterruptedException {
+        configureConnection(CLUSTER_A, List.of("topic-b", "topic-a", "topic-c"));
+        mockTopicDetails(CLUSTER_A);
+
+        PagedList<Topic> topics = topicRepository.list(
+            CLUSTER_A,
+            new Pagination(10, URIBuilder.empty(), 1),
+            TopicRepository.TopicListView.ALL,
+            java.util.Optional.empty(),
+            List.of()
+        );
+
+        assertEquals(List.of("topic-a", "topic-b", "topic-c"), names(topics));
+        verify(kafkaWrapper, never()).listTopics(CLUSTER_A);
+        verify(kafkaWrapper).describeExistingTopics(CLUSTER_A, List.of("topic-a", "topic-b", "topic-c"));
+    }
+
+    @Test
+    void topicDiscoveryAllowlistNormalizesValues() throws ExecutionException, InterruptedException {
+        configureConnection(CLUSTER_A, Arrays.asList(" topic-a ", "topic-a", "", "   ", null, "topic-b"));
+        mockTopicDetails(CLUSTER_A);
+
+        PagedList<Topic> topics = topicRepository.list(
+            CLUSTER_A,
+            new Pagination(10, URIBuilder.empty(), 1),
+            TopicRepository.TopicListView.ALL,
+            java.util.Optional.empty(),
+            List.of()
+        );
+
+        assertEquals(List.of("topic-a", "topic-b"), names(topics));
+        verify(kafkaWrapper, never()).listTopics(CLUSTER_A);
+        verify(kafkaWrapper).describeExistingTopics(CLUSTER_A, List.of("topic-a", "topic-b"));
+    }
+
+    @Test
+    void topicDiscoveryAllowlistIntersectsWithRbacPatterns() throws ExecutionException, InterruptedException {
+        configureConnection(CLUSTER_A, List.of("topic-a", "topic-b", "secret-topic"));
+        mockTopicDetails(CLUSTER_A);
+
+        PagedList<Topic> topics = topicRepository.list(
+            CLUSTER_A,
+            new Pagination(10, URIBuilder.empty(), 1),
+            TopicRepository.TopicListView.ALL,
+            java.util.Optional.empty(),
+            List.of("^topic-.*$")
+        );
+
+        assertEquals(List.of("topic-a", "topic-b"), names(topics));
+        verify(kafkaWrapper, never()).listTopics(CLUSTER_A);
+        verify(kafkaWrapper).describeExistingTopics(CLUSTER_A, List.of("topic-a", "topic-b"));
+    }
+
+    @Test
+    void topicDiscoveryAllowlistIntersectsWithSearch() throws ExecutionException, InterruptedException {
+        configureConnection(CLUSTER_A, List.of("orders-created", "orders-paid", "customers-created"));
+        mockTopicDetails(CLUSTER_A);
+
+        PagedList<Topic> topics = topicRepository.list(
+            CLUSTER_A,
+            new Pagination(10, URIBuilder.empty(), 1),
+            TopicRepository.TopicListView.ALL,
+            java.util.Optional.of("orders"),
+            List.of()
+        );
+
+        assertEquals(List.of("orders-created", "orders-paid"), names(topics));
+        verify(kafkaWrapper, never()).listTopics(CLUSTER_A);
+        verify(kafkaWrapper).describeExistingTopics(CLUSTER_A, List.of("orders-created", "orders-paid"));
+    }
+
+    @Test
+    void topicDiscoveryAllowlistStillAppliesTopicListViews() throws ExecutionException, InterruptedException {
+        configureConnection(CLUSTER_A, List.of("topic-a", "_consumer_offsets", "topic-changelog"));
+        mockTopicDetails(CLUSTER_A);
+
+        PagedList<Topic> topics = topicRepository.list(
+            CLUSTER_A,
+            new Pagination(10, URIBuilder.empty(), 1),
+            TopicRepository.TopicListView.HIDE_INTERNAL_STREAM,
+            java.util.Optional.empty(),
+            List.of()
+        );
+
+        assertEquals(List.of("topic-a"), names(topics));
+        verify(kafkaWrapper, never()).listTopics(CLUSTER_A);
+        verify(kafkaWrapper).describeExistingTopics(CLUSTER_A, List.of("topic-a"));
+    }
+
+    @Test
+    void topicDiscoveryAllowlistIsIsolatedPerConnection() throws ExecutionException, InterruptedException {
+        configureConnection(CLUSTER_A, List.of("topic-a"));
+        configureConnection(CLUSTER_B, null);
+        mockListTopics(CLUSTER_B, "topic-b");
+        mockTopicDetails(CLUSTER_A);
+        mockTopicDetails(CLUSTER_B);
+
+        PagedList<Topic> clusterATopics = topicRepository.list(
+            CLUSTER_A,
+            new Pagination(10, URIBuilder.empty(), 1),
+            TopicRepository.TopicListView.ALL,
+            java.util.Optional.empty(),
+            List.of()
+        );
+        PagedList<Topic> clusterBTopics = topicRepository.list(
+            CLUSTER_B,
+            new Pagination(10, URIBuilder.empty(), 1),
+            TopicRepository.TopicListView.ALL,
+            java.util.Optional.empty(),
+            List.of()
+        );
+
+        assertEquals(List.of("topic-a"), names(clusterATopics));
+        assertEquals(List.of("topic-b"), names(clusterBTopics));
+        verify(kafkaWrapper, never()).listTopics(CLUSTER_A);
+        verify(kafkaWrapper).listTopics(CLUSTER_B);
+    }
+
+    @Test
+    void topicDiscoveryAllowlistResolvesExistenceBeforePaginationAndOffsetsOnlySelectedPage() throws ExecutionException, InterruptedException {
+        configureConnection(CLUSTER_A, List.of("topic-a", "topic-b", "topic-c", "topic-d"));
+        mockTopicDetails(CLUSTER_A);
+
+        PagedList<Topic> topics = topicRepository.list(
+            CLUSTER_A,
+            new Pagination(2, URIBuilder.empty(), 2),
+            TopicRepository.TopicListView.ALL,
+            java.util.Optional.empty(),
+            List.of()
+        );
+
+        assertEquals(List.of("topic-c", "topic-d"), names(topics));
+        assertEquals(4, topics.total());
+        verify(kafkaWrapper, never()).listTopics(CLUSTER_A);
+        verify(kafkaWrapper).describeExistingTopics(CLUSTER_A, List.of("topic-a", "topic-b", "topic-c", "topic-d"));
+        verify(kafkaWrapper).describeTopicsOffsets(CLUSTER_A, List.of("topic-c", "topic-d"));
+    }
+
+    @Test
+    void missingAllowlistedTopicBeforePageBoundaryDoesNotShortenFirstPage() throws ExecutionException, InterruptedException {
+        configureConnection(CLUSTER_A, List.of("a-missing", "b-existing", "c-existing"));
+        when(kafkaWrapper.describeExistingTopics(CLUSTER_A, List.of("a-missing", "b-existing", "c-existing"))).thenReturn(descriptions(List.of(
+            "b-existing",
+            "c-existing"
+        )));
+        when(kafkaWrapper.describeTopicsOffsets(eq(CLUSTER_A), anyList())).thenAnswer(invocation -> offsets(invocation.getArgument(1)));
+
+        PagedList<Topic> topics = topicRepository.list(
+            CLUSTER_A,
+            new Pagination(2, URIBuilder.empty(), 1),
+            TopicRepository.TopicListView.ALL,
+            java.util.Optional.empty(),
+            List.of()
+        );
+
+        assertEquals(List.of("b-existing", "c-existing"), names(topics));
+        assertEquals(2, topics.total());
+        verify(kafkaWrapper, never()).listTopics(CLUSTER_A);
+        verify(kafkaWrapper).describeExistingTopics(CLUSTER_A, List.of("a-missing", "b-existing", "c-existing"));
+        verify(kafkaWrapper).describeTopicsOffsets(CLUSTER_A, List.of("b-existing", "c-existing"));
+    }
+
+    @Test
+    void missingAllowlistedTopicBetweenPagesDoesNotSkipExistingTopics() throws ExecutionException, InterruptedException {
+        configureConnection(CLUSTER_A, List.of("e-existing", "d-existing", "c-existing", "b-missing", "a-existing"));
+        when(kafkaWrapper.describeExistingTopics(CLUSTER_A, List.of("a-existing", "b-missing", "c-existing", "d-existing", "e-existing"))).thenReturn(descriptions(List.of(
+            "a-existing",
+            "c-existing",
+            "d-existing",
+            "e-existing"
+        )));
+        when(kafkaWrapper.describeTopicsOffsets(eq(CLUSTER_A), anyList())).thenAnswer(invocation -> offsets(invocation.getArgument(1)));
+
+        PagedList<Topic> topics = topicRepository.list(
+            CLUSTER_A,
+            new Pagination(2, URIBuilder.empty(), 2),
+            TopicRepository.TopicListView.ALL,
+            java.util.Optional.empty(),
+            List.of()
+        );
+
+        assertEquals(List.of("d-existing", "e-existing"), names(topics));
+        assertEquals(4, topics.total());
+        verify(kafkaWrapper, never()).listTopics(CLUSTER_A);
+        verify(kafkaWrapper).describeExistingTopics(CLUSTER_A, List.of("a-existing", "b-missing", "c-existing", "d-existing", "e-existing"));
+        verify(kafkaWrapper).describeTopicsOffsets(CLUSTER_A, List.of("d-existing", "e-existing"));
+    }
+
+    @Test
+    void allConfiguredAllowlistedTopicsMissingReturnsEmptyPageWithoutOffsets() throws ExecutionException, InterruptedException {
+        configureConnection(CLUSTER_A, List.of("a-missing", "b-missing"));
+        when(kafkaWrapper.describeExistingTopics(CLUSTER_A, List.of("a-missing", "b-missing"))).thenReturn(Collections.emptyMap());
+
+        ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(TopicRepository.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        try {
+            PagedList<Topic> topics = topicRepository.list(
+                CLUSTER_A,
+                new Pagination(2, URIBuilder.empty(), 1),
+                TopicRepository.TopicListView.ALL,
+                java.util.Optional.empty(),
+                List.of()
+            );
+
+            assertEquals(List.of(), names(topics));
+            assertEquals(0, topics.total());
+            assertTrue(hasWarning(appender, "a-missing"));
+            assertTrue(hasWarning(appender, "b-missing"));
+        } finally {
+            logger.detachAppender(appender);
+        }
+
+        verify(kafkaWrapper, never()).listTopics(CLUSTER_A);
+        verify(kafkaWrapper).describeExistingTopics(CLUSTER_A, List.of("a-missing", "b-missing"));
+        verify(kafkaWrapper, never()).describeTopicsOffsets(eq(CLUSTER_A), anyList());
+        verify(logDirRepository, never()).findByTopic(eq(CLUSTER_A), anyString());
+    }
+
+    @Test
+    void missingAllowlistedTopicIsOmittedAndWarnedWithoutFallback() throws ExecutionException, InterruptedException {
+        configureConnection(CLUSTER_A, List.of("topic-existing-a", "topic-missing", "topic-existing-b"));
+        when(kafkaWrapper.describeExistingTopics(eq(CLUSTER_A), anyList())).thenReturn(descriptions(List.of(
+            "topic-existing-a",
+            "topic-existing-b"
+        )));
+        when(kafkaWrapper.describeTopicsOffsets(eq(CLUSTER_A), anyList())).thenAnswer(invocation -> offsets(invocation.getArgument(1)));
+
+        ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(TopicRepository.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        try {
+            PagedList<Topic> topics = topicRepository.list(
+                CLUSTER_A,
+                new Pagination(10, URIBuilder.empty(), 1),
+                TopicRepository.TopicListView.ALL,
+                java.util.Optional.empty(),
+                List.of()
+            );
+
+            assertEquals(List.of("topic-existing-a", "topic-existing-b"), names(topics));
+            assertTrue(appender.list.stream().anyMatch(event ->
+                event.getLevel().equals(Level.WARN) &&
+                    event.getFormattedMessage().contains(CLUSTER_A) &&
+                    event.getFormattedMessage().contains("topic-missing")
+            ));
+        } finally {
+            logger.detachAppender(appender);
+        }
+
+        verify(kafkaWrapper, never()).listTopics(CLUSTER_A);
+        verify(kafkaWrapper).describeTopicsOffsets(CLUSTER_A, List.of("topic-existing-a", "topic-existing-b"));
+    }
+
+    @Test
+    void unrelatedAllowlistDescribeExceptionIsNotSwallowed() throws ExecutionException, InterruptedException {
+        configureConnection(CLUSTER_A, List.of("topic-a"));
+        when(kafkaWrapper.describeExistingTopics(eq(CLUSTER_A), anyList()))
+            .thenThrow(new ExecutionException(new TimeoutException("timeout")));
+
+        assertThrows(ExecutionException.class, () -> topicRepository.list(
+            CLUSTER_A,
+            new Pagination(10, URIBuilder.empty(), 1),
+            TopicRepository.TopicListView.ALL,
+            java.util.Optional.empty(),
+            List.of()
+        ));
+
+        verify(kafkaWrapper, never()).listTopics(CLUSTER_A);
+    }
+
+    @Test
+    void directTopicLookupIsIndependentFromTopicDiscoveryAllowlist() throws ExecutionException, InterruptedException {
+        configureConnection(CLUSTER_A, List.of("topic-a"));
+        mockTopicDetails(CLUSTER_A);
+
+        Topic topic = topicRepository.findByName(CLUSTER_A, "outside-topic");
+
+        assertEquals("outside-topic", topic.getName());
+        verify(kafkaWrapper).describeTopics(CLUSTER_A, List.of("outside-topic"));
+        verify(kafkaWrapper, never()).describeExistingTopics(eq(CLUSTER_A), anyList());
+        verify(kafkaWrapper, never()).listTopics(CLUSTER_A);
+    }
+
+    @Test
+    void allNamesWithTopicDiscoveryAllowlistOmitsMissingTopics() throws ExecutionException, InterruptedException {
+        configureConnection(CLUSTER_A, List.of("topic-existing-a", "topic-missing", "topic-existing-b"));
+        when(kafkaWrapper.describeExistingTopics(eq(CLUSTER_A), anyList())).thenReturn(descriptions(List.of(
+            "topic-existing-a",
+            "topic-existing-b"
+        )));
+
+        List<String> topics = topicRepository.all(
+            CLUSTER_A,
+            TopicRepository.TopicListView.ALL,
+            java.util.Optional.empty(),
+            List.of()
+        );
+
+        assertEquals(List.of("topic-existing-a", "topic-existing-b"), topics);
+        verify(kafkaWrapper, never()).listTopics(CLUSTER_A);
+    }
+
+    @Test
+    void fullDiscoveryAllNamesUsesListTopicsWhenAllowlistAbsent() throws ExecutionException, InterruptedException {
+        configureConnection(CLUSTER_A, null);
+        mockListTopics(CLUSTER_A, "topic-b", "topic-a");
+
+        List<String> topics = topicRepository.all(
+            CLUSTER_A,
+            TopicRepository.TopicListView.ALL,
+            java.util.Optional.empty(),
+            List.of()
+        );
+
+        assertEquals(List.of("topic-a", "topic-b"), topics);
+        verify(kafkaWrapper).listTopics(CLUSTER_A);
+    }
+
+    @Test
+    void allowlistMetadataRequestsUseFilteredCandidatesAndSelectedPageOffsets() throws ExecutionException, InterruptedException {
+        configureConnection(CLUSTER_A, List.of("topic-a", "topic-b", "topic-c", "topic-d", "topic-e", "other"));
+        mockTopicDetails(CLUSTER_A);
+
+        topicRepository.list(
+            CLUSTER_A,
+            new Pagination(2, URIBuilder.empty(), 1),
+            TopicRepository.TopicListView.ALL,
+            java.util.Optional.of("topic"),
+            List.of()
+        );
+
+        ArgumentCaptor<List<String>> descriptionsCaptor = listCaptor();
+        ArgumentCaptor<List<String>> offsetsCaptor = listCaptor();
+        verify(kafkaWrapper).describeExistingTopics(eq(CLUSTER_A), descriptionsCaptor.capture());
+        verify(kafkaWrapper).describeTopicsOffsets(eq(CLUSTER_A), offsetsCaptor.capture());
+
+        assertEquals(List.of("topic-a", "topic-b", "topic-c", "topic-d", "topic-e"), descriptionsCaptor.getValue());
+        assertEquals(List.of("topic-a", "topic-b"), offsetsCaptor.getValue());
+        verify(kafkaWrapper, never()).listTopics(CLUSTER_A);
+    }
+
+    private void configureConnection(String clusterId, List<String> allowlist) {
+        Connection connection = new Connection(clusterId);
+        if (allowlist != null) {
+            connection.getTopicDiscovery().setAllowlist(allowlist);
+        }
+
+        lenient().when(kafkaModule.getConnection(clusterId)).thenReturn(connection);
+    }
+
+    private void mockListTopics(String clusterId, String... topics) throws ExecutionException {
+        List<TopicListing> listings = Arrays.stream(topics)
+            .map(this::topicListing)
+            .collect(Collectors.toList());
+
+        when(kafkaWrapper.listTopics(clusterId)).thenReturn(listings);
+    }
+
+    private void mockTopicDetails(String clusterId) throws ExecutionException, InterruptedException {
+        lenient().when(kafkaWrapper.describeExistingTopics(eq(clusterId), anyList())).thenAnswer(invocation -> descriptions(invocation.getArgument(1)));
+        lenient().when(kafkaWrapper.describeTopics(eq(clusterId), anyList())).thenAnswer(invocation -> descriptions(invocation.getArgument(1)));
+        lenient().when(kafkaWrapper.describeTopicsOffsets(eq(clusterId), anyList())).thenAnswer(invocation -> offsets(invocation.getArgument(1)));
+    }
+
+    private TopicListing topicListing(String name) {
+        TopicListing listing = org.mockito.Mockito.mock(TopicListing.class);
+        when(listing.name()).thenReturn(name);
+        return listing;
+    }
+
+    private Map<String, TopicDescription> descriptions(List<String> topics) {
+        Map<String, TopicDescription> descriptions = new LinkedHashMap<>();
+        topics.forEach(topic -> descriptions.put(topic, new TopicDescription(topic, false, List.of())));
+        return descriptions;
+    }
+
+    private Map<String, List<Partition.Offsets>> offsets(List<String> topics) {
+        Map<String, List<Partition.Offsets>> offsets = new LinkedHashMap<>();
+        topics.forEach(topic -> offsets.put(topic, List.of()));
+        return offsets;
+    }
+
+    private List<String> names(List<Topic> topics) {
+        return topics.stream()
+            .map(Topic::getName)
+            .collect(Collectors.toList());
+    }
+
+    private boolean hasWarning(ListAppender<ILoggingEvent> appender, String topic) {
+        return appender.list.stream().anyMatch(event ->
+            event.getLevel().equals(Level.WARN) &&
+                event.getFormattedMessage().contains(CLUSTER_A) &&
+                event.getFormattedMessage().contains(topic)
+        );
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private ArgumentCaptor<List<String>> listCaptor() {
+        return ArgumentCaptor.forClass((Class) List.class);
+    }
+
+    private void setField(String name, Object value) throws Exception {
+        Field field = TopicRepository.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(topicRepository, value);
+    }
+}


### PR DESCRIPTION
## Overview

Adds an optional per-connection topic discovery allowlist.

When a non-empty allowlist is configured, AKHQ uses the configured exact topic names as discovery candidates instead of requesting the complete topic list from Kafka.

## Motivation

AKHQ currently calls `listTopics()` before applying search, RBAC and topic view filters.

For clusters with a large topic catalogue or slow connectivity, requesting the complete topic list can be unnecessarily expensive when only a small, known set of topics is relevant.

## Configuration

```yaml
akhq:
  connections:
    my-cluster:
      properties:
        bootstrap.servers: "kafka:9092"

      topic-discovery:
        allowlist:
          - "topic-a"
          - "topic-b"
```

## Behaviour

* The configuration is optional and scoped per connection.
* An absent, empty or effectively blank allowlist preserves the existing full-discovery behaviour.
* Topic names use exact, case-sensitive matching.
* Blank values are ignored and duplicate names are removed.
* Search, RBAC patterns, topic views, sorting and pagination continue to apply.
* Missing configured topics are omitted and logged as warnings.
* Missing topics are removed before pagination totals and page boundaries are calculated.
* Topic offsets and full topic details are requested only for topics on the selected page.
* Direct topic operations remain independent from the discovery allowlist.
* The allowlist is a discovery and performance option, not an authorization mechanism.

## Backward compatibility

Existing configurations are unaffected.

No frontend or HTTP API changes are introduced.

## Validation

* Added per-connection configuration binding coverage.
* Added Kafka wrapper tests for batched per-topic result handling, missing topics and cache refresh.
* Added repository tests covering:

  * absent, empty and blank allowlists;
  * normalization and duplicate removal;
  * RBAC, search and topic views;
  * connection isolation;
  * missing topics;
  * pagination boundaries and totals;
  * page-scoped offset retrieval;
  * direct topic lookup independence.
* Existing `TopicRepositoryTest` coverage remains passing.
* Manually verified using an external AKHQ configuration against a Kafka connection.
* Full Gradle `clean build` completed successfully:

  * 317 tests;
  * 0 failures;
  * 0 errors;
  * 6 skipped.
