### PR TITLE
fix(avro): handle null values in map/array of nullable union

### DIFF
--- a/src/main/java/org/akhq/utils/AvroDeserializer.java
+++ b/src/main/java/org/akhq/utils/AvroDeserializer.java
@@ -114,6 +114,15 @@ public class AvroDeserializer {
     }
 
     private static Object unionDeserializer(Object value, Schema schema) {
+        if (value == null) {
+            return schema
+                .getTypes()
+                .stream()
+                .filter(type -> type.getType() == Type.NULL)
+                .findFirst()
+                .map(type -> AvroDeserializer.objectDeserializer(null, type))
+                .orElse(null);
+        }
         return AvroDeserializer.objectDeserializer(value, schema
             .getTypes()
             .stream()
@@ -129,13 +138,9 @@ public class AvroDeserializer {
     }
 
     private static Map<String, ?> mapDeserializer(Map<String, ?> value, Schema schema) {
-        return value
-            .entrySet()
-            .stream()
-            .collect(Collectors.toMap(
-                Map.Entry::getKey,
-                e -> AvroDeserializer.objectDeserializer(e.getValue(), schema.getValueType()))
-            );
+        Map<String, Object> result = new LinkedHashMap<>();
+        value.forEach((k, v) -> result.put(k, AvroDeserializer.objectDeserializer(v, schema.getValueType())));
+        return result;
     }
 
     private static Collection<?> arrayDeserializer(Collection<?> value, Schema schema) {

--- a/src/test/java/org/akhq/utils/AvroDeserializerTest.java
+++ b/src/test/java/org/akhq/utils/AvroDeserializerTest.java
@@ -190,4 +190,63 @@ class AvroDeserializerTest {
 
         assertThat(result, is(defaultValues));
     }
+
+    @Test
+    void testMapWithNullableUnionValueContainingNull() {
+        String type = "{"
+            + "\"name\": \"root\","
+            + "\"type\": \"record\","
+            + "\"fields\": ["
+            + "    {"
+            + "        \"name\": \"props\","
+            + "        \"type\": {\"type\": \"map\", \"values\": [\"string\", \"null\"]}"
+            + "    }"
+            + "    ]"
+            + "}";
+        Schema schema = new Schema.Parser().parse(type);
+
+        Map<String, Object> mapValue = new HashMap<>();
+        mapValue.put("present", "value");
+        mapValue.put("absent", null);
+
+        GenericRecord record = new org.apache.avro.generic.GenericData.Record(schema);
+        record.put("props", mapValue);
+
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("props", mapValue);
+
+        Map<String, Object> result = AvroDeserializer.recordDeserializer(record);
+
+        assertThat(result, is(expected));
+    }
+
+    @Test
+    void testArrayWithNullableUnionElementContainingNull() {
+        String type = "{"
+            + "\"name\": \"root\","
+            + "\"type\": \"record\","
+            + "\"fields\": ["
+            + "    {"
+            + "        \"name\": \"items\","
+            + "        \"type\": {\"type\": \"array\", \"items\": [\"string\", \"null\"]}"
+            + "    }"
+            + "    ]"
+            + "}";
+        Schema schema = new Schema.Parser().parse(type);
+
+        List<Object> items = new java.util.ArrayList<>();
+        items.add("a");
+        items.add(null);
+        items.add("b");
+
+        GenericRecord record = new org.apache.avro.generic.GenericData.Record(schema);
+        record.put("items", items);
+
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("items", items);
+
+        Map<String, Object> result = AvroDeserializer.recordDeserializer(record);
+
+        assertThat(result, is(expected));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a bug where records containing a `map<union[string, null]>` (or `array<union[string, null]>`) with `null` values were rendered as garbled binary text in the UI instead of proper JSON. The same messages are decoded correctly by `kcat` and other Avro tools using the same schema registry.

Two independent issues in `AvroDeserializer` were addressed:

1. **`mapDeserializer`** used `Collectors.toMap`, which throws `NullPointerException` when a value is `null` (a well-known Java behavior — `HashMap` allows null values, but `Collectors.toMap` does not). Replaced with a `LinkedHashMap` built via `forEach`, which also preserves iteration order.
2. **`unionDeserializer`** resolved the concrete union branch by running `GenericData().validate(type, value)` against each branch. For a `null` value this could fail to find a match and threw `NoSuchElementException` via `orElseThrow`. It now short-circuits to the `NULL` branch when the value is null, which is the only Avro-valid interpretation.

## Background: why did this manifest as "garbled text"?

`Record.convertToString` catches the deserialization exception and falls back to `new String(payload)`, rendering the raw Avro binary as text:

```java
} catch (Exception exception) {
    this.exceptions.add(exception.getMessage());
    return new String(payload);
}
```

Because `exceptions` is annotated with `@JsonIgnore`, the underlying failure is never surfaced to the UI. Users see garbled characters (Avro field names in the payload remain readable as UTF-8, but the surrounding ZigZag-encoded integers and union tags become replacement characters) with no indication of what went wrong.

The bug only triggers when specific messages contain `null` values inside a map/array with a nullable union. Messages from the *same producer* using the *same schema* would render correctly when values were non-null and get garbled when even a single value was null — which made this hard to diagnose from the UI alone.

`kcat` (and other tools built on Confluent's `libserdes`) render such records correctly because they convert Avro binary directly to Avro-JSON using the writer schema in a single Avro-standard step, whereas akhq goes through its own `GenericRecord → Map<String, Object> → Jackson` conversion, and it was the middle step that failed.

## Tests

Added two tests to `AvroDeserializerTest`:

- `testMapWithNullableUnionValueContainingNull` — `map<union[string, null]>` with a `null` value
- `testArrayWithNullableUnionElementContainingNull` — `array<union[string, null]>` with a `null` element

Both fail without this fix and pass with it. All existing tests in `org.akhq.utils` (89 total) continue to pass.

## Test plan

- [x] `./gradlew test --tests "org.akhq.utils.*" -x startTestKafkaCluster` passes locally on Java 25
- [x] New tests fail on `dev` without the fix (NPE from `Collectors.toMap`, then `NoSuchElementException` from `unionDeserializer`)
- [x] New tests pass with the fix