### PR TITLE
feat: add page size dropdown to topic data page

### DIFF
--- a/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
+++ b/client/src/containers/Topic/Topic/TopicData/TopicData.jsx
@@ -13,6 +13,7 @@ import {
   uriTopicsPartitions
 } from '../../../../utils/endpoints';
 import Pagination from '../../../../components/Pagination/Pagination';
+import PageSize from '../../../../components/PageSize/PageSize';
 import DatePicker from '../../../../components/DatePicker';
 import camelCase from 'lodash/camelCase';
 import constants, { SETTINGS_VALUES } from '../../../../utils/constants';
@@ -64,6 +65,7 @@ class TopicData extends Root {
     pageNumber: 1,
     nextPage: '',
     recordCount: 0,
+    currentPageSize: 50,
     showFilters: '',
     showDeleteModal: false,
     showDownloadModal: false,
@@ -152,6 +154,9 @@ class TopicData extends Root {
           : this.state.endDatetime,
         offsetsSearch: query.get('after') ? query.get('after') : this.state.offsetsSearch,
         search: this._buildSearchFromQueryString(query),
+        currentPageSize: query.get('uiPageSize')
+          ? parseInt(query.get('uiPageSize'), 10)
+          : this.state.currentPageSize,
         offsets: query.get('offset')
           ? this._getOffsetsByOffset(query.get('partition'), query.get('offset'))
           : query.get('after')
@@ -312,13 +317,14 @@ class TopicData extends Root {
   }
 
   _buildFilters() {
-    const { sortBy, partition, datetime, endDatetime, offsetsSearch, search } = this.state;
+    const { sortBy, partition, datetime, endDatetime, offsetsSearch, search, currentPageSize } = this.state;
 
     const filters = [];
 
     if (sortBy) filters.push(`sort=${sortBy}`);
     if (offsetsSearch) filters.push(`after=${offsetsSearch}`);
     if (partition) filters.push(`partition=${partition}`);
+    if (currentPageSize) filters.push(`size=${currentPageSize}`);
 
     if (datetime) {
       filters.push(`timestamp=${encodeURIComponent(this._buildTimestampFilter(datetime))}`);
@@ -668,6 +674,12 @@ class TopicData extends Root {
     return offsetsOptions;
   };
 
+  handlePageSizeChangeSubmission = value => {
+    this.setState({ currentPageSize: value, pageNumber: 1 }, () => {
+      this._navigateWithCurrentFilters(true);
+    });
+  };
+
   _navigateWithFilters(filters, replaceInNavigation = true) {
     const { selectedCluster, selectedTopic } = this.state;
 
@@ -948,7 +960,8 @@ class TopicData extends Root {
       canDownload,
       percent,
       loading,
-      roles
+      roles,
+      currentPageSize
     } = this.state;
 
     let actions = [constants.TABLE_SHARE, constants.TABLE_COPY];
@@ -985,6 +998,10 @@ class TopicData extends Root {
 
           <nav className="pagination-data">
             <div>
+              <PageSize
+                currentPageSize={currentPageSize}
+                onChange={this.handlePageSizeChangeSubmission}
+              />
               <Pagination
                 pageNumber={pageNumber}
                 totalRecords={recordCount}

--- a/src/main/java/org/akhq/controllers/TopicController.java
+++ b/src/main/java/org/akhq/controllers/TopicController.java
@@ -214,7 +214,8 @@ public class TopicController extends AbstractController {
         Optional<String> searchByHeaderKey,
         Optional<String> searchByHeaderValue,
         Optional<String> searchByKeySubject,
-        Optional<String> searchByValueSubject
+        Optional<String> searchByValueSubject,
+        Optional<Integer> size
     ) throws ExecutionException, InterruptedException {
         checkIfClusterAndResourceAllowed(cluster, topicName);
 
@@ -232,6 +233,8 @@ public class TopicController extends AbstractController {
                         searchByHeaderKey,
                         searchByHeaderValue,
                         searchByKeySubject,
+                        searchByValueSubject,
+                        size);
                         searchByValueSubject);
         URIBuilder uri = URIBuilder.fromURI(request.getUri());
         List<Record> data = this.recordRepository.consume(cluster, options);
@@ -423,7 +426,8 @@ public class TopicController extends AbstractController {
             searchByHeaderKey,
             searchByHeaderValue,
             searchByKeySubject,
-            searchByValueSubject
+            searchByValueSubject,
+            Optional.empty()
         );
 
         Topic topic = topicRepository.findByName(cluster, topicName);
@@ -480,7 +484,8 @@ public class TopicController extends AbstractController {
             searchByHeaderKey,
             searchByHeaderValue,
             searchByKeySubject,
-            searchByValueSubject
+            searchByValueSubject,
+            Optional.empty()
         );
 
         // Set in MAX_POLL_RECORDS_CONFIG, big number increases speed
@@ -585,6 +590,7 @@ public class TopicController extends AbstractController {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty()
         );
 
@@ -664,6 +670,7 @@ public class TopicController extends AbstractController {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty()
         );
 
@@ -690,7 +697,8 @@ public class TopicController extends AbstractController {
         Optional<String> searchByHeaderKey,
         Optional<String> searchByHeaderValue,
         Optional<String> searchByKeySubject,
-        Optional<String> searchByValueSubject
+        Optional<String> searchByValueSubject,
+        Optional<Integer> size
     ) {
         RecordRepository.Options options = new RecordRepository.Options(environment, cluster, topicName);
 
@@ -706,6 +714,7 @@ public class TopicController extends AbstractController {
         searchByHeaderValue.ifPresent(options::setSearchByHeaderValue);
         searchByKeySubject.ifPresent(options::setSearchByKeySubject);
         searchByValueSubject.ifPresent(options::setSearchByValueSubject);
+        size.ifPresent(options::setSize);
         return options;
     }
 


### PR DESCRIPTION
## Summary

Add a page size selector dropdown to the topic data (messages) page, matching the one already available on the topic list page.

## Changes

### Backend (`TopicController.java`)
- Added optional `size` parameter to `data()` and `dataSearchOptions()` endpoints
- When provided, overrides the default `topic-data.size` from configuration

### Frontend (`TopicData.jsx`)
- Imported `PageSize` component
- Added `currentPageSize` state (default 50)
- Parse `uiPageSize` from URL query params on load
- Include `size` parameter in API filter queries
- Render `PageSize` dropdown next to pagination controls
- Added `handlePageSizeChangeSubmission` handler

Closes #3030