### PR TITLE
fix: allow searching schemas by numeric ID in addition to subject name (#2450)

### DIFF
--- a/src/main/java/org/akhq/repositories/SchemaRegistryRepository.java
+++ b/src/main/java/org/akhq/repositories/SchemaRegistryRepository.java
@@ -100,10 +100,30 @@ public class SchemaRegistryRepository extends AbstractRepository {
         if(maybeRegistryRestClient.isEmpty()){
             return List.of();
         }
-        return maybeRegistryRestClient.get()
+
+        List<String> nameMatched = maybeRegistryRestClient.get()
             .getAllSubjects()
             .stream()
             .filter(s -> isSearchMatch(search, s) && isMatchRegex(filters, s))
+            .collect(Collectors.toList());
+
+        List<String> idMatched = List.of();
+        if (search.isPresent()) {
+            try {
+                int schemaId = Integer.parseInt(search.get());
+                idMatched = getSubjectsBySchemaId(clusterId, schemaId).stream()
+                    .map(Schema::getSubject)
+                    .filter(s -> isMatchRegex(filters, s))
+                    .collect(Collectors.toList());
+            } catch (NumberFormatException ignored) {
+            } catch (IOException | RestClientException ignored) {
+            }
+        }
+
+        LinkedHashSet<String> merged = new LinkedHashSet<>(nameMatched);
+        merged.addAll(idMatched);
+
+        return merged.stream()
             .sorted(Comparator.comparing(String::toLowerCase))
             .collect(Collectors.toList());
     }


### PR DESCRIPTION
## Description

Fixes #2450

The schema registry search only performed substring matching on subject names, which meant searching by numeric schema ID returned "No schemas available". This change adds support for numeric ID lookups alongside the existing subject name search.

## Changes

Modified `SchemaRegistryRepository.all()` to detect when the search term is a valid integer and query `getSubjectsBySchemaId()` in addition to the existing subject name matching. Results are merged via `LinkedHashSet` to deduplicate.

## Testing

- Verified that searching by subject name substring still works
- Verified that searching by numeric schema ID now returns matching schemas
- Verified that non-numeric search terms work as before