### PR TITLE
fix(avro): handle Utf8 keys in map deserialization

### DIFF
--- a/src/main/java/org/akhq/utils/AvroDeserializer.java
+++ b/src/main/java/org/akhq/utils/AvroDeserializer.java
@@ -55,7 +55,6 @@ public class AvroDeserializer {
             );
     }
 
-    @SuppressWarnings("unchecked")
     private static Object objectDeserializer(Object value, Schema schema) {
         LogicalType logicalType = schema.getLogicalType();
         Type primitiveType = schema.getType();
@@ -87,7 +86,7 @@ public class AvroDeserializer {
                 case UNION:
                     return AvroDeserializer.unionDeserializer(value, schema);
                 case MAP:
-                    return AvroDeserializer.mapDeserializer((Map<String, ?>) value, schema);
+                    return AvroDeserializer.mapDeserializer((Map<?, ?>) value, schema);
                 case RECORD:
                     return AvroDeserializer.recordDeserializer((GenericRecord) value);
                 case ENUM:
@@ -137,9 +136,9 @@ public class AvroDeserializer {
             .orElseThrow());
     }
 
-    private static Map<String, ?> mapDeserializer(Map<String, ?> value, Schema schema) {
+    private static Map<String, ?> mapDeserializer(Map<?, ?> value, Schema schema) {
         Map<String, Object> result = new LinkedHashMap<>();
-        value.forEach((k, v) -> result.put(k, AvroDeserializer.objectDeserializer(v, schema.getValueType())));
+        value.forEach((k, v) -> result.put(k.toString(), AvroDeserializer.objectDeserializer(v, schema.getValueType())));
         return result;
     }
 

--- a/src/test/java/org/akhq/utils/AvroDeserializerTest.java
+++ b/src/test/java/org/akhq/utils/AvroDeserializerTest.java
@@ -249,4 +249,38 @@ class AvroDeserializerTest {
 
         assertThat(result, is(expected));
     }
+
+    @Test
+    void testMapWithUtf8Keys() {
+        String type = "{"
+            + "\"name\": \"root\","
+            + "\"type\": \"record\","
+            + "\"fields\": ["
+            + "    {"
+            + "        \"name\": \"props\","
+            + "        \"type\": {\"type\": \"map\", \"values\": \"string\"}"
+            + "    }"
+            + "    ]"
+            + "}";
+        Schema schema = new Schema.Parser().parse(type);
+
+        // Avro returns Utf8 keys when "avro.java.string": "String" is not set on the map/schema.
+        // Simulate that by putting Utf8 instances as keys directly.
+        Map<org.apache.avro.util.Utf8, Object> mapValue = new HashMap<>();
+        mapValue.put(new org.apache.avro.util.Utf8("k1"), "v1");
+        mapValue.put(new org.apache.avro.util.Utf8("k2"), "v2");
+
+        GenericRecord record = new org.apache.avro.generic.GenericData.Record(schema);
+        record.put("props", mapValue);
+
+        Map<String, Object> expectedInner = new HashMap<>();
+        expectedInner.put("k1", "v1");
+        expectedInner.put("k2", "v2");
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("props", expectedInner);
+
+        Map<String, Object> result = AvroDeserializer.recordDeserializer(record);
+
+        assertThat(result, is(expected));
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to #3120. When an Avro map field's schema does not carry `\"avro.java.string\": \"String\"`, Confluent's `KafkaAvroDeserializer` returns `Utf8` instances as map keys instead of `java.lang.String`. `AvroDeserializer.mapDeserializer` was declared as `Map<String, ?>` and cast the incoming Map to that type. The cast succeeded at compile time via erasure but blew up at runtime with:

```
java.lang.ClassCastException: class org.apache.avro.util.Utf8 cannot be cast to class java.lang.String
    at org.akhq.utils.AvroDeserializer.mapDeserializer(AvroDeserializer.java:142)
```

The failure was masked in `Record.convertToString` by a catch-all that falls back to `new String(payload)`, so the UI rendered raw Avro bytes as garbled text instead of surfacing the deserialization failure. Because `exceptions` on `Record` is `@JsonIgnore`, there was no visible signal in the UI or the HTTP response either.

This only manifests for schemas that omit the `avro.java.string=String` hint on map values (or on the enclosing map). That's a perfectly valid Avro construct that's common in schemas authored without Java-specific hints (e.g. by non-JVM producers).

## Fix

Widen `mapDeserializer` to accept `Map<?, ?>` and call `k.toString()` when inserting into the result map. `CharSequence` values were already handled correctly by `objectDeserializer`'s `STRING` branch.

## Tests

Adds `testMapWithUtf8Keys` which constructs a `GenericRecord` and inserts `Utf8` instances directly as map keys. Without the fix it fails with the `ClassCastException` above; with the fix it passes. All 35 tests in `AvroDeserializerTest` pass.

## Test plan

- [x] `./gradlew test --tests \"org.akhq.utils.AvroDeserializerTest\" -x startTestKafkaCluster` — 35/35 pass
- [x] Verified with a real production payload from a `map<union[string, null]>` schema that does not set `avro.java.string=String`: rendered as garbled text before, renders as JSON after