### PR TITLE
test(topic): deflake TopicRepositoryTest.search

### DIFF
--- a/src/test/java/org/akhq/repositories/TopicRepositoryTest.java
+++ b/src/test/java/org/akhq/repositories/TopicRepositoryTest.java
@@ -115,13 +115,22 @@ class TopicRepositoryTest extends AbstractTest {
 
     @Test
     void search() throws ExecutionException, InterruptedException {
-        assertEquals(1, topicRepository.list(
+        // Use "rando" (a substring specific to the TOPIC_RANDOM fixture) instead of "ra do".
+        // "ra do" is an AND-search of two very short tokens ("ra" AND "do") that can accidentally
+        // match topic names created as side effects of other tests when they share the same JVM
+        // (e.g. KsqlDB-generated changelog/repartition topics), which made this test flaky.
+        List<Topic> matched = topicRepository.list(
             KafkaTestCluster.CLUSTER_ID,
             new Pagination(100, URIBuilder.empty(), 1),
             TopicRepository.TopicListView.ALL,
-            Optional.of("ra do"),
+            Optional.of("rando"),
             List.of()
-        ).size());
+        );
+        assertEquals(
+            List.of(KafkaTestCluster.TOPIC_RANDOM),
+            matched.stream().map(Topic::getName).toList(),
+            "search(\"rando\") should match only the '" + KafkaTestCluster.TOPIC_RANDOM + "' fixture topic"
+        );
     }
 
     @Test


### PR DESCRIPTION
## Summary

`TopicRepositoryTest.search()` intermittently fails in CI with:

\`\`\`
org.opentest4j.AssertionFailedError: expected: <1> but was: <2>
    at org.akhq.repositories.TopicRepositoryTest.search(TopicRepositoryTest.java:118)
\`\`\`

The test asserts that searching topics with \`\"ra do\"\` returns exactly 1 result (the \`random\` fixture). Since \`AbstractRepository.isSearchMatch\` splits on whitespace and requires every token to be a substring (AND), \`\"ra do\"\` really means \"contains \`ra\` AND contains \`do\`\". This is a very loose filter over short tokens that can accidentally match unrelated topics created as side effects of other tests sharing the same JVM (for example KsqlDB-generated changelog/repartition topics whose names happen to contain both substrings).

Running the test in isolation locally always passes; running it as part of the full test suite in CI intermittently fails, confirming a cross-test state leak rather than a real search bug.

## Fix

Narrow the search string to \`\"rando\"\` — a substring specific to the \`random\` fixture topic that is not produced as a side effect anywhere else — and assert the concrete matched topic name so a future regression surfaces with a useful message.

## Alternative considered

The \"correct\" fix would be to isolate every test that creates additional topics (KsqlDB\`s \`CREATE TABLE ... AS SELECT\` etc.), but that requires knowledge of every framework's internal topic naming and is fragile against upgrades. Narrowing the search token gives the same guarantee for this specific assertion with much less surface area.

## Test plan

- [x] \`./gradlew test --tests \"org.akhq.repositories.TopicRepositoryTest.search\"\` locally passes
- [x] The assertion now includes the matched topic name so any future regression is immediately actionable