### PR TITLE
fix(helm): chart release not done after AKHQ release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - dev
-  release:
-    types: [released]
+  repository_dispatch:
+    types: [ akhq-release-docs ]
 
 jobs:
   check:
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.client_payload.sha || github.sha }}
 
       # Setup
       - name: Setup Node
@@ -33,29 +35,6 @@ jobs:
           node_modules/.bin/githubcontrib --repo akhq --owner tchiotludo --format html --sortOrder desc > .vuepress/public/contributors.html
           npm run build
           echo "akhq.io" > .vuepress/dist/CNAME
-
-      # Copy for helm
-      - name: Add some files
-        run: |
-          cp LICENSE helm/akhq/LICENSE
-          cp README.md helm/akhq/README.md
-
-      # Helm charts - only release on GitHub release creation
-      - name: Configure Git
-        if: github.event_name == 'release'
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Run chart-releaser
-        if: github.event_name == 'release'
-        uses: helm/chart-releaser-action@v1
-        with:
-          charts_dir: helm
-          pages_branch: helm
-          mark_as_latest: false
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       # Clone helm charts
       - name: Clone helm charts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       # Caches
       - name: Gradle cache
@@ -115,6 +117,28 @@ jobs:
             build/dist/akhq-*.tar
             build/dist/akhq-*.zip
 
+      - name: Add chart files
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          cp LICENSE helm/akhq/LICENSE
+          cp README.md helm/akhq/README.md
+
+      - name: Configure Git
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: helm/chart-releaser-action@v1
+        with:
+          charts_dir: helm
+          pages_branch: helm
+          mark_as_latest: false
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
       # Docker
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -164,6 +188,13 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
+
+      - name: Trigger docs publish
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          event-type: akhq-release-docs
+          client-payload: '{"sha": "${{ github.sha }}"}'
 
       # Slack
       - name: Slack notification

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,13 +17,23 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
     steps:
-      - uses: actions/checkout@v7
+      - name: Checkout (full history for tags)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      - name: Checkout (shallow for branches/PRs)
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
 
       # Caches
       - name: Gradle cache


### PR DESCRIPTION
Fix release orchestration so Helm chart publishing and docs refresh happen reliably after an AKHQ tag release.

## Problem
docs.yml was expected to run after AKHQ release to execute Helm-related publication flow, but release events created from workflow context with GITHUB_TOKEN do not reliably trigger downstream on: release workflows. This caused Helm/docs release coupling issues.

## Changes
1. Move Helm release to main.yml (tag path)
    - Added tag-only steps
    - This makes chart publishing part of the main release pipeline.

2. Ensure full git history for release tooling
    - Updated main checkout to fetch-depth: 0 (required/recommended for chart-releaser and tag/history-aware operations).

3. Trigger docs publish explicitly after release

4. Update docs workflow trigger model
    - docs.yml now triggers on: push to dev (normal docs updates) + repository_dispatch type akhq-release-docs (post-release refresh)
    - On dispatch, checkout uses payload SHA to build docs from released code.