### PR TITLE
fix(docker): micronaut duplicate config error on empty classpath

### DIFF
--- a/docker/app/akhq
+++ b/docker/app/akhq
@@ -7,4 +7,9 @@ do
   JAVA_OPTS="${JAVA_OPTS} ${JVM_OPT}"
 done
 
-exec /opt/java/openjdk/bin/java ${JAVA_OPTS} -cp /app/akhq.jar:${CLASSPATH} org.akhq.App
+CP=/app/akhq.jar
+# Only append CLASSPATH when non-empty to avoid a trailing ':' (which adds /app to classpath
+# and can make Micronaut load mounted /app/application.yml as a duplicate resource).
+[ -n "${CLASSPATH:-}" ] && CP="${CP}:${CLASSPATH}"
+
+exec /opt/java/openjdk/bin/java ${JAVA_OPTS} -cp "${CP}" org.akhq.App


### PR DESCRIPTION
## Summary

Fix Docker startup classpath handling to prevent Micronaut duplicate config errors when users mount `/app/application.yml`.

`docker/app/akhq` previously built Java classpath in a way that could leave an empty classpath segment (`...jar:`).  
In Java, an empty classpath entry resolves to the working directory (`/app`), which made mounted `/app/application.yml` visible as a classpath resource in addition to `application.yml` inside `akhq.jar`.

With Micronaut 5, this can fail startup with:

`Duplicate configuration resource 'application.yml' found on the classpath`.

## What changed

- Build classpath from a base value:
  - `CP=/app/akhq.jar`
- Append `${CLASSPATH}` **only when non-empty**:
  - `[ -n "${CLASSPATH:-}" ] && CP="${CP}:${CLASSPATH}"`
- Start Java with `-cp "${CP}"`