### PR TITLE
fix(ui): prevent topic page crash when cleanup.policy value is null

### DIFF
--- a/client/src/containers/Topic/Topic/Topic.jsx
+++ b/client/src/containers/Topic/Topic/Topic.jsx
@@ -157,7 +157,7 @@ class Topic extends Root {
   canEmptyTopic = () => {
     const { configs } = this.state;
     const res = configs.filter(config => config.name === 'cleanup.policy');
-    return res && res.length === 1 && res[0].value.includes('delete');
+    return res.length === 1 && res[0].value != null && res[0].value.includes('delete');
   };
 
   emptyTopic = () => {


### PR DESCRIPTION
## Summary
- Guard `canEmptyTopic()` against `null` config values so the topic detail page renders when `cleanup.policy` is left at the cluster default.

## Context
Kafka's [`ConfigEntry.value()`](https://kafka.apache.org/40/javadoc/org/apache/kafka/clients/admin/ConfigEntry.html#value--) may return `null` (when a topic config is not explicitly set and no cluster-level override exists). The value is serialized as-is by the backend, and the React client called `.includes('delete')` on it unconditionally, throwing a `TypeError` that broke the entire topic detail page for affected topics.

Fixes #3112