### PR TITLE
fix: prevent duplicate /me and /auths calls on re-render (#913)

### DIFF
--- a/client/src/utils/AkhqRoutes.jsx
+++ b/client/src/utils/AkhqRoutes.jsx
@@ -141,7 +141,10 @@ class AkhqRoutes extends Root {
     let clusterId = this.state.clusterId;
 
     if (this.state.user.length <= 0) {
-      this._initUserAndAuth();
+      if (!this._authRequestPending) {
+        this._authRequestPending = true;
+        this._initUserAndAuth();
+      }
       return <></>;
     }
 


### PR DESCRIPTION
## What
Fixes #913

Prevents duplicate `/api/me` and `/api/auths` requests from being fired on every re-render of `AkhqRoutes`.

## Why
`_initUserAndAuth()` was being called directly inside `render()`, guarded only by `this.state.user.length <= 0`. Since the requests are asynchronous and `state.user` is only set once the response resolves, any re-render that happens before the response arrives (e.g. navigating between pages) triggers the same two API calls again.

## Fix
Added a simple instance flag (`_authRequestPending`) that is set synchronously before firing the requests, preventing them from being re-triggered while a request is already in flight.

## Testing
Verified locally by logging in with basic-auth and navigating between multiple pages (Nodes → Topics → Nodes) with DevTools Network tab open (Preserve log). Before the fix, `/api/me` and `/api/auths` fired once per navigation. After the fix, they fire once per session.