### PR TITLE
feat(topic): add favourite topics

### DIFF
--- a/client/src/components/Table/Table.jsx
+++ b/client/src/components/Table/Table.jsx
@@ -13,6 +13,7 @@ import {
   faSearch,
   faShare,
   faSort,
+  faStar,
   faTrash
 } from '@fortawesome/free-solid-svg-icons';
 import { Link } from 'react-router-dom';
@@ -338,13 +339,46 @@ class Table extends Component {
   }
 
   renderActions(row) {
-    const { actions, onAdd, onDelete, onEdit, onRestart, onShare, onDownload, onCopy, idCol } =
+    const {
+      actions,
+      onAdd,
+      onDelete,
+      onEdit,
+      onRestart,
+      onShare,
+      onDownload,
+      onCopy,
+      onFavorite,
+      idCol
+    } =
       this.props;
 
     let idColVal = idCol ? row[this.props.idCol] : row.id;
 
     return (
       <>
+        {actions.find(el => el === constants.TABLE_FAVORITE) && onFavorite && (
+          <td className="khq-row-action khq-row-action-main action-hover">
+            <span
+              role="button"
+              tabIndex={0}
+              className={`favorite-action ${row.favorite ? 'is-favorite' : ''}`}
+              title={row.favorite ? 'Remove from favourites' : 'Add to favourites'}
+              aria-label={row.favorite ? 'Remove from favourites' : 'Add to favourites'}
+              onClick={() => {
+                onFavorite(row);
+              }}
+              onKeyDown={event => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  onFavorite(row);
+                }
+              }}
+            >
+              <FontAwesomeIcon icon={faStar} />
+            </span>
+          </td>
+        )}
         {actions.find(el => el === constants.TABLE_ADD) && (
           <td className="khq-row-action khq-row-action-main action-hover">
             <span
@@ -565,6 +599,7 @@ Table.propTypes = {
   onDownload: PropTypes.func,
   updateCheckbox: PropTypes.func,
   onCopy: PropTypes.func,
+  onFavorite: PropTypes.func,
 
   idCol: PropTypes.string,
   toPresent: PropTypes.array,

--- a/client/src/components/Table/TableFavorite.test.jsx
+++ b/client/src/components/Table/TableFavorite.test.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import Table from './Table';
+import { TABLE_FAVORITE } from '../../utils/constants';
+
+vi.mock('react-router-dom', () => ({
+  Link: props => <div {...props} />,
+  useLocation: () => ({}),
+  useNavigate: () => vi.fn(),
+  useParams: () => ({}),
+  useNavigationType: () => 'POP'
+}));
+
+describe('Table favourite action', () => {
+  const columns = [{ id: 'name', accessor: 'name', colName: 'Name', type: 'text' }];
+
+  it('renders both states and invokes the callback for each toggle direction', () => {
+    const onFavorite = vi.fn();
+    render(
+      <Table
+        columns={columns}
+        data={[{ id: 'payments', name: 'payments', favorite: true }, { id: 'orders', name: 'orders' }]}
+        actions={[TABLE_FAVORITE]}
+        onFavorite={onFavorite}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Remove from favourites' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Add to favourites' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove from favourites' }));
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Add to favourites' }), { key: 'Enter' });
+
+    expect(onFavorite).toHaveBeenCalledWith(expect.objectContaining({ id: 'payments' }));
+    expect(onFavorite).toHaveBeenCalledWith(expect.objectContaining({ id: 'orders' }));
+  });
+});

--- a/client/src/components/Table/styles.scss
+++ b/client/src/components/Table/styles.scss
@@ -1,5 +1,19 @@
-.action-hover :hover {
-  cursor: pointer;
+.action-hover {
+  :hover {
+    cursor: pointer;
+  }
+
+  .favorite-action {
+    color: inherit;
+  }
+
+  .favorite-action:not(.is-favorite) svg {
+    opacity: 0.55;
+  }
+
+  .favorite-action.is-favorite {
+    color: #ffd166;
+  }
 }
 
 .no-stripes tr {
@@ -31,8 +45,4 @@ td {
   top: -5px;
   cursor: pointer;
   font-size: $font-size-lg;
-}
-
-.empty-consumergroups {
-  min-height: 31px;
 }

--- a/client/src/containers/Topic/TopicList/TopicList.jsx
+++ b/client/src/containers/Topic/TopicList/TopicList.jsx
@@ -24,8 +24,11 @@ import PageSize from '../../../components/PageSize';
 import { withRouter } from '../../../utils/withRouter';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
+import { getTopicFavorites, toggleTopicFavorite } from '../../../utils/localstorage';
 
 class TopicList extends Root {
+  topicRequestId = 0;
+
   state = {
     topics: [],
     showDeleteModal: false,
@@ -52,7 +55,9 @@ class TopicList extends Root {
     loading: true,
     cancel: undefined,
     collapseConsumerGroups: {},
-    uiOptions: {}
+    uiOptions: {},
+    favorites: [],
+    preserveTopicsDuringNextLoad: false
   };
 
   componentDidMount() {
@@ -128,7 +133,8 @@ class TopicList extends Root {
         keepSearch: keepSearchTmp,
         uiOptions: uiOptions ?? {},
         pageNumber: pageNumber,
-        currentPageSize: currentPageSize
+        currentPageSize: currentPageSize,
+        favorites: getTopicFavorites(clusterId)
       },
       callBackFunction
     );
@@ -182,18 +188,25 @@ class TopicList extends Root {
   };
 
   async getTopics() {
-    const { selectedCluster, pageNumber, currentPageSize } = this.state;
+    const topicRequestId = ++this.topicRequestId;
+    const { selectedCluster, pageNumber, currentPageSize, favorites, preserveTopicsDuringNextLoad } =
+      this.state;
     const { search, topicListView } = this.state.searchData;
-    this.setState({ loading: true });
+    if (!preserveTopicsDuringNextLoad) {
+      this.setState({ loading: true });
+    }
 
     let response = await this.getApi(
-      uriTopics(selectedCluster, search, topicListView, pageNumber, currentPageSize)
+      uriTopics(selectedCluster, search, topicListView, pageNumber, currentPageSize, favorites)
     );
+    if (topicRequestId !== this.topicRequestId) {
+      return;
+    }
     let data = response.data;
 
     if (data) {
       if (data.results) {
-        this.handleTopics(data.results);
+        this.handleTopics(data.results, topicRequestId);
       } else {
         this.setState({ topics: [] });
       }
@@ -201,18 +214,19 @@ class TopicList extends Root {
         selectedCluster,
         totalPageNumber: data.page < 1 ? 1 : data.page,
         currentPageSize: data.pageSize,
-        loading: false
+        loading: false,
+        preserveTopicsDuringNextLoad: false
       });
     } else {
-      this.setState({ topics: [], loading: false });
+      this.setState({ topics: [], loading: false, preserveTopicsDuringNextLoad: false });
     }
   }
 
-  handleTopics(topics) {
+  handleTopics(topics, topicRequestId = this.topicRequestId) {
     let tableTopics = {};
     const collapseConsumerGroups = {};
 
-    const { selectedCluster, uiOptions, roles } = this.state;
+    const { selectedCluster, uiOptions, roles, favorites } = this.state;
     const uiOptionsTopic = uiOptions.topic ?? {};
 
     const setState = () => {
@@ -230,7 +244,8 @@ class TopicList extends Root {
         replicationFactor: topic.replicaCount,
         replicationInSync: topic.inSyncReplicaCount,
         groupComponent: undefined,
-        internal: topic.internal
+        internal: topic.internal,
+        favorite: favorites.includes(topic.name)
       };
       collapseConsumerGroups[topic.name] = uiOptionsTopic.showAllConsumerGroups ? true : false;
     });
@@ -248,6 +263,9 @@ class TopicList extends Root {
       this.getApi(
         uriConsumerGroupByTopics(selectedCluster, encodeURIComponent(topicsName), groupsListView)
       ).then(value => {
+        if (topicRequestId !== this.topicRequestId) {
+          return;
+        }
         topics.forEach(topic => {
           tableTopics[topic.name].groupComponent =
             value && value.data
@@ -266,6 +284,9 @@ class TopicList extends Root {
     if (!uiOptionsTopic.skipLastRecord && roles.TOPIC_DATA && roles.TOPIC_DATA.includes('READ')) {
       this.getApi(uriTopicLastRecord(selectedCluster, encodeURIComponent(topicsName))).then(
         value => {
+          if (topicRequestId !== this.topicRequestId) {
+            return;
+          }
           topics.forEach(topic => {
             tableTopics[topic.name].lastWrite = value.data[topic.name]
               ? value.data[topic.name].timestamp
@@ -327,6 +348,25 @@ class TopicList extends Root {
       localStorage.removeItem('topicListSearch');
     }
   }
+
+  handleFavorite = topic => {
+    const refreshCurrentPage = this.state.pageNumber === 1;
+    const favorites = toggleTopicFavorite(this.state.selectedCluster, topic.id);
+    this.setState(({ topics }) => ({
+      favorites,
+      pageNumber: 1,
+      // The server response will reorder page one; update the star without replacing the table first.
+      topics: topics.map(currentTopic =>
+        currentTopic.id === topic.id ? { ...currentTopic, favorite: favorites.includes(topic.id) } : currentTopic
+      ),
+      preserveTopicsDuringNextLoad: true
+    }), () => {
+      this.navigateWithQuery(this.state.searchData, 1, this.state.currentPageSize, true);
+      if (refreshCurrentPage) {
+        this.getTopics();
+      }
+    });
+  };
 
   render() {
     const {
@@ -467,7 +507,7 @@ class TopicList extends Root {
     }
 
     let detailsHref = undefined;
-    const actions = [constants.TABLE_CONFIG];
+    const actions = [constants.TABLE_FAVORITE, constants.TABLE_CONFIG];
     if (roles.TOPIC_DATA && roles.TOPIC_DATA.includes('READ')) {
       actions.push(constants.TABLE_DETAILS);
       detailsHref = id => `/ui/${selectedCluster}/topic/${id}/data`;
@@ -532,6 +572,7 @@ class TopicList extends Root {
           onDelete={topic => {
             this.handleOnDelete(topic);
           }}
+          onFavorite={this.handleFavorite}
           detailsHref={detailsHref}
           configHref={id => `/ui/${selectedCluster}/topic/${id}/configs`}
           actions={actions}
@@ -562,4 +603,5 @@ class TopicList extends Root {
   }
 }
 
+export { TopicList };
 export default withRouter(TopicList);

--- a/client/src/containers/Topic/TopicList/TopicList.test.jsx
+++ b/client/src/containers/Topic/TopicList/TopicList.test.jsx
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TopicList } from './TopicList';
+
+const createTopicList = pageNumber => {
+  const topicList = new TopicList({
+    params: { clusterId: 'cluster-a' },
+    router: { navigate: vi.fn() },
+    location: { pathname: '/ui/cluster-a/topic', search: '' }
+  });
+
+  topicList.state = {
+    ...topicList.state,
+    selectedCluster: 'cluster-a',
+    pageNumber,
+    currentPageSize: 25,
+    searchData: { search: '', topicListView: 'HIDE_INTERNAL' },
+    topics: [{ id: 'payments', favorite: false }],
+    favorites: [],
+    roles: { TOPIC_DATA: [] },
+    uiOptions: { topic: { skipConsumerGroups: true, skipLastRecord: true } }
+  };
+  topicList.setState = (update, callback) => {
+    const nextState = typeof update === 'function' ? update(topicList.state) : update;
+    topicList.state = { ...topicList.state, ...nextState };
+    callback?.();
+  };
+  topicList.navigateWithQuery = vi.fn();
+  topicList.getTopics = vi.fn();
+
+  return topicList;
+};
+
+describe('TopicList favourites', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('updates the star immediately and preserves the table during a page-one refresh', () => {
+    const topicList = createTopicList(1);
+
+    topicList.handleFavorite({ id: 'payments' });
+
+    expect(topicList.state.topics).toEqual([{ id: 'payments', favorite: true }]);
+    expect(topicList.state.preserveTopicsDuringNextLoad).toBe(true);
+    expect(topicList.navigateWithQuery).toHaveBeenCalledOnce();
+    expect(topicList.getTopics).toHaveBeenCalledOnce();
+  });
+
+  it('lets the page-reset navigation perform the single refresh from later pages', () => {
+    const topicList = createTopicList(2);
+
+    topicList.handleFavorite({ id: 'payments' });
+
+    expect(topicList.state.pageNumber).toBe(1);
+    expect(topicList.navigateWithQuery).toHaveBeenCalledOnce();
+    expect(topicList.getTopics).not.toHaveBeenCalled();
+  });
+
+  it('passes stored favourites to the topic request', async () => {
+    const topicList = createTopicList(1);
+    topicList.state.favorites = ['payments', 'orders'];
+    topicList.getApi = vi.fn().mockResolvedValue({
+      data: {
+        results: [],
+        page: 1,
+        pageSize: 25
+      }
+    });
+
+    await TopicList.prototype.getTopics.call(topicList);
+
+    const request = new URL(topicList.getApi.mock.calls[0][0], 'http://localhost');
+    expect(request.searchParams.getAll('favorite')).toEqual(['payments', 'orders']);
+  });
+
+  it('marks rows whose names are stored as favourites', () => {
+    const topicList = createTopicList(1);
+    topicList.state.favorites = ['payments'];
+
+    topicList.handleTopics([
+      {
+        name: 'payments',
+        size: 0,
+        logDirSize: 0,
+        partitions: [],
+        replicaCount: 1,
+        inSyncReplicaCount: 1,
+        internal: false
+      },
+      {
+        name: 'orders',
+        size: 0,
+        logDirSize: 0,
+        partitions: [],
+        replicaCount: 1,
+        inSyncReplicaCount: 1,
+        internal: false
+      }
+    ]);
+
+    expect(topicList.state.topics.map(topic => [topic.id, topic.favorite])).toEqual([
+      ['payments', true],
+      ['orders', false]
+    ]);
+  });
+});

--- a/client/src/utils/constants.jsx
+++ b/client/src/utils/constants.jsx
@@ -27,6 +27,7 @@ export const TABLE_RESTART = 'restart';
 export const TABLE_SHARE = 'share';
 export const TABLE_DOWNLOAD = 'download';
 export const TABLE_COPY = 'copy';
+export const TABLE_FAVORITE = 'favorite';
 
 // Tab names/route names
 export const CLUSTER = 'cluster';
@@ -98,6 +99,7 @@ export default {
   TABLE_RESTART,
   TABLE_SHARE,
   TABLE_COPY,
+  TABLE_FAVORITE,
   TABLE_DOWNLOAD,
   CLUSTER,
   NODE,

--- a/client/src/utils/endpoints.jsx
+++ b/client/src/utils/endpoints.jsx
@@ -36,12 +36,23 @@ export const uriUIOptions = clusterId => {
   return `${apiUrl}/${clusterId}/ui-options`;
 };
 
-export const uriTopics = (clusterId, search, show, page, pageSize) => {
-  if (pageSize === 1) {
-    return `${apiUrl}/${clusterId}/topic?search=${search}&show=${show}&page=${page}`;
-  } else {
-    return `${apiUrl}/${clusterId}/topic?search=${search}&show=${show}&page=${page}&uiPageSize=${pageSize}`;
+export const uriTopics = (clusterId, search, show, page, pageSize, favorites = []) => {
+  const maxFavoriteQueryLength = 4096;
+  const params = new URLSearchParams({ search, show, page: String(page) });
+  if (pageSize !== 1) {
+    params.set('uiPageSize', pageSize);
   }
+  [...new Set(favorites.filter(favorite => typeof favorite === 'string' && favorite.length > 0))].forEach(
+    favorite => {
+      const nextParams = new URLSearchParams(params);
+      nextParams.append('favorite', favorite);
+      if (nextParams.toString().length + 1 <= maxFavoriteQueryLength) {
+        params.append('favorite', favorite);
+      }
+    }
+  );
+
+  return `${apiUrl}/${clusterId}/topic?${params.toString()}`;
 };
 
 export const uriTopicDefaultConf = () => `${apiUrl}/topic/defaults-configs`;

--- a/client/src/utils/endpoints.test.jsx
+++ b/client/src/utils/endpoints.test.jsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { uriTopics } from './endpoints';
+
+describe('uriTopics favourites', () => {
+  it('encodes repeated favourites and search values', () => {
+    const url = new URL(uriTopics('cluster-a', 'orders & payments', 'ALL', 2, 25, [
+      'orders & payments',
+      'café+events'
+    ]));
+
+    expect(url.searchParams.getAll('favorite')).toEqual(['orders & payments', 'café+events']);
+    expect(url.searchParams.get('search')).toBe('orders & payments');
+    expect(url.searchParams.get('show')).toBe('ALL');
+    expect(url.searchParams.get('page')).toBe('2');
+    expect(url.searchParams.get('uiPageSize')).toBe('25');
+  });
+
+  it('preserves the legacy page-size omission and supports an empty list', () => {
+    const url = new URL(uriTopics('cluster-a', '', 'HIDE_INTERNAL', 1, 1));
+
+    expect(url.searchParams.getAll('favorite')).toEqual([]);
+    expect(url.searchParams.has('uiPageSize')).toBe(false);
+  });
+
+  it('bounds the serialized favourite query', () => {
+    const favorites = Array.from({ length: 100 }, (_, index) => `topic-${index}-${'x'.repeat(100)}`);
+    const url = uriTopics('cluster-a', '', 'ALL', 1, 25, favorites);
+
+    expect(new URL(url).search.length).toBeLessThanOrEqual(4096);
+    expect(new URL(url).searchParams.getAll('favorite')[0]).toBe(favorites[0]);
+    expect(new URL(url).searchParams.getAll('favorite').length).toBeLessThan(favorites.length);
+  });
+});

--- a/client/src/utils/localstorage.jsx
+++ b/client/src/utils/localstorage.jsx
@@ -28,3 +28,51 @@ export const popProduceToTopicValues = () => {
 export const setProduceToTopicValues = newProduceToTopicValues => {
   localStorage.setItem('produceToTopicValues', JSON.stringify(newProduceToTopicValues));
 };
+
+const TOPIC_FAVORITES_KEY = 'topicFavorites';
+export const MAX_TOPIC_FAVORITES = 100;
+
+const normalizeTopicFavorites = favorites => {
+  if (!Array.isArray(favorites)) {
+    return [];
+  }
+
+  return [...new Set(favorites.filter(favorite => typeof favorite === 'string' && favorite.length > 0))]
+    .slice(0, MAX_TOPIC_FAVORITES);
+};
+
+const getTopicFavoritesByCluster = () => {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(TOPIC_FAVORITES_KEY));
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+};
+
+export const getTopicFavorites = cluster => {
+  return normalizeTopicFavorites(getTopicFavoritesByCluster()[cluster]);
+};
+
+export const toggleTopicFavorite = (cluster, topic) => {
+  const favoritesByCluster = getTopicFavoritesByCluster();
+  const favorites = getTopicFavorites(cluster);
+  if (typeof topic !== 'string' || topic.length === 0) {
+    return favorites;
+  }
+  const nextFavorites = favorites.includes(topic)
+    ? favorites.filter(favorite => favorite !== topic)
+    : favorites.length < MAX_TOPIC_FAVORITES
+      ? favorites.concat(topic)
+      : favorites;
+
+  localStorage.setItem(
+    TOPIC_FAVORITES_KEY,
+    JSON.stringify({
+      ...favoritesByCluster,
+      [cluster]: nextFavorites
+    })
+  );
+
+  return nextFavorites;
+};

--- a/client/src/utils/localstorage.test.jsx
+++ b/client/src/utils/localstorage.test.jsx
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getTopicFavorites, toggleTopicFavorite } from './localstorage';
+
+describe('topic favourites', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('keeps favourites ordered and scoped to a cluster', () => {
+    toggleTopicFavorite('cluster-a', 'payments');
+    toggleTopicFavorite('cluster-a', 'customers');
+    toggleTopicFavorite('cluster-b', 'payments');
+
+    expect(getTopicFavorites('cluster-a')).toEqual(['payments', 'customers']);
+    expect(getTopicFavorites('cluster-b')).toEqual(['payments']);
+  });
+
+  it('removes an existing favourite', () => {
+    toggleTopicFavorite('cluster-a', 'payments');
+    toggleTopicFavorite('cluster-a', 'payments');
+
+    expect(getTopicFavorites('cluster-a')).toEqual([]);
+  });
+
+  it.each(['not-json', '[]', '"text"', '42'])('ignores malformed stored data: %s', stored => {
+    localStorage.setItem('topicFavorites', stored);
+
+    expect(getTopicFavorites('cluster-a')).toEqual([]);
+    expect(toggleTopicFavorite('cluster-a', 'payments')).toEqual(['payments']);
+  });
+
+  it('ignores a malformed cluster value', () => {
+    localStorage.setItem('topicFavorites', JSON.stringify({ 'cluster-a': 'payments' }));
+
+    expect(getTopicFavorites('cluster-a')).toEqual([]);
+  });
+
+  it('normalizes malformed entries and duplicates', () => {
+    localStorage.setItem(
+      'topicFavorites',
+      JSON.stringify({ 'cluster-a': ['payments', 42, '', 'payments', null, 'orders'] })
+    );
+
+    expect(getTopicFavorites('cluster-a')).toEqual(['payments', 'orders']);
+  });
+
+  it('does not add a new favourite beyond the per-cluster limit', () => {
+    const favorites = Array.from({ length: 100 }, (_, index) => `topic-${index}`);
+    localStorage.setItem('topicFavorites', JSON.stringify({ 'cluster-a': favorites }));
+
+    expect(toggleTopicFavorite('cluster-a', 'new-topic')).toEqual(favorites);
+  });
+
+  it.each(['', null, 42])('ignores invalid new favourites: %s', topic => {
+    expect(toggleTopicFavorite('cluster-a', topic)).toEqual([]);
+    expect(getTopicFavorites('cluster-a')).toEqual([]);
+  });
+});

--- a/src/main/java/org/akhq/controllers/TopicController.java
+++ b/src/main/java/org/akhq/controllers/TopicController.java
@@ -95,7 +95,8 @@ public class TopicController extends AbstractController {
         Optional<String> search,
         Optional<TopicRepository.TopicListView> show,
         Optional<Integer> page,
-        Optional<Integer> uiPageSize
+        Optional<Integer> uiPageSize,
+        Optional<List<String>> favorite
     ) throws ExecutionException, InterruptedException {
         checkIfClusterAllowed(cluster);
 
@@ -107,7 +108,8 @@ public class TopicController extends AbstractController {
             pagination,
             show.orElse(TopicRepository.TopicListView.HIDE_INTERNAL),
             search,
-            buildUserBasedResourceFilters(cluster)
+            buildUserBasedResourceFilters(cluster),
+            favorite.orElse(List.of())
         ));
     }
 
@@ -745,4 +747,3 @@ public class TopicController extends AbstractController {
         private long offset;
     }
 }
-

--- a/src/main/java/org/akhq/repositories/TopicRepository.java
+++ b/src/main/java/org/akhq/repositories/TopicRepository.java
@@ -51,19 +51,35 @@ public class TopicRepository extends AbstractRepository {
         HIDE_EMPTY
     }
 
-    public PagedList<Topic> list(String clusterId, Pagination pagination, TopicListView view, Optional<String> search, List<String> filters) throws ExecutionException, InterruptedException {
-        List<String> all = all(clusterId, view, search, filters);
+    public PagedList<Topic> list(String clusterId, Pagination pagination, TopicListView view, Optional<String> search, List<String> filters, List<String> favorites) throws ExecutionException, InterruptedException {
+        List<String> all = all(clusterId, view, search, filters, favorites);
 
-        return PagedList.of(all, pagination, topicList -> this.findByName(clusterId, topicList));
+        return PagedList.of(all, pagination, topicList -> this.findByNameInOrder(clusterId, topicList));
+    }
+
+    public PagedList<Topic> list(String clusterId, Pagination pagination, TopicListView view, Optional<String> search, List<String> filters) throws ExecutionException, InterruptedException {
+        return list(clusterId, pagination, view, search, filters, List.of());
     }
 
     public List<String> all(String clusterId, TopicListView view, Optional<String> search, List<String> filters) throws ExecutionException, InterruptedException {
+        return all(clusterId, view, search, filters, List.of());
+    }
+
+    public List<String> all(String clusterId, TopicListView view, Optional<String> search, List<String> filters, List<String> favorites) throws ExecutionException, InterruptedException {
+        Map<String, Integer> favoritePositions = new HashMap<>();
+        for (String favorite : favorites) {
+            favoritePositions.putIfAbsent(favorite, favoritePositions.size());
+        }
+
         return kafkaWrapper.listTopics(clusterId)
             .stream()
             .map(TopicListing::name)
             .filter(name -> isSearchMatch(search, name) && isMatchRegex(filters, name))
             .filter(name -> isListViewMatch(view, name))
-            .sorted(Comparator.comparing(String::toLowerCase))
+            .sorted(
+                Comparator.comparingInt((String name) -> favoritePositions.getOrDefault(name, Integer.MAX_VALUE))
+                    .thenComparing(name -> name.toLowerCase())
+            )
             .collect(Collectors.toList());
     }
 
@@ -107,6 +123,14 @@ public class TopicRepository extends AbstractRepository {
         list.sort(Comparator.comparing(Topic::getName));
 
         return list;
+    }
+
+    private List<Topic> findByNameInOrder(String clusterId, List<String> topics) throws ExecutionException, InterruptedException {
+        Map<String, Topic> topicsByName = this.findByName(clusterId, topics)
+            .stream()
+            .collect(Collectors.toMap(Topic::getName, topic -> topic));
+
+        return topics.stream().map(topicsByName::get).filter(Objects::nonNull).collect(Collectors.toList());
     }
 
     private boolean isInternal(String name) {

--- a/src/test/java/org/akhq/controllers/TopicControllerTest.java
+++ b/src/test/java/org/akhq/controllers/TopicControllerTest.java
@@ -55,6 +55,23 @@ public class TopicControllerTest extends AbstractTest {
 
     @Test
     @Order(1)
+    void listApiAcceptsRepeatedFavoritesAndLegacyRequests() {
+        ResultPagedList<Topic> legacy = this.retrievePagedList(HttpRequest.GET(BASE_URL), Topic.class);
+        ResultPagedList<Topic> withFavorites = this.retrievePagedList(
+            HttpRequest.GET(BASE_URL + "?favorite=" + KafkaTestCluster.TOPIC_RANDOM + "&favorite=" + KafkaTestCluster.TOPIC_COMPACTED),
+            Topic.class
+        );
+
+        assertEquals(DEFAULT_PAGE_SIZE, legacy.getResults().size());
+        assertEquals(KafkaTestCluster.TOPIC_AUDIT, legacy.getResults().get(0).getName());
+        assertEquals(DEFAULT_PAGE_SIZE, legacy.getPageSize());
+        assertEquals(KafkaTestCluster.TOPIC_HIDE_INTERNAL_COUNT, legacy.getTotal());
+        assertEquals(KafkaTestCluster.TOPIC_RANDOM, withFavorites.getResults().get(0).getName());
+        assertEquals(KafkaTestCluster.TOPIC_COMPACTED, withFavorites.getResults().get(1).getName());
+    }
+
+    @Test
+    @Order(1)
     void homeApi() {
         Topic result = this.retrieve(HttpRequest.GET(TOPIC_URL), Topic.class);
         assertEquals(KafkaTestCluster.TOPIC_COMPACTED, result.getName());

--- a/src/test/java/org/akhq/repositories/TopicRepositoryTest.java
+++ b/src/test/java/org/akhq/repositories/TopicRepositoryTest.java
@@ -12,6 +12,7 @@ import org.akhq.KafkaTestCluster;
 import org.akhq.models.Config;
 import org.akhq.models.Partition;
 import org.akhq.models.Topic;
+import org.akhq.utils.PagedList;
 import org.akhq.utils.Pagination;
 import org.apache.kafka.common.config.TopicConfig;
 import org.codehaus.httpcache4j.uri.URIBuilder;
@@ -32,6 +33,7 @@ import java.util.function.Predicate;
 
 import static org.akhq.controllers.TopicControllerTest.CREATE_TOPIC_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -134,6 +136,72 @@ class TopicRepositoryTest extends AbstractTest {
             Optional.of("stream"),
             List.of("rando.*")
         ).size());
+    }
+
+    @Test
+    void listFavoritesBeforeAlphabeticalTopics() throws ExecutionException, InterruptedException {
+        List<String> alphabeticalTopics = topicRepository.all(
+            KafkaTestCluster.CLUSTER_ID,
+            TopicRepository.TopicListView.HIDE_INTERNAL,
+            Optional.empty(),
+            List.of()
+        );
+        List<String> favorites = List.of(KafkaTestCluster.TOPIC_RANDOM, KafkaTestCluster.TOPIC_COMPACTED);
+
+        PagedList<Topic> firstPage = topicRepository.list(
+            KafkaTestCluster.CLUSTER_ID,
+            new Pagination(2, URIBuilder.empty(), 1),
+            TopicRepository.TopicListView.HIDE_INTERNAL,
+            Optional.empty(),
+            List.of(),
+            List.of(KafkaTestCluster.TOPIC_RANDOM, KafkaTestCluster.TOPIC_COMPACTED, KafkaTestCluster.TOPIC_RANDOM, "missing-topic")
+        );
+        PagedList<Topic> secondPage = topicRepository.list(
+            KafkaTestCluster.CLUSTER_ID,
+            new Pagination(2, URIBuilder.empty(), 2),
+            TopicRepository.TopicListView.HIDE_INTERNAL,
+            Optional.empty(),
+            List.of(),
+            favorites
+        );
+
+        List<String> nonFavorites = alphabeticalTopics.stream()
+            .filter(topic -> !favorites.contains(topic))
+            .toList();
+
+        assertEquals(favorites, firstPage.stream().map(Topic::getName).toList());
+        assertEquals(nonFavorites.subList(0, 2), secondPage.stream().map(Topic::getName).toList());
+        assertEquals(alphabeticalTopics.size(), firstPage.total());
+        assertEquals(alphabeticalTopics.size(), secondPage.total());
+    }
+
+    @Test
+    void listFavoritesKeepsAlphabeticalOrderAfterFavoritesAndAppliesFilters() throws ExecutionException, InterruptedException {
+        String favorite = KafkaTestCluster.TOPIC_STREAM_IN;
+        List<String> matchingTopics = topicRepository.all(
+            KafkaTestCluster.CLUSTER_ID,
+            TopicRepository.TopicListView.ALL,
+            Optional.of("stream"),
+            List.of()
+        );
+
+        List<Topic> result = topicRepository.list(
+            KafkaTestCluster.CLUSTER_ID,
+            new Pagination(10, URIBuilder.empty(), 1),
+            TopicRepository.TopicListView.ALL,
+            Optional.of("stream"),
+            List.of(),
+            List.of(favorite, KafkaTestCluster.TOPIC_COMPACTED)
+        );
+
+        List<String> expected = matchingTopics.stream()
+            .filter(topic -> !topic.equals(favorite))
+            .toList();
+        expected = new java.util.ArrayList<>(expected);
+        expected.add(0, favorite);
+
+        assertEquals(expected, result.stream().map(Topic::getName).toList());
+        assertFalse(result.stream().map(Topic::getName).toList().contains(KafkaTestCluster.TOPIC_COMPACTED));
     }
 
     @Test


### PR DESCRIPTION
### Summary

Adds the ability to favourite topics from the Topics page.

Favourite topics are stored in the browser per cluster and are shown before the remaining topics when the Topics page is loaded. Users can add or remove a favourite without navigating away from the current page.

### What Changed

- Added a star action to the Topics table.
- Added cluster-scoped local storage for favourite topics.
- Added repeated favourite parameters to topic-list requests.
- Updated the backend to order matching topics first, followed by the remaining topics alphabetically.
- Preserved filtering, pagination, and existing topic-list requests that omit `favorite`.
- Added safeguards for malformed stored values, duplicate favourites, and unusually large favourite query strings.
- Prevented stale consumer-group and last-record requests from replacing newer topic-list results.

### Demo
 
<img width="550" alt="akhq-favourites-demo" src="https://github.com/user-attachments/assets/2b394cc2-95f5-4faa-9b94-577e2d86d28e" />

### Notes

Favourite state is stored locally in the browser. It is not shared between users or persisted by AKHQ on the server. If the complete stored list cannot fit within the 4096-character query budget, the earliest favourites are sent and later favourites remain locally starred but are not prioritized by that request.

### Verification

- Focused frontend tests: 4 files, 20 tests passed.
- Full frontend suite in the clean feature checkout: 7 files passed, with 5 unrelated baseline failures caused by legacy `Simulate.change` tests, timezone-dependent converter expectations, and an existing Table fixture missing `detailsHref` - I am more than happy to fix these as part of this PR. See note below.
- Frontend build passed with existing Sass mixed-declarations, plugin-timing, and large-chunk warnings.
- Focused backend controller/repository tests: 34 tests passed with Java 25 and Colima.

_Note: The unrelated frontend compatibility fixes are intentionally excluded from this focused feature PR. I am happy to address them in a separate maintenance change if preferred._
