### PR TITLE
feat (azure) : add azure event hub support (#2707)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,6 +156,10 @@ dependencies {
     // avro
     implementation("org.apache.avro:avro:1.12.1")
 
+    // azure schema registry
+    implementation ("com.azure:azure-data-schemaregistry:1.5.11")
+    implementation ("com.azure:azure-identity:1.18.3")
+
     // jackson-module-scala
     implementation("com.fasterxml.jackson.module:jackson-module-scala_2.13:2.21.4")
 

--- a/client/src/containers/Schema/SchemaDetail/SchemaVersions/SchemaVersions.jsx
+++ b/client/src/containers/Schema/SchemaDetail/SchemaVersions/SchemaVersions.jsx
@@ -29,7 +29,7 @@ class SchemaVersions extends Root {
     if (schemas) {
       let data = schemas.map(schema => {
         return {
-          id: schema.id,
+          id: schema.azureSchemaId ? schema.azureSchemaId : schema.id,
           version: schema.version,
           schemaType: schema.schemaType,
           schema:

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -46,6 +46,7 @@ module.exports = {
             children: [
               '/docs/configuration/schema-registry/tibco.md',
                 '/docs/configuration/schema-registry/glue.md',
+                '/docs/configuration/schema-registry/azure.md',
                 '/docs/configuration/schema-registry/schema-references.md',
             ]
           },

--- a/docs/docs/configuration/brokers.md
+++ b/docs/docs/configuration/brokers.md
@@ -4,7 +4,7 @@
   * `properties`: all the configurations found on [Kafka consumer documentation](https://kafka.apache.org/documentation/#consumerconfigs). Most important is `bootstrap.servers` that is a list of host:port of your Kafka brokers.
   * `schema-registry`: *(optional)*
     * `url`: the schema registry url
-    * `type`: the type of schema registry used, either 'confluent' or 'tibco'
+    * `type`: the type of schema registry used, one of 'confluent', 'tibco', 'glue' or 'azure'
     * `basic-auth-username`: schema registry basic auth username
     * `basic-auth-password`: schema registry basic auth password
     * `properties`: all the configurations for registry client, especially ssl configuration
@@ -124,6 +124,44 @@ akhq:
         sasl.mechanism: OAUTHBEARER
 ```
 I put oauth.ssl.endpoint_identification_algorithm = "" for testing or my certificates did not match the FQDN. In a production, you have to remove it.
+
+## OAuth2 authentication for Azure Event Hub
+
+AKHQ can connect to Azure Event Hub (Kafka protocol endpoint) using OAuth2/`SASL_SSL` with the
+[Microsoft Entra ID (Azure AD)](https://learn.microsoft.com/en-us/azure/event-hubs/authenticate-application) identity of
+a Service Principal or a Managed Identity.
+
+Authentication is handled by the custom callback handler `org.akhq.azure.KafkaOAuth2AuthenticateCallbackHandler`
+(shipped with AKHQ), which uses the Azure Identity SDK
+[`DefaultAzureCredential`](https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme) chain to
+retrieve an access token for the `https://<namespace>.servicebus.windows.net/.default` scope. This means the
+credential resolution follows the standard Azure SDK order (environment variables, workload identity, managed
+identity, Azure CLI, etc.), so credentials must be provided through one of these standard mechanisms (for example
+the `AZURE_CLIENT_ID`, `AZURE_TENANT_ID` and `AZURE_CLIENT_SECRET` environment variables for a Service Principal).
+
+```yaml
+akhq:
+  connections:
+    azure-eventhub:
+      properties:
+        bootstrap.servers: "my-eventhub.servicebus.windows.net:9093"
+        security.protocol: SASL_SSL
+        sasl.mechanism: OAUTHBEARER
+        sasl.jaas.config: >
+          org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required
+          oauth.scope="kafka-cluster";
+        sasl.login.callback.handler.class: "org.akhq.azure.KafkaOAuth2AuthenticateCallbackHandler"
+        ssl.endpoint.identification.algorithm: https
+```
+
+* `sasl.jaas.config`: the `oauth.scope` value is not used to request the token (the token audience is derived from
+  `bootstrap.servers`), but the property must be present for the JAAS module to be valid.
+* `sasl.login.callback.handler.class`: must be set to `org.akhq.azure.KafkaOAuth2AuthenticateCallbackHandler`.
+* `ssl.endpoint.identification.algorithm`: set to `https` (default Kafka client behaviour) unless your certificate does
+  not match the Event Hub FQDN.
+
+See [Azure Schema Registry](schema-registry/azure.md) to also configure schema resolution for messages produced to
+Azure Event Hub.
 
 
 

--- a/docs/docs/configuration/schema-registry/azure.md
+++ b/docs/docs/configuration/schema-registry/azure.md
@@ -1,0 +1,45 @@
+# Azure Schema Registry
+
+AKHQ supports deserialization of Avro messages produced to Azure Event Hub using the
+[Azure Schema Registry](https://learn.microsoft.com/en-us/azure/event-hubs/schema-registry-overview).
+
+Currently, Azure Schema Registry support is limited to the deserialization of Avro messages. JSON and Protobuf
+schemas are not supported for this registry type. Also, since Azure Event Hub does not use the record key to store
+schema information, key schema lookup is not supported and will always return `null`.
+
+## Configuration
+
+* `type`: must be set to `azure`
+* `url`: the fully qualified namespace of your Event Hub / Schema Registry (e.g. `my-eventhub.servicebus.windows.net`).
+  The `.servicebus.windows.net` suffix is appended automatically if not already present.
+* `properties.schema.group`: the name of the schema group in Azure Schema Registry that contains the schemas for this
+  cluster.
+
+Authentication against the Azure Schema Registry is done using the
+[`DefaultAzureCredential`](https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme) chain provided
+by the Azure Identity SDK (environment variables, managed identity, Azure CLI, etc.). It reuses the same credential
+chain as the [Azure Event Hub OAuth2 broker authentication](../brokers.md#oauth2-authentication-for-azure-event-hub).
+
+```yaml
+akhq:
+  connections:
+    azure-eventhub:
+      properties:
+        bootstrap.servers: "my-eventhub.servicebus.windows.net:9093"
+        security.protocol: SASL_SSL
+        sasl.mechanism: OAUTHBEARER
+        sasl.jaas.config: >
+          org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required
+          oauth.scope="kafka-cluster";
+        sasl.login.callback.handler.class: "org.akhq.azure.KafkaOAuth2AuthenticateCallbackHandler"
+        ssl.endpoint.identification.algorithm: https
+      schema-registry:
+        type: "azure"
+        url: "my-eventhub.servicebus.windows.net"
+        properties:
+          schema.group: "my-schema-group"
+```
+
+The client used to connect to the Azure Schema Registry is authenticated the same way as the Kafka connection
+(`DefaultAzureCredentialBuilder`), so no additional `basic-auth-username` / `basic-auth-password` is required or
+supported for this registry type.

--- a/src/main/java/org/akhq/azure/KafkaOAuth2AuthenticateCallbackHandler.java
+++ b/src/main/java/org/akhq/azure/KafkaOAuth2AuthenticateCallbackHandler.java
@@ -1,0 +1,73 @@
+package org.akhq.azure;
+
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.credential.TokenRequestContext;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback;
+import reactor.core.publisher.Mono;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.AppConfigurationEntry;
+import java.net.URI;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
+
+public class KafkaOAuth2AuthenticateCallbackHandler implements AuthenticateCallbackHandler {
+    private static final Duration ACCESS_TOKEN_REQUEST_BLOCK_TIME = Duration.ofSeconds(30);
+    private static final String TOKEN_AUDIENCE_FORMAT = "%s://%s/.default";
+
+    private Function<TokenCredential, Mono<OAuthBearerTokenImpl>> resolveToken;
+    private final TokenCredential credential = new DefaultAzureCredentialBuilder().build();
+
+    @Override
+    public void configure(Map<String, ?> configs, String mechanism, List<AppConfigurationEntry> jaasConfigEntries) {
+        TokenRequestContext request = buildTokenRequestContext(configs);
+        this.resolveToken = tokenCredential -> tokenCredential.getToken(request).map(OAuthBearerTokenImpl::new);
+    }
+
+    private TokenRequestContext buildTokenRequestContext(Map<String, ?> configs) {
+        URI uri = buildEventHubsServerUri(configs);
+        String tokenAudience = buildTokenAudience(uri);
+        TokenRequestContext request = new TokenRequestContext();
+        request.addScopes(tokenAudience);
+        return request;
+    }
+
+    private URI buildEventHubsServerUri(Map<String, ?> configs) {
+        String bootstrapServer = Arrays.asList(configs.get(BOOTSTRAP_SERVERS_CONFIG)).get(0).toString();
+        bootstrapServer = bootstrapServer.replaceAll("\\[|\\]", "");
+        return URI.create("https://" + bootstrapServer);
+    }
+
+    private String buildTokenAudience(URI uri) {
+        return TOKEN_AUDIENCE_FORMAT.formatted(uri.getScheme(), uri.getHost());
+    }
+
+    @Override
+    public void handle(Callback[] callbacks) throws UnsupportedCallbackException {
+        for (Callback callback : callbacks) {
+            if (callback instanceof OAuthBearerTokenCallback oauthCallback) {
+                this.resolveToken
+                        .apply(credential)
+                        .doOnNext(oauthCallback::token)
+                        .doOnError(throwable -> oauthCallback.error("invalid_grant", throwable.getMessage(), null))
+                        .block(ACCESS_TOKEN_REQUEST_BLOCK_TIME);
+            } else {
+                throw new UnsupportedCallbackException(callback);
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        //Pas besoin de modifier cette méthode
+    }
+}
+

--- a/src/main/java/org/akhq/azure/OAuthBearerTokenImpl.java
+++ b/src/main/java/org/akhq/azure/OAuthBearerTokenImpl.java
@@ -1,0 +1,61 @@
+package org.akhq.azure;
+
+import com.azure.core.credential.AccessToken;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.JWTParser;
+import org.apache.kafka.common.errors.SaslAuthenticationException;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
+
+import java.text.ParseException;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class OAuthBearerTokenImpl implements OAuthBearerToken {
+    private final AccessToken accessToken;
+    private final JWTClaimsSet claims;
+
+    public OAuthBearerTokenImpl(AccessToken accessToken) {
+        this.accessToken = accessToken;
+        try {
+            claims = JWTParser.parse(accessToken.getToken()).getJWTClaimsSet();
+        } catch (ParseException exception) {
+            throw new SaslAuthenticationException("Unable to parse the access token", exception);
+        }
+    }
+
+    @Override
+    public String value() {
+        return accessToken.getToken();
+    }
+
+    @Override
+    public Long startTimeMs() {
+        return claims.getIssueTime().getTime();
+    }
+
+    @Override
+    public long lifetimeMs() {
+        return claims.getExpirationTime().getTime();
+    }
+
+    @Override
+    public Set<String> scope() {
+        return Optional.ofNullable(claims.getClaim("scp"))
+                .map(s -> Arrays.stream(((String) s)
+                                .split(" "))
+                        .collect(Collectors.toSet()))
+                .orElse(null);
+    }
+
+    @Override
+    public String principalName() {
+        return (String) claims.getClaim("upn");
+    }
+
+    public boolean isExpired() {
+        return accessToken.isExpired();
+    }
+}
+

--- a/src/main/java/org/akhq/configs/SchemaRegistryType.java
+++ b/src/main/java/org/akhq/configs/SchemaRegistryType.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 public enum SchemaRegistryType {
     CONFLUENT((byte) 0x0),
     TIBCO((byte) 0x80),
-    GLUE((byte) 0x0);
+    GLUE((byte) 0x0),
+    AZURE((byte) 0x0);
 
     private byte magicByte;
 

--- a/src/main/java/org/akhq/controllers/SchemaController.java
+++ b/src/main/java/org/akhq/controllers/SchemaController.java
@@ -177,7 +177,7 @@ public class SchemaController extends AbstractController {
     public Schema getSubjectBySchemaIdAndTopic(
         HttpRequest<?> request,
         String cluster,
-        Integer id,
+        String id,
         @Nullable @QueryValue String topic
     ) throws IOException, RestClientException {
         // TODO Do the check on the subject name too

--- a/src/main/java/org/akhq/models/Record.java
+++ b/src/main/java/org/akhq/models/Record.java
@@ -13,6 +13,7 @@ import io.confluent.kafka.schemaregistry.json.JsonSchema;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import lombok.*;
 import org.akhq.configs.SchemaRegistryType;
+import org.akhq.modules.schemaregistry.AzureSchemaRegistryDeserializer;
 import org.akhq.utils.AvroToJsonDeserializer;
 import org.akhq.utils.AvroToJsonSerializer;
 import org.akhq.utils.ConsumerOffsetsDecoder;
@@ -111,10 +112,10 @@ public class Record {
         this.timestamp = ZonedDateTime.ofInstant(Instant.ofEpochMilli(record.timestamp()), ZoneId.systemDefault());
         this.bytesKey = bytesKey;
         this.awsGlueKafkaDeserializer = awsGlueKafkaDeserializer;
-        this.keySchemaId = getAvroSchemaId(this.bytesKey);
+        this.keySchemaId = getAvroSchemaId(this.bytesKey, schemaRegistryType);
         this.keySubject = getAvroSchemaSubject(this.keySchemaId, this.bytesKey);
         this.bytesValue = bytesValue;
-        this.valueSchemaId = getAvroSchemaId(this.bytesValue);
+        this.valueSchemaId = getAvroSchemaId(this.bytesValue,schemaRegistryType);
         this.valueSubject = getAvroSchemaSubject(this.valueSchemaId, this.bytesValue);
         this.headers = headers;
         this.truncated = false;
@@ -136,16 +137,15 @@ public class Record {
         this.timestampType = record.timestampType();
         this.bytesKey = record.key();
         this.awsGlueKafkaDeserializer = awsGlueKafkaDeserializer;
-        this.keySchemaId = getAvroSchemaId(this.bytesKey);
-        this.keySubject = getAvroSchemaSubject(this.keySchemaId, this.bytesKey);
-        this.bytesValue = bytesValue;
-        this.valueSchemaId = getAvroSchemaId(this.bytesValue);
-        this.valueSubject = getAvroSchemaSubject(this.valueSchemaId, this.bytesValue);
         for (Header header: record.headers()) {
             String headerValue = String.valueOf(ContentUtils.convertToObject(header.value()));
             this.headers.add(new KeyValue<>(header.key(), headerValue));
         }
-
+        this.keySchemaId = getAvroSchemaId(this.bytesKey, schemaRegistryType);
+        this.keySubject = getAvroSchemaSubject(this.keySchemaId, this.bytesKey);
+        this.bytesValue = bytesValue;
+        this.valueSchemaId = getAvroSchemaId(this.bytesValue, schemaRegistryType);
+        this.valueSubject = getAvroSchemaSubject(this.valueSchemaId, this.bytesValue);
         this.kafkaAvroDeserializer = kafkaAvroDeserializer;
         this.protobufToJsonDeserializer = protobufToJsonDeserializer;
         this.avroToJsonDeserializer = avroToJsonDeserializer;
@@ -192,6 +192,9 @@ public class Record {
         this.truncated = truncated;
     }
 
+    private boolean isAzureRegistry(){
+        return kafkaAvroDeserializer instanceof AzureSchemaRegistryDeserializer;
+    }
     private String convertToString(byte[] payload, String schemaId, boolean isKey) {
         if (payload == null) {
             return null;
@@ -202,14 +205,13 @@ public class Record {
                 if (this.awsGlueKafkaDeserializer != null) {
                     return this.awsGlueKafkaDeserializer.deserialize(this.topic.getName(), payload).toString();
                 }
-                if (client != null) {
+                if (client != null && !isAzureRegistry()) {
                     ParsedSchema schema = client.getSchemaById(Integer.parseInt(schemaId));
                     if ( schema.schemaType().equals(ProtobufSchema.TYPE) ) {
                        toType = kafkaProtoDeserializer.deserialize(topic.getName(), payload);
                        if (!(toType instanceof Message)) {
                            return String.valueOf(toType);
                        }
-
                        Message dynamicMessage = (Message)toType;
                        return avroToJsonSerializer.getMapper().readTree(JsonFormat.printer().print(dynamicMessage)).toString();
                     } else  if ( schema.schemaType().equals(JsonSchema.TYPE) ) {
@@ -221,8 +223,14 @@ public class Record {
                       return node.toString();
                     }
                 }
-
-                toType = kafkaAvroDeserializer.deserialize(topic.getName(), payload);
+                if (isAzureRegistry()) {
+                    if (isKey) return null; // Azure Event Hub does not support key schema
+                    AzureSchemaRegistryDeserializer azureDeserializer =
+                        (AzureSchemaRegistryDeserializer) kafkaAvroDeserializer;
+                    toType = azureDeserializer.deserialize(topic.getName(), payload, schemaId);
+                } else {
+                    toType = kafkaAvroDeserializer.deserialize(topic.getName(), payload);
+                }
 
                 //for primitive avro type
                 if (!(toType instanceof GenericRecord)) {
@@ -340,7 +348,26 @@ public class Record {
         return TransactionLog.read(ByteBuffer.wrap(this.bytesKey), ByteBuffer.wrap(payload)).toString();
     }
 
-    private String getAvroSchemaId(byte[] payload) {
+    private String extractSchemaIdFromHeaders() {
+        if (this.headers == null) {
+            return null;
+        }
+        String contentType = null;
+        for (KeyValue<String, String> header : this.headers) {
+            if ("content-type".equalsIgnoreCase(header.getKey())) {
+                contentType = header.getValue();
+            }
+        }
+        if (contentType == null) {
+            return null;
+        }
+        // Extract GUID after "avro/binary+"
+        if (contentType.startsWith("avro/binary+")) {
+            return  contentType.substring("avro/binary+".length());
+        }
+        return null;
+    }
+    private String getAvroSchemaId(byte[] payload, SchemaRegistryType schemaRegistryType) {
         if (topic.isInternalTopic()) {
             return null;
         }
@@ -356,6 +383,11 @@ public class Record {
 
             ByteBuffer buffer = ByteBuffer.wrap(payload);
             byte magicBytes = buffer.get();
+
+            if (schemaRegistryType == SchemaRegistryType.AZURE){
+                return extractSchemaIdFromHeaders();
+            }
+
             int schemaId = buffer.getInt();
 
             if (magicBytes == MAGIC_BYTE && schemaId >= 0) {

--- a/src/main/java/org/akhq/models/Schema.java
+++ b/src/main/java/org/akhq/models/Schema.java
@@ -26,6 +26,7 @@ public class Schema {
     private final Parser parser = new Parser().setValidateDefaults(false);
 
     private Integer id;
+    private String azureSchemaId;
     private String subject;
     private Integer version;
     private Config.CompatibilityLevelConfig compatibilityLevel;
@@ -41,6 +42,11 @@ public class Schema {
 
     private String exception;
 
+    public Schema(String schemaId, String subject, int version) {
+        this.azureSchemaId = schemaId;
+        this.subject = subject;
+        this.version = version;
+    }
     public Schema(int schemaId, String subject, int version) {
         this.id = schemaId;
         this.subject = subject;
@@ -55,6 +61,16 @@ public class Schema {
         this.references = schema.getReferences();
         this.exception = schema.exception;
         this.compatibilityLevel = config.getCompatibilityLevel();
+    }
+
+
+    public Schema (String schemaId, String subject, int version, org.apache.avro.Schema avroSchema , String schema) {
+        this.azureSchemaId = schemaId;
+        this.subject = subject;
+        this.version = version;
+        this.compatibilityLevel = Config.CompatibilityLevelConfig.NONE;
+        this.avroSchema = avroSchema;
+        this.schema = schema;
     }
 
     public Schema(io.confluent.kafka.schemaregistry.client.rest.entities.Schema schema, ParsedSchema parsedSchema, Schema.Config config) {

--- a/src/main/java/org/akhq/modules/KafkaModule.java
+++ b/src/main/java/org/akhq/modules/KafkaModule.java
@@ -1,5 +1,8 @@
 package org.akhq.modules;
 
+import com.azure.data.schemaregistry.SchemaRegistryClientBuilder;
+import com.azure.identity.DefaultAzureCredential;
+import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.SchemaProvider;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
@@ -376,5 +379,41 @@ public class KafkaModule {
         }
 
         return this.ksqlDbClient.get(clusterId);
+    }
+
+    private final Map<String, com.azure.data.schemaregistry.SchemaRegistryClient> azureSchemaRegistryClient = new HashMap<>();
+    public com.azure.data.schemaregistry.SchemaRegistryClient getAzureSchemaRegistryClient(String clusterId) throws InvalidClusterException {
+        if (!this.clusterExists(clusterId)) {
+            throw new InvalidClusterException(INVALID_CLUSTER + clusterId + "'");
+        }
+        if(!this.azureSchemaRegistryClient.containsKey(clusterId)){
+            Connection connection = this.getConnection(clusterId);
+            Connection.SchemaRegistry schemaRegistry = connection.getSchemaRegistry();
+            // Get endpoint
+            String namespace = schemaRegistry.getUrl();
+            String fullyQualifiedNamespace = namespace.contains(".")
+                ? namespace
+                : namespace + ".servicebus.windows.net";
+
+            //build credential from DefaultAzureCredentialBuilder
+            DefaultAzureCredential credential = new DefaultAzureCredentialBuilder().build();
+            // Create Schema Registry client
+            com.azure.data.schemaregistry.SchemaRegistryClient client = new  SchemaRegistryClientBuilder()
+                .fullyQualifiedNamespace(fullyQualifiedNamespace)
+                .credential(credential)
+                .buildClient();
+            azureSchemaRegistryClient.put(clusterId, client);
+        }
+        return azureSchemaRegistryClient.get(clusterId);
+    }
+
+    public String getAzureGroupeName (String clusterId) throws InvalidClusterException {
+        if (!this.clusterExists(clusterId)) {
+            throw new InvalidClusterException(INVALID_CLUSTER + clusterId + "'");
+        }
+        Connection connection = this.getConnection(clusterId);
+        Connection.SchemaRegistry schemaRegistry = connection.getSchemaRegistry();
+        Map<String, String> properties = schemaRegistry.getProperties();
+        return properties.get("schema.group");
     }
 }

--- a/src/main/java/org/akhq/modules/schemaregistry/AzureSchemaRegistryDeserializer.java
+++ b/src/main/java/org/akhq/modules/schemaregistry/AzureSchemaRegistryDeserializer.java
@@ -1,0 +1,77 @@
+package org.akhq.modules.schemaregistry;
+
+import com.azure.data.schemaregistry.SchemaRegistryClient;
+import jakarta.inject.Singleton;
+import lombok.SneakyThrows;
+import org.akhq.modules.KafkaModule;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.kafka.common.serialization.Deserializer;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Azure Schema Registry support for AKHQ
+ * Deserializes RAW Avro messages from Azure Event Hub using schemas from Azure Schema Registry
+ */
+@Singleton
+public class AzureSchemaRegistryDeserializer implements Deserializer<Object> {
+
+    private final Map<String, Schema> schemaCache = new HashMap<>();
+    private final KafkaModule kafkaModule;
+    private final String configuredClusterId;
+
+    public AzureSchemaRegistryDeserializer(KafkaModule kafkaModule, String clusterId) {
+        this.kafkaModule = kafkaModule;
+        this.configuredClusterId = clusterId;
+    }
+
+
+    @SneakyThrows
+    @Override
+    public Object deserialize(String topic, byte[] data) {
+        return deserialize(topic, data, null);
+    }
+
+    /**
+     * Deserialize with headers support (Azure Schema Registry uses content-type header)
+     */
+    public Object deserialize(String topic, byte[] data, String schemaId) throws IOException {
+        if (data == null || data.length == 0) {
+            return null;
+        }
+        Schema schema = this.getSchemaById(configuredClusterId, schemaId);
+        GenericDatumReader<GenericRecord> reader = new GenericDatumReader<>(schema);
+        BinaryDecoder decoder = DecoderFactory.get().binaryDecoder(data, null);
+        return reader.read(null, decoder);
+    }
+
+    /**
+     * Get schema by ID from Azure Schema Registry
+     */
+    private Schema getSchemaById(String clusterId, String schemaId) {
+        return schemaCache.computeIfAbsent(schemaId, id -> {
+            try {
+                SchemaRegistryClient client = this.kafkaModule.getAzureSchemaRegistryClient(clusterId);
+                // Get schema definition by ID
+                String schemaDefinition = client.getSchema(schemaId).getDefinition();
+                // Parse Avro schema
+                Schema.Parser parser = new Schema.Parser();
+                return parser.parse(schemaDefinition);
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to retrieve schema by ID from Azure: " + schemaId, e);
+            }
+        });
+    }
+
+    @Override
+    public void close() {
+        // Clear caches
+        schemaCache.clear();
+    }
+}

--- a/src/main/java/org/akhq/repositories/SchemaRegistryRepository.java
+++ b/src/main/java/org/akhq/repositories/SchemaRegistryRepository.java
@@ -3,6 +3,9 @@ package org.akhq.repositories;
 import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryKafkaDeserializer;
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
 import com.amazonaws.services.schemaregistry.utils.AvroRecordType;
+import com.azure.data.schemaregistry.SchemaRegistryClient;
+import com.azure.data.schemaregistry.models.SchemaProperties;
+import com.azure.data.schemaregistry.models.SchemaRegistrySchema;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
@@ -16,18 +19,18 @@ import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import org.akhq.configs.Connection;
 import org.akhq.configs.SchemaRegistryType;
 import org.akhq.models.Schema;
 import org.akhq.models.audit.SchemaAuditEvent;
 import org.akhq.modules.AuditModule;
 import org.akhq.modules.KafkaModule;
+import org.akhq.modules.schemaregistry.AzureSchemaRegistryDeserializer;
 import org.akhq.utils.PagedList;
 import org.akhq.utils.Pagination;
 import org.apache.kafka.common.serialization.Deserializer;
-
-import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 
@@ -50,6 +53,7 @@ public class SchemaRegistryRepository extends AbstractRepository {
     private final Map<String, Deserializer> kafkaJsonDeserializers = new HashMap<>();
     private final Map<String, Deserializer> kafkaProtoDeserializers = new HashMap<>();
     private final Map<String, Deserializer> awsGlueKafkaDeserializers = new HashMap<>();
+    private final Map<String, Integer> azureSchemaProperties = new HashMap<>();
 
 
     public PagedList<Schema> list(String clusterId, Pagination pagination, Optional<String> search, List<String> filters) throws IOException, RestClientException, ExecutionException, InterruptedException {
@@ -60,27 +64,27 @@ public class SchemaRegistryRepository extends AbstractRepository {
         return toSchemasLatestVersion(all(clusterId, search, filters), clusterId);
     }
 
-    private List<Schema> toSchemasLatestVersion(List<String> subjectList, String clusterId){
-        return subjectList .stream()
-                .map(s -> {
-                    try {
-                        return getLatestVersion(clusterId, s);
-                    } catch (RestClientException | IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                })
-                .collect(Collectors.toList());
+    private List<Schema> toSchemasLatestVersion(List<String> subjectList, String clusterId) {
+        return subjectList.stream()
+            .map(s -> {
+                try {
+                    return getLatestVersion(clusterId, s);
+                } catch (RestClientException | IOException e) {
+                    throw new RuntimeException(e);
+                }
+            })
+            .collect(Collectors.toList());
     }
 
-    private ParsedSchema getParsedSchema(io.confluent.kafka.schemaregistry.client.rest.entities.Schema schema, String clusterId)  {
+    private ParsedSchema getParsedSchema(io.confluent.kafka.schemaregistry.client.rest.entities.Schema schema, String clusterId) {
         ParsedSchema parsedSchema;
-        if ( schema.getSchemaType().equals(JsonSchema.TYPE) ) {
+        if (schema.getSchemaType().equals(JsonSchema.TYPE)) {
             parsedSchema = this.kafkaModule
                 .getJsonSchemaProvider(clusterId)
                 .parseSchema(schema.getSchema(), schema.getReferences())
                 .orElse(null);
 
-        } else if( schema.getSchemaType().equals(ProtobufSchema.TYPE)) {
+        } else if (schema.getSchemaType().equals(ProtobufSchema.TYPE)) {
             parsedSchema = this.kafkaModule
                 .getProtobufSchemaProvider(clusterId)
                 .parseSchema(schema.getSchema(), schema.getReferences())
@@ -94,10 +98,10 @@ public class SchemaRegistryRepository extends AbstractRepository {
         return parsedSchema;
     }
 
-    public List<String> all(String clusterId, Optional<String> search, List<String> filters) throws  IOException, RestClientException {
+    public List<String> all(String clusterId, Optional<String> search, List<String> filters) throws IOException, RestClientException {
         Optional<RestService> maybeRegistryRestClient = Optional.ofNullable(kafkaModule
-                .getRegistryRestClient(clusterId));
-        if(maybeRegistryRestClient.isEmpty()){
+            .getRegistryRestClient(clusterId));
+        if (maybeRegistryRestClient.isEmpty()) {
             return List.of();
         }
         return maybeRegistryRestClient.get()
@@ -123,23 +127,42 @@ public class SchemaRegistryRepository extends AbstractRepository {
         return found;
     }
 
-    public List<Schema> getSubjectsBySchemaId(String clusterId, int id) throws  IOException, RestClientException {
+    private boolean isAzureRegistry(String clusterId) {
+        if (!this.kafkaAvroDeserializers.containsKey(clusterId)) {
+            return false;
+        } else {
+            return this.kafkaAvroDeserializers.get(clusterId) instanceof AzureSchemaRegistryDeserializer;
+        }
+    }
+
+    public List<Schema> getSubjectsBySchemaId(String clusterId, String id) throws IOException, RestClientException {
+        //check if schema registry is Azure Event Hub
+        if (isAzureRegistry(clusterId)) {
+            SchemaRegistryClient clienAzure = this.kafkaModule.getAzureSchemaRegistryClient(clusterId);
+            SchemaProperties schemaProperties = clienAzure.getSchema(id).getProperties();
+            if (!azureSchemaProperties.containsKey(schemaProperties.getName())) {
+                azureSchemaProperties.put(schemaProperties.getName(), schemaProperties.getVersion());
+            }
+            Schema schema = new Schema(id, schemaProperties.getName(), schemaProperties.getVersion());
+            return List.of(schema);
+        }
+
         Optional<RestService> maybeRegistryRestClient = Optional.ofNullable(kafkaModule
             .getRegistryRestClient(clusterId));
         if (maybeRegistryRestClient.isEmpty()) {
             return List.of();
         }
-
+        int schemaIdInt = Integer.parseInt(id);
         return maybeRegistryRestClient.get()
-            .getAllVersionsById(id)
+            .getAllVersionsById(schemaIdInt)
             .stream()
-            .map(v -> new Schema(id, v.getSubject(), v.getVersion()))
+            .map(v -> new Schema(schemaIdInt, v.getSubject(), v.getVersion()))
             .collect(Collectors.toList());
     }
 
     public Optional<Schema> getById(String clusterId, Integer id) throws IOException, RestClientException, ExecutionException, InterruptedException {
-        for (String subject: this.all(clusterId, Optional.empty(), List.of())) {
-            for (Schema version: this.getAllVersions(clusterId, subject)) {
+        for (String subject : this.all(clusterId, Optional.empty(), List.of())) {
+            for (Schema version : this.getAllVersions(clusterId, subject)) {
                 if (version.getId().equals(id)) {
                     return Optional.of(version);
                 }
@@ -150,6 +173,14 @@ public class SchemaRegistryRepository extends AbstractRepository {
     }
 
     public Schema getLatestVersion(String clusterId, String subject) throws IOException, RestClientException {
+        if (isAzureRegistry(clusterId)) {
+            int lastversion = azureSchemaProperties.getOrDefault(subject, 1);
+            SchemaRegistryClient clientAzure = this.kafkaModule.getAzureSchemaRegistryClient(clusterId);
+            String groupeName = this.kafkaModule.getAzureGroupeName(clusterId);
+            SchemaRegistrySchema schemaAzure = clientAzure.getSchema(groupeName, subject, lastversion);
+            org.apache.avro.Schema schemaAvro = new org.apache.avro.Schema.Parser().parse(schemaAzure.getDefinition());
+            return new Schema(schemaAzure.getProperties().getId(), subject, schemaAzure.getProperties().getVersion(), schemaAvro, schemaAzure.getDefinition());
+        }
         io.confluent.kafka.schemaregistry.client.rest.entities.Schema latestVersion = this.kafkaModule
             .getRegistryRestClient(clusterId)
             .getLatestVersion(subject);
@@ -160,8 +191,10 @@ public class SchemaRegistryRepository extends AbstractRepository {
     }
 
     public List<Schema> getAllVersions(String clusterId, String subject) throws IOException, RestClientException {
+        if (isAzureRegistry(clusterId)) {
+            return List.of(getLatestVersion(clusterId, subject));
+        }
         Schema.Config config = this.getConfig(clusterId, subject);
-
         return this.kafkaModule
             .getRegistryRestClient(clusterId)
             .getAllVersions(subject)
@@ -209,7 +242,7 @@ public class SchemaRegistryRepository extends AbstractRepository {
     public Schema register(String clusterId, String subject, String type, String schema, List<SchemaReference> references) throws IOException, RestClientException {
         RegisterSchemaResponse registerSchemaResponse = this.kafkaModule
             .getRegistryRestClient(clusterId)
-            .registerSchema(schema, type != null? type: "AVRO", references, subject);
+            .registerSchema(schema, type != null ? type : "AVRO", references, subject);
 
         Schema latestVersion = getLatestVersion(clusterId, subject);
 
@@ -277,9 +310,10 @@ public class SchemaRegistryRepository extends AbstractRepository {
     }
 
     public Deserializer getKafkaAvroDeserializer(String clusterId) {
+        SchemaRegistryType schemaRegistryType = getSchemaRegistryType(clusterId);
         if (!this.kafkaAvroDeserializers.containsKey(clusterId)) {
             Deserializer deserializer;
-            SchemaRegistryType schemaRegistryType = getSchemaRegistryType(clusterId);
+
             if (schemaRegistryType == SchemaRegistryType.TIBCO) {
                 try {
                     deserializer = (Deserializer) Class.forName("com.tibco.messaging.kafka.avro.AvroDeserializer").getDeclaredConstructor().newInstance();
@@ -291,9 +325,13 @@ public class SchemaRegistryRepository extends AbstractRepository {
                     }
                     config.putAll(this.kafkaModule.getConnection(clusterId).getProperties());
                     deserializer.configure(config, false);
-                } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException | ClassNotFoundException e) {
+                } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
+                         NoSuchMethodException | ClassNotFoundException e) {
                     throw new IllegalArgumentException("Configured schema registry type was 'tibco', but TIBCO Avro client library not found on classpath");
                 }
+            } else if (schemaRegistryType == SchemaRegistryType.AZURE) {
+                deserializer = new AzureSchemaRegistryDeserializer(this.kafkaModule, clusterId);
+                deserializer.configure(this.kafkaModule.getConnection(clusterId).getProperties(), false);
             } else {
                 deserializer = new KafkaAvroDeserializer(this.kafkaModule.getRegistryClient(clusterId));
             }
@@ -310,6 +348,8 @@ public class SchemaRegistryRepository extends AbstractRepository {
             SchemaRegistryType schemaRegistryType = getSchemaRegistryType(clusterId);
             if (schemaRegistryType == SchemaRegistryType.TIBCO) {
                 throw new IllegalArgumentException("Configured schema registry type was 'tibco', but TIBCO JSON client is not supported");
+            } else if (schemaRegistryType == SchemaRegistryType.AZURE) {
+                throw new IllegalArgumentException("Configured schema registry type was 'azure', but Azure JSON schema is not supported");
             } else {
                 deserializer = new KafkaJsonSchemaDeserializer(this.kafkaModule.getRegistryClient(clusterId));
             }
@@ -326,6 +366,8 @@ public class SchemaRegistryRepository extends AbstractRepository {
             SchemaRegistryType schemaRegistryType = getSchemaRegistryType(clusterId);
             if (schemaRegistryType == SchemaRegistryType.TIBCO) {
                 throw new IllegalArgumentException("Configured schema registry type was 'tibco', but TIBCO PROTOBUF client is not supported");
+            } else if (schemaRegistryType == SchemaRegistryType.AZURE) {
+                throw new IllegalArgumentException("Configured schema registry type was 'azure', but Azure PROTOBUF schema is not supported");
             } else {
                 deserializer = new KafkaProtobufDeserializer(this.kafkaModule.getRegistryClient(clusterId));
             }
@@ -344,13 +386,14 @@ public class SchemaRegistryRepository extends AbstractRepository {
         }
         return schemaRegistryType;
     }
+
     public Deserializer getAwsGlueKafkaDeserializer(String clusterId) {
 
-        if (!this.awsGlueKafkaDeserializers.containsKey(clusterId)){
+        if (!this.awsGlueKafkaDeserializers.containsKey(clusterId)) {
             Connection.SchemaRegistry schemaRegistry = kafkaModule.getConnection(clusterId).getSchemaRegistry();
             Map<String, Object> params = new HashMap<>();
             params.put(AWSSchemaRegistryConstants.REGISTRY_NAME, schemaRegistry.getGlueSchemaRegistryName());
-            params.put(AWSSchemaRegistryConstants.AWS_REGION,schemaRegistry.getAwsRegion());
+            params.put(AWSSchemaRegistryConstants.AWS_REGION, schemaRegistry.getAwsRegion());
             params.put(AWSSchemaRegistryConstants.AVRO_RECORD_TYPE, AvroRecordType.GENERIC_RECORD.getName());
 
             // Adding secondary deserializer so that messages that aren't serialized using avro,proto or json are deserialized using StringDeserializer

--- a/src/test/java/org/akhq/models/RecordTest.java
+++ b/src/test/java/org/akhq/models/RecordTest.java
@@ -1,0 +1,92 @@
+package org.akhq.models;
+
+import org.akhq.configs.SchemaRegistryType;
+import org.akhq.modules.schemaregistry.AzureSchemaRegistryDeserializer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RecordTest {
+
+    private static final String TOPIC_NAME = "azure-event-hub-topic";
+    private static final String SCHEMA_ID = "123e4567-e89b-12d3-a456-426614174000";
+
+    @Mock
+    private AzureSchemaRegistryDeserializer azureSchemaRegistryDeserializer;
+
+    private Topic newTopic() {
+        Topic topic = new Topic();
+        topic.setName(TOPIC_NAME);
+        topic.setInternal(false);
+        return topic;
+    }
+
+    private Record newAzureRecord(byte[] keyBytes, byte[] valueBytes, String contentTypeHeader) {
+        ConsumerRecord<byte[], byte[]> consumerRecord = new ConsumerRecord<>(TOPIC_NAME, 0, 0, keyBytes, valueBytes);
+        if (contentTypeHeader != null) {
+            consumerRecord.headers().add(new RecordHeader("content-type", contentTypeHeader.getBytes(StandardCharsets.UTF_8)));
+        }
+
+        return new Record(
+            null,
+            consumerRecord,
+            SchemaRegistryType.AZURE,
+            azureSchemaRegistryDeserializer,
+            null,
+            null,
+            null,
+            null,
+            null,
+            valueBytes,
+            newTopic(),
+            null
+        );
+    }
+
+    @Test
+    void schemaIdIsExtractedFromContentTypeHeaderForAzureRegistry() {
+        Record record = newAzureRecord(
+            "key".getBytes(StandardCharsets.UTF_8),
+            "value".getBytes(StandardCharsets.UTF_8),
+            "avro/binary+" + SCHEMA_ID
+        );
+
+        assertEquals(SCHEMA_ID, record.getValueSchemaId());
+    }
+
+    @Test
+    void getKeyReturnsNullForAzureRegistryEvenWhenSchemaIdIsPresent() {
+        Record record = newAzureRecord(
+            "key".getBytes(StandardCharsets.UTF_8),
+            "value".getBytes(StandardCharsets.UTF_8),
+            "avro/binary+" + SCHEMA_ID
+        );
+
+        assertNull(record.getKey());
+    }
+
+    @Test
+    void getValueDelegatesToAzureSchemaRegistryDeserializer() throws IOException {
+        byte[] valueBytes = "value".getBytes(StandardCharsets.UTF_8);
+        Record record = newAzureRecord(
+            "key".getBytes(StandardCharsets.UTF_8),
+            valueBytes,
+            "avro/binary+" + SCHEMA_ID
+        );
+
+        when(azureSchemaRegistryDeserializer.deserialize(TOPIC_NAME, valueBytes, SCHEMA_ID)).thenReturn("decoded-value");
+
+        assertEquals("decoded-value", record.getValue());
+    }
+
+}


### PR DESCRIPTION
# Add Azure Event Hubs support for topic data browsing and Azure Schema Registry integration

## Summary

This Merge Request introduces the first step of Azure Event Hubs and Azure Schema Registry support in AKHQ.

The scope of this MR is intentionally limited to **topic data consultation and message deserialization** for topics hosted on **Azure Event Hubs**. It enables AKHQ users to browse and inspect messages while leveraging schemas managed by **Azure Schema Registry**.

## Changes Included

### Azure Event Hubs Support

- Added support for Azure Event Hubs as a Kafka-compatible platform.
- Introduced Azure-specific configuration options.
- Added documentation explaining how to configure AKHQ with Azure Event Hubs.

### Azure Schema Registry Integration

- Added support for Azure Schema Registry as a schema provider.
- Implemented schema retrieval and caching mechanisms.
- Added Avro payload deserialization using schemas stored in Azure Schema Registry.

### Documentation Updates

- Added configuration examples for Azure Event Hubs.
- Added configuration examples for Azure Schema Registry.
- Documented authentication and setup requirements.

## Scope

This MR focuses exclusively on **read-only capabilities** for Azure Event Hubs topics.

Supported features:

- Browse Azure Event Hubs topics.
- View messages from AKHQ.
- Deserialize Avro payloads using Azure Schema Registry schemas.
- Inspect topic data through the AKHQ user interface.

## Limitations

This MR does **not** include support for:

- Producing messages to Azure Event Hubs.
- Creating or registering schemas.
- Schema management operations.
- Any write operations on Azure Event Hubs topics.

The goal of this first contribution is to provide a reliable solution for browsing and visualizing data stored in Azure Event Hubs while keeping the implementation scope manageable and easier to review.

## Follow-up Work

A dedicated follow-up Merge Request will be proposed to add **message production support for Azure Event Hubs topics**, including the necessary Azure Schema Registry integration required for schema-aware data publishing.