### PR TITLE
fix(api): correct OpenAPI spec URL (#3078)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -307,6 +307,13 @@ task startTestKafkaCluster(type: com.github.psxpaul.task.JavaExecFork) {
     timeout = 300
 }
 
+tasks.withType(JavaCompile).configureEach {
+    options.fork = true
+    options.forkOptions.jvmArgs += [
+        '-Dmicronaut.openapi.filename=akhq'
+    ]
+}
+
 /**********************************************************************************************************************\
  * Jar
  **********************************************************************************************************************/


### PR DESCRIPTION
## What does this PR do?

Fixes the `/api` documentation page failing to load the OpenAPI specification because the generated specification filename is version-dependent.

The application expects the OpenAPI specification to be available at:

`/swagger/akhq.yml`

However, the Micronaut OpenAPI build currently generates a versioned filename such as:

`akhq-1.0.0.yml`

As a result, the `/api` page requests `/swagger/akhq.yml`, which does not exist and returns a 404.

## Changes

Configure the Java compilation process to explicitly set the Micronaut OpenAPI output filename:

```groovy
tasks.withType(JavaCompile).configureEach {
    options.fork = true
    options.forkOptions.jvmArgs += [
        '-Dmicronaut.openapi.filename=akhq'
    ]
}
```

This makes the generated OpenAPI specification consistently use:

`akhq.yml`

instead of a version-dependent filename.

## Why this approach?

Rather than updating the application to reference a version-specific generated filename, this keeps the OpenAPI specification filename stable.

This avoids coupling the `/api` page to the project version and prevents the same issue from recurring whenever the application version changes.

It also preserves the existing `/swagger/akhq.yml` path already used by the application.

## Verification

* Reproduced the issue locally before the change.
* Confirmed that the generated OpenAPI specification was using a versioned filename.
* Verified that the generated specification is now named `akhq.yml`.
* Verified that the `/api` page loads the OpenAPI documentation successfully after the change.

Fixes #3078
