### PR TITLE
fix(ui): support Unicode ACL principals

### DIFF
--- a/client/src/containers/Acl/AclDetail/AclDetails.jsx
+++ b/client/src/containers/Acl/AclDetail/AclDetails.jsx
@@ -8,27 +8,36 @@ import { getSelectedTab } from '../../../utils/functions';
 import { Link } from 'react-router-dom';
 import Root from '../../../components/Root';
 import { withRouter } from '../../../utils/withRouter';
+import {
+  decodeBase64PathSegment,
+  decodeUtf8FromBase64,
+  encodeBase64PathSegment
+} from '../../../utils/base64';
 
 class AclDetails extends Root {
   state = {
     clusterId: this.props.params.clusterId,
-    principalEncoded: this.props.params.principalEncoded,
+    principalEncoded: decodeBase64PathSegment(this.props.params.principalEncoded),
     selectedTab: 'topics'
   };
 
   tabs = ['topics', 'groups', 'clusters', 'transactionalids'];
 
   componentDidMount() {
-    const { clusterId, principalEncoded } = this.props.params;
+    const { clusterId } = this.props.params;
+    const principalEncoded = decodeBase64PathSegment(this.props.params.principalEncoded);
     const tabSelected = getSelectedTab(this.props, this.tabs);
     this.setState(
       {
+        principalEncoded,
         selectedTab: tabSelected ? tabSelected : 'topics'
       },
       () => {
         this.props.router.navigate(
           {
-            pathname: `/ui/${clusterId}/acls/${principalEncoded}/${this.state.selectedTab}`
+            pathname: `/ui/${clusterId}/acls/${encodeBase64PathSegment(principalEncoded)}/${
+              this.state.selectedTab
+            }`
           },
           { replace: true }
         );
@@ -39,7 +48,10 @@ class AclDetails extends Root {
   componentDidUpdate(prevProps) {
     if (this.props.location.pathname !== prevProps.location.pathname) {
       const tabSelected = getSelectedTab(this.props, this.tabs);
-      this.setState({ selectedTab: tabSelected });
+      this.setState({
+        principalEncoded: decodeBase64PathSegment(this.props.params.principalEncoded),
+        selectedTab: tabSelected
+      });
     }
   }
 
@@ -67,7 +79,8 @@ class AclDetails extends Root {
 
   render() {
     const { principalEncoded, clusterId } = this.state;
-    const principal = atob(principalEncoded);
+    const principal = decodeUtf8FromBase64(principalEncoded);
+    const principalPathSegment = encodeBase64PathSegment(principalEncoded);
     return (
       <div>
         <Header title={`Acl: ${principal}`} />
@@ -75,7 +88,7 @@ class AclDetails extends Root {
           <ul className="nav nav-tabs" role="tablist">
             <li className="nav-item">
               <Link
-                to={`/ui/${clusterId}/acls/${principalEncoded}/topics`}
+                to={`/ui/${clusterId}/acls/${principalPathSegment}/topics`}
                 className={this.tabClassName('topics')}
               >
                 Topics
@@ -83,7 +96,7 @@ class AclDetails extends Root {
             </li>
             <li className="nav-item">
               <Link
-                to={`/ui/${clusterId}/acls/${principalEncoded}/groups`}
+                to={`/ui/${clusterId}/acls/${principalPathSegment}/groups`}
                 className={this.tabClassName('groups')}
               >
                 Groups
@@ -91,7 +104,7 @@ class AclDetails extends Root {
             </li>
             <li className="nav-item">
               <Link
-                to={`/ui/${clusterId}/acls/${principalEncoded}/clusters`}
+                to={`/ui/${clusterId}/acls/${principalPathSegment}/clusters`}
                 className={this.tabClassName('clusters')}
               >
                 Clusters
@@ -99,7 +112,7 @@ class AclDetails extends Root {
             </li>
             <li className="nav-item">
               <Link
-                to={`/ui/${clusterId}/acls/${principalEncoded}/transactionalids`}
+                to={`/ui/${clusterId}/acls/${principalPathSegment}/transactionalids`}
                 className={this.tabClassName('transactionalids')}
               >
                 Transactional Ids

--- a/client/src/containers/Acl/AclList/Acls.jsx
+++ b/client/src/containers/Acl/AclList/Acls.jsx
@@ -6,8 +6,9 @@ import { uriAclsList } from '../../../utils/endpoints';
 import SearchBar from '../../../components/SearchBar';
 import Root from '../../../components/Root';
 import { withRouter } from '../../../utils/withRouter';
+import { encodeBase64PathSegment, encodeUtf8ToBase64 } from '../../../utils/base64';
 
-class Acls extends Root {
+export class Acls extends Root {
   state = {
     data: [],
     selectedCluster: '',
@@ -43,7 +44,7 @@ class Acls extends Root {
 
   handleData(acls) {
     let tableAcls = acls.map(acl => {
-      acl.principalEncoded = btoa(acl.principal);
+      acl.principalEncoded = encodeUtf8ToBase64(acl.principal);
       return {
         id: acl,
         user: acl.principal || ''
@@ -111,7 +112,9 @@ class Acls extends Root {
               </td>
             </tr>
           }
-          detailsHref={acl => `/ui/${clusterId}/acls/${acl.principalEncoded}`}
+          detailsHref={acl =>
+            `/ui/${clusterId}/acls/${encodeBase64PathSegment(acl.principalEncoded)}`
+          }
         />
       </div>
     );

--- a/client/src/containers/Acl/AclList/Acls.test.jsx
+++ b/client/src/containers/Acl/AclList/Acls.test.jsx
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Acls } from './Acls';
+
+const buildAcls = () => {
+  const acls = new Acls({
+    location: { search: '' },
+    params: { clusterId: 'local' },
+    router: { navigate: vi.fn() }
+  });
+
+  acls.setState = state => {
+    acls.state = { ...acls.state, ...state };
+  };
+
+  return acls;
+};
+
+describe('Acls', () => {
+  it('encodes ACL principals as UTF-8 Base64 without throwing for Unicode values', () => {
+    const acls = buildAcls();
+    const data = [
+      { principal: 'User:alice' },
+      { principal: 'User:张伟' },
+      { principal: 'User:Renée' },
+      { principal: 'User:प्रिय' },
+      { principal: 'User:service/account+ops' },
+      { principal: '' }
+    ];
+
+    expect(() => acls.handleData(data)).not.toThrow();
+    expect(data.map(acl => acl.principalEncoded)).toEqual([
+      'VXNlcjphbGljZQ==',
+      'VXNlcjrlvKDkvJ8=',
+      'VXNlcjpSZW7DqWU=',
+      'VXNlcjrgpKrgpY3gpLDgpL/gpK8=',
+      'VXNlcjpzZXJ2aWNlL2FjY291bnQrb3Bz',
+      ''
+    ]);
+  });
+});

--- a/client/src/utils/base64.js
+++ b/client/src/utils/base64.js
@@ -1,0 +1,21 @@
+const bytesToBinaryString = bytes => {
+  let binaryString = '';
+  bytes.forEach(byte => {
+    binaryString += String.fromCharCode(byte);
+  });
+  return binaryString;
+};
+
+export const encodeUtf8ToBase64 = value => {
+  return btoa(bytesToBinaryString(new TextEncoder().encode(value)));
+};
+
+export const decodeUtf8FromBase64 = value => {
+  const binaryString = atob(value);
+  const bytes = Uint8Array.from(binaryString, character => character.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+};
+
+export const encodeBase64PathSegment = value => encodeURIComponent(value);
+
+export const decodeBase64PathSegment = value => decodeURIComponent(value);

--- a/client/src/utils/base64.test.js
+++ b/client/src/utils/base64.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  decodeBase64PathSegment,
+  decodeUtf8FromBase64,
+  encodeBase64PathSegment,
+  encodeUtf8ToBase64
+} from './base64';
+
+describe('base64 utils', () => {
+  it.each([
+    { name: 'ASCII principal', principal: 'User:alice', expected: 'VXNlcjphbGljZQ==' },
+    { name: 'accented Latin principal', principal: 'User:Renée', expected: 'VXNlcjpSZW7DqWU=' },
+    { name: 'CJK principal', principal: 'User:张伟', expected: 'VXNlcjrlvKDkvJ8=' },
+    {
+      name: 'Devanagari principal with a Base64 slash',
+      principal: 'User:प्रिय',
+      expected: 'VXNlcjrgpKrgpY3gpLDgpL/gpK8='
+    },
+    {
+      name: 'symbol principal',
+      principal: 'User:service/account+ops',
+      expected: 'VXNlcjpzZXJ2aWNlL2FjY291bnQrb3Bz'
+    },
+    { name: 'empty principal', principal: '', expected: '' }
+  ])('encodes $name as UTF-8 Base64', ({ principal, expected }) => {
+    expect(encodeUtf8ToBase64(principal)).toBe(expected);
+  });
+
+  it.each(['User:alice', 'User:张伟', 'User:Renée', 'User:प्रिय', 'User:service/account+ops', ''])(
+    'decodes UTF-8 Base64 back to the original principal',
+    principal => {
+      expect(decodeUtf8FromBase64(encodeUtf8ToBase64(principal))).toBe(principal);
+    }
+  );
+
+  it('preserves the existing Base64 representation for ASCII principals', () => {
+    const principal = 'User:CN=akhq,O=example';
+
+    expect(encodeUtf8ToBase64(principal)).toBe(btoa(principal));
+  });
+
+  it('encodes Base64 values for path segments without changing the Base64 value', () => {
+    const base64Value = encodeUtf8ToBase64('User:प्रिय');
+
+    expect(base64Value).toBe('VXNlcjrgpKrgpY3gpLDgpL/gpK8=');
+    expect(encodeBase64PathSegment(base64Value)).toBe('VXNlcjrgpKrgpY3gpLDgpL%2FgpK8%3D');
+    expect(decodeBase64PathSegment(encodeBase64PathSegment(base64Value))).toBe(base64Value);
+  });
+});

--- a/client/src/utils/endpoints.jsx
+++ b/client/src/utils/endpoints.jsx
@@ -1,4 +1,5 @@
 import prefix from './../prefix';
+import { encodeBase64PathSegment } from './base64';
 
 const baseUrl =
   import.meta.env.VITE_BASE_URL ||
@@ -321,7 +322,9 @@ export const uriConsumerGroupByTopics = (clusterId, topicList, groupsListView) =
 };
 
 export const uriAclsByPrincipal = (clusterId, principalEncoded, resourceType = 'ANY') => {
-  return `${apiUrl}/${clusterId}/acls/${principalEncoded}?resourceType=${resourceType}`;
+  return `${apiUrl}/${clusterId}/acls/${encodeBase64PathSegment(
+    principalEncoded
+  )}?resourceType=${resourceType}`;
 };
 
 export const uriLiveTail = (clusterId, search, topics, size) => {

--- a/src/main/java/org/akhq/models/AccessControl.java
+++ b/src/main/java/org/akhq/models/AccessControl.java
@@ -10,6 +10,9 @@ import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -25,11 +28,19 @@ public class AccessControl {
     private String encodedPrincipal;
 
     public static String encodePrincipal(String principal) {
-        return Base64.getEncoder().encodeToString(principal.getBytes());
+        return Base64.getEncoder().encodeToString(principal.getBytes(StandardCharsets.UTF_8));
     }
 
     public static String decodePrincipal(String encodedPrincipal) {
-        return new String(Base64.getDecoder().decode(encodedPrincipal));
+        return new String(Base64.getDecoder().decode(decodePathSegment(encodedPrincipal)), StandardCharsets.UTF_8);
+    }
+
+    private static String decodePathSegment(String encodedPrincipal) {
+        try {
+            return URLDecoder.decode(encodedPrincipal.replace("+", "%2B"), StandardCharsets.UTF_8.name());
+        } catch (IllegalArgumentException | UnsupportedEncodingException e) {
+            return encodedPrincipal;
+        }
     }
 
     public AccessControl(String principal, Collection<AclBinding> aclBinding) {

--- a/src/test/java/org/akhq/models/AccessControlTest.java
+++ b/src/test/java/org/akhq/models/AccessControlTest.java
@@ -1,0 +1,44 @@
+package org.akhq.models;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AccessControlTest {
+    @Test
+    void shouldRoundTripUtf8Principals() {
+        assertRoundTrip("User:alice");
+        assertRoundTrip("User:张伟");
+        assertRoundTrip("User:Renée");
+        assertRoundTrip("User:प्रिय");
+        assertRoundTrip("User:service/account+ops");
+        assertRoundTrip("");
+    }
+
+    @Test
+    void shouldPreserveAsciiPrincipalEncoding() {
+        String principal = "User:CN=akhq,O=example";
+
+        assertEquals("VXNlcjpDTj1ha2hxLE89ZXhhbXBsZQ==", AccessControl.encodePrincipal(principal));
+        assertEquals(
+            AccessControl.encodePrincipal(principal),
+            Base64.getEncoder().encodeToString(principal.getBytes(StandardCharsets.US_ASCII))
+        );
+    }
+
+    @Test
+    void shouldDecodeUrlEncodedPrincipalPathSegments() {
+        assertEquals("User:प्रिय", AccessControl.decodePrincipal("VXNlcjrgpKrgpY3gpLDgpL%2FgpK8%3D"));
+        assertEquals(
+            "User:CN=张伟,OU=开发部,O=例公司,C=CN",
+            AccessControl.decodePrincipal("VXNlcjpDTj3lvKDkvJ8sT1U95byA5Y%2BR6YOoLE895L6L5YWs5Y%2B4LEM9Q04%3D")
+        );
+    }
+
+    private void assertRoundTrip(String principal) {
+        assertEquals(principal, AccessControl.decodePrincipal(AccessControl.encodePrincipal(principal)));
+    }
+}


### PR DESCRIPTION
## Summary

- encode ACL principals as UTF-8 before Base64 conversion
- preserve the existing Base64 representation while escaping it when used in URL path segments
- add regression coverage for Unicode principal values and path-unsafe Base64 output

## Problem

Calling `btoa()` directly with a Unicode principal throws a `DOMException`, preventing the ACL list from loading. Standard Base64 can also contain `/` and `+`, so the UI now escapes those values only at URL path boundaries without changing the Base64 alphabet expected by existing API code.

## Testing

- `npm test -- --run src/utils/base64.test.js src/containers/Acl/AclList/Acls.test.jsx`
- `npm run build`
- `JAVA_HOME=/home/ubuntu/.local/jdks/jdk-25.0.4.1+1 PATH=/home/ubuntu/.local/jdks/jdk-25.0.4.1+1/bin:$PATH ./gradlew test --tests org.akhq.models.AccessControlTest -x distTar -x distZip -x shadowDistTar -x shadowDistZip -x buildLayers -x shadowJar -x runnerJar`
- `git diff --check`

Notes: full frontend lint/test/prettier checks were not clean in this local environment due existing unrelated failures/configuration issues.

Fixes #1920
